### PR TITLE
BTAT-2773 Refactor services/controllers to use ServiceResponse instead of HttpGetResult

### DIFF
--- a/app/connectors/FinancialDataConnector.scala
+++ b/app/connectors/FinancialDataConnector.scala
@@ -21,7 +21,6 @@ import java.time.LocalDate
 import config.AppConfig
 import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
 import javax.inject.{Inject, Singleton}
-import models.errors.ServerSideError
 import models.payments.Payments
 import models.viewModels.PaymentsHistoryModel
 import play.api.Logger
@@ -73,5 +72,4 @@ class FinancialDataConnector @Inject()(http: HttpClient,
       )
     )))
   }
-
 }

--- a/app/controllers/OpenPaymentsController.scala
+++ b/app/controllers/OpenPaymentsController.scala
@@ -21,7 +21,7 @@ import audit.models.ViewOutstandingVatPaymentsAuditModel
 import config.AppConfig
 import javax.inject.Inject
 import models.User
-import models.payments.{Payment, Payments}
+import models.payments.Payment
 import models.viewModels.OpenPaymentsModel
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._

--- a/app/controllers/OpenPaymentsController.scala
+++ b/app/controllers/OpenPaymentsController.scala
@@ -39,14 +39,14 @@ extends AuthorisedController with I18nSupport {
   def openPayments(): Action[AnyContent] = authorisedAction { implicit request =>
     user =>
       paymentsService.getOpenPayments(user.vrn).map {
-        case Some(Payments(payments)) if payments.nonEmpty =>
-          val model = getModel(payments)
+        case Right(Some(payments)) =>
+          val model = getModel(payments.financialTransactions)
           auditEvent(user, model)
           Ok(views.html.payments.openPayments(user, model))
-        case Some(_) =>
+        case Right(_) =>
           auditEvent(user, Seq.empty)
           Ok(views.html.payments.noPayments(user))
-        case None => InternalServerError(views.html.errors.paymentsError())
+        case Left(_) => InternalServerError(views.html.errors.paymentsError())
       }
   }
 

--- a/app/controllers/PaymentHistoryController.scala
+++ b/app/controllers/PaymentHistoryController.scala
@@ -18,9 +18,9 @@ package controllers
 
 import audit.AuditingService
 import config.AppConfig
-import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
-import javax.inject.Inject
-import models.User
+import javax.inject.{Inject, Singleton}
+
+import models.{ServiceResponse, User}
 import models.viewModels.{PaymentsHistoryModel, PaymentsHistoryViewModel}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent}
@@ -29,12 +29,13 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 
+@Singleton
 class PaymentHistoryController @Inject()(val messagesApi: MessagesApi,
-                                          val paymentsService: PaymentsService,
-                                          dateService: DateService,
-                                          val enrolmentsAuthService: EnrolmentsAuthService,
-                                          implicit val appConfig: AppConfig,
-                                          auditingService: AuditingService)
+                                         val paymentsService: PaymentsService,
+                                         dateService: DateService,
+                                         val enrolmentsAuthService: EnrolmentsAuthService,
+                                         implicit val appConfig: AppConfig,
+                                         auditingService: AuditingService)
   extends AuthorisedController with I18nSupport {
 
 
@@ -51,11 +52,11 @@ class PaymentHistoryController @Inject()(val messagesApi: MessagesApi,
   }
 
   private[controllers] def getFinancialTransactions(user: User, selectedYear: Int)
-                                                   (implicit hc: HeaderCarrier): Future[HttpGetResult[PaymentsHistoryViewModel]] = {
+                                                   (implicit hc: HeaderCarrier): Future[ServiceResponse[PaymentsHistoryViewModel]] = {
     val currentYear    = dateService.now().getYear
     val potentialYears = List(currentYear, currentYear - 1)
 
-    def getPaymentHistory(year: Int): Future[(Int, HttpGetResult[Seq[PaymentsHistoryModel]])] = {
+    def getPaymentHistory(year: Int): Future[(Int, ServiceResponse[Seq[PaymentsHistoryModel]])] = {
       paymentsService.getPaymentsHistory(user, year) map(year -> _)
     }
 

--- a/app/controllers/VatDetailsController.scala
+++ b/app/controllers/VatDetailsController.scala
@@ -63,7 +63,8 @@ class VatDetailsController @Inject()(val messagesApi: MessagesApi,
   }
 
   private[controllers] def constructViewModel(nextReturn: ServiceResponse[Option[VatReturnObligation]],
-                                              nextPayment: ServiceResponse[Option[Payment]], entityName: Option[String]): VatDetailsViewModel = {
+                                              nextPayment: ServiceResponse[Option[Payment]],
+                                              entityName: ServiceResponse[Option[String]]): VatDetailsViewModel = {
 
     val getDueDate: ServiceResponse[Option[Obligation]] => Option[LocalDate] = _.fold(_ => None, _.map(_.due))
     val getIsOverdue: Option[LocalDate] => Boolean = _.fold(false)(d => dateService.now().isAfter(d))
@@ -73,11 +74,15 @@ class VatDetailsController @Inject()(val messagesApi: MessagesApi,
     val obligation: Option[LocalDate] = getDueDate(nextReturn)
     val obligationIsOverdue = getIsOverdue(obligation)
     val obligationHasError = nextReturn.isLeft
+    val displayedName = entityName match {
+      case Right(name) => name
+      case Left(_) => None
+    }
 
     VatDetailsViewModel(
       payment,
       obligation,
-      entityName,
+      displayedName,
       dateService.now().getYear,
       obligationIsOverdue,
       paymentIsOverdue,

--- a/app/models/errors/ServiceError.scala
+++ b/app/models/errors/ServiceError.scala
@@ -23,3 +23,4 @@ case object VatLiabilitiesError extends ServiceError
 case object PaymentsError extends ServiceError
 case object NextObligationError extends ServiceError
 case object NextPaymentError extends ServiceError
+case object CustomerInformationError extends ServiceError

--- a/app/models/errors/ServiceError.scala
+++ b/app/models/errors/ServiceError.scala
@@ -19,3 +19,7 @@ package models.errors
 sealed trait ServiceError
 
 case object PaymentSetupError extends ServiceError
+case object VatLiabilitiesError extends ServiceError
+case object PaymentsError extends ServiceError
+case object NextObligationError extends ServiceError
+case object NextPaymentError extends ServiceError

--- a/app/services/AccountDetailsService.scala
+++ b/app/services/AccountDetailsService.scala
@@ -18,7 +18,7 @@ package services
 
 import connectors.VatSubscriptionConnector
 import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
 import models.errors.CustomerInformationError
 import models.{CustomerInformation, ServiceResponse}
@@ -26,6 +26,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
 
+@Singleton
 class AccountDetailsService @Inject()(connector: VatSubscriptionConnector) {
 
   def getAccountDetails(vrn: String)

--- a/app/services/AccountDetailsService.scala
+++ b/app/services/AccountDetailsService.scala
@@ -19,19 +19,23 @@ package services
 import connectors.VatSubscriptionConnector
 import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
 import javax.inject.Inject
-import models.CustomerInformation
+
+import models.errors.CustomerInformationError
+import models.{CustomerInformation, ServiceResponse}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class AccountDetailsService @Inject()(connector: VatSubscriptionConnector) {
 
-  def getAccountDetails(vrn: String) (implicit hc: HeaderCarrier, ec: ExecutionContext) :
-    Future[HttpGetResult[CustomerInformation]] = connector.getCustomerInfo(vrn)
+  def getAccountDetails(vrn: String)
+                       (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[CustomerInformation]] =
+    connector.getCustomerInfo(vrn)
 
 
-  def getEntityName(vrn: String) (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]] = connector.getCustomerInfo(vrn).map {
-    case Right(model: CustomerInformation) => model.entityName
-    case Left(_) => None
-  }
+  def getEntityName(vrn: String) (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[Option[String]]] =
+    connector.getCustomerInfo(vrn).map {
+      case Right(model: CustomerInformation) => Right(model.entityName)
+      case Left(_) => Left(CustomerInformationError)
+    }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 val compile: Seq[ModuleID] = Seq(
   ws,
   "uk.gov.hmrc" %% "bootstrap-play-25" % "1.6.0",
-  "uk.gov.hmrc" %% "govuk-template" % "5.20.0",
+  "uk.gov.hmrc" %% "govuk-template" % "5.21.0",
   "uk.gov.hmrc" %% "play-ui" % "7.15.0",
   "uk.gov.hmrc" %% "play-partials" % "6.1.0",
   "uk.gov.hmrc" %% "play-whitelist-filter" % "2.0.0",

--- a/test/controllers/OpenPaymentsControllerSpec.scala
+++ b/test/controllers/OpenPaymentsControllerSpec.scala
@@ -21,6 +21,7 @@ import java.time.LocalDate
 import audit.AuditingService
 import audit.models.ExtendedAuditModel
 import models.User
+import models.errors.PaymentsError
 import models.payments.{Payment, Payments}
 import models.viewModels.OpenPaymentsModel
 import org.jsoup.Jsoup
@@ -93,7 +94,7 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
           super.setupMocks()
           (mockPaymentsService.getOpenPayments(_: String)(_: HeaderCarrier, _: ExecutionContext))
             .expects(*, *, *)
-            .returns(Future.successful(Some(Payments(Seq(payment, payment)))))
+            .returns(Future.successful(Right(Some(Payments(Seq(payment, payment))))))
         }
 
         private val result = target.openPayments()(fakeRequest)
@@ -106,7 +107,7 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
           super.setupMocks()
           (mockPaymentsService.getOpenPayments(_: String)(_: HeaderCarrier, _: ExecutionContext))
             .expects(*, *, *)
-            .returns(Future.successful(Some(Payments(Seq.empty))))
+            .returns(Future.successful(Right(Some(Payments(Seq(payment, payment))))))
         }
 
         val result: Result = await(target.openPayments()(fakeRequest))
@@ -123,7 +124,7 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
           super.setupMocks()
           (mockPaymentsService.getOpenPayments(_: String)(_: HeaderCarrier, _: ExecutionContext))
             .expects(*, *, *)
-            .returns(Future.successful(Some(Payments(Seq.empty))))
+            .returns(Future.successful(Right(None)))
         }
 
         private val result = target.openPayments()(fakeRequest)
@@ -136,7 +137,7 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
           super.setupMocks()
           (mockPaymentsService.getOpenPayments(_: String)(_: HeaderCarrier, _: ExecutionContext))
             .expects(*, *, *)
-            .returns(Future.successful(Some(Payments(Seq.empty))))
+            .returns(Future.successful(Right(None)))
         }
 
         val result: Result = await(target.openPayments()(fakeRequest))
@@ -171,7 +172,7 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
           super.setupMocks()
           (mockPaymentsService.getOpenPayments(_: String)(_: HeaderCarrier, _: ExecutionContext))
             .expects(*, *, *)
-            .returns(Future.successful(None))
+            .returns(Future.successful(Left(PaymentsError)))
         }
 
         private val result = target.openPayments()(fakeRequest)
@@ -184,7 +185,7 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
           super.setupMocks()
           (mockPaymentsService.getOpenPayments(_: String)(_: HeaderCarrier, _: ExecutionContext))
             .expects(*, *, *)
-            .returns(Future.successful(None))
+            .returns(Future.successful(Left(PaymentsError)))
         }
 
         val result: Result = await(target.openPayments()(fakeRequest))

--- a/test/controllers/PaymentHistoryControllerSpec.scala
+++ b/test/controllers/PaymentHistoryControllerSpec.scala
@@ -20,9 +20,8 @@ import java.time.LocalDate
 
 import audit.AuditingService
 import audit.models.AuditModel
-import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
-import models.User
-import models.errors.ServerSideError
+import models.{ServiceResponse, User}
+import models.errors.VatLiabilitiesError
 import models.viewModels.{PaymentsHistoryModel, PaymentsHistoryViewModel}
 import play.api.http.Status
 import play.api.mvc.Result
@@ -38,7 +37,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
   private trait Test {
-    val serviceResult: HttpGetResult[Seq[PaymentsHistoryModel]] =
+    val serviceResult: ServiceResponse[Seq[PaymentsHistoryModel]] =
       Right(Seq(
         PaymentsHistoryModel(
           taxPeriodFrom = LocalDate.parse(s"2018-01-01"),
@@ -53,8 +52,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
           clearedDate   = LocalDate.parse(s"2018-03-01")
         )
       ))
-    val serviceResultYearOne: HttpGetResult[Seq[PaymentsHistoryModel]] = serviceResult
-    val serviceResultYearTwo: HttpGetResult[Seq[PaymentsHistoryModel]] = serviceResult
+    val serviceResultYearOne: ServiceResponse[Seq[PaymentsHistoryModel]] = serviceResult
+    val serviceResultYearTwo: ServiceResponse[Seq[PaymentsHistoryModel]] = serviceResult
 
     val authResult: Future[_] =
       Future.successful(Enrolments(Set(
@@ -63,7 +62,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
     val serviceCall: Boolean = true
     val authCall: Boolean = true
-    val year: Int = 2018
+    val targetYear: Int = 2018
     val testUser: User = User("999999999")
     implicit val hc: HeaderCarrier = HeaderCarrier()
 
@@ -123,17 +122,17 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
     "the user is logged in" should {
 
       "return 200" in new Test {
-        private val result = target.paymentHistory(year = 2018)(fakeRequest)
+        private val result = target.paymentHistory(targetYear)(fakeRequest)
         status(result) shouldBe Status.OK
       }
 
       "return HTML" in new Test {
-        private val result = target.paymentHistory(year = 2018)(fakeRequest)
+        private val result = target.paymentHistory(targetYear)(fakeRequest)
         contentType(result) shouldBe Some("text/html")
       }
 
       "return charset utf-8" in new Test {
-        private val result = target.paymentHistory(year = 2018)(fakeRequest)
+        private val result = target.paymentHistory(targetYear)(fakeRequest)
         charset(result) shouldBe Some("utf-8")
       }
     }
@@ -143,7 +142,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
       "return 401 (Unauthorised)" in new Test {
         override val serviceCall = false
         override val authResult: Future[Nothing] = Future.failed(MissingBearerToken())
-        val result: Future[Result] = target.paymentHistory(year = 2018)(fakeRequest)
+        val result: Future[Result] = target.paymentHistory(targetYear)(fakeRequest)
         status(result) shouldBe Status.UNAUTHORIZED
       }
     }
@@ -153,7 +152,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
       "return 403 (Forbidden)" in new Test {
         override val serviceCall = false
         override val authResult: Future[Nothing] = Future.failed(InsufficientEnrolments())
-        val result: Future[Result] = target.paymentHistory(year = 2018)(fakeRequest)
+        val result: Future[Result] = target.paymentHistory(targetYear)(fakeRequest)
         status(result) shouldBe Status.FORBIDDEN
       }
     }
@@ -162,7 +161,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "return 404 (Not Found)" in new Test {
         override val serviceCall = false
-        private val result = target.paymentHistory(year = 2021)(fakeRequest)
+        override val targetYear = 2021
+        private val result = target.paymentHistory(targetYear)(fakeRequest)
         status(result) shouldBe Status.NOT_FOUND
       }
     }
@@ -172,7 +172,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
       "return 404 (Not Found)" in new Test {
         mockAppConfig.features.allowPaymentHistory(false)
         override val serviceCall = false
-        private val result = target.paymentHistory(year = 2018)(fakeRequest)
+        private val result = target.paymentHistory(targetYear)(fakeRequest)
         status(result) shouldBe Status.NOT_FOUND
       }
     }
@@ -184,9 +184,9 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "return the correct year tabs" in new Test {
         override val authCall = false
-        override val serviceResultYearTwo = Left(ServerSideError("501", "Service not implemented."))
+        override val serviceResultYearTwo = Left(VatLiabilitiesError)
 
-        val examplePaymentHistory: HttpGetResult[PaymentsHistoryViewModel] =
+        val examplePaymentHistory: ServiceResponse[PaymentsHistoryViewModel] =
           Right(PaymentsHistoryViewModel(
             Seq(2018),
             2018,
@@ -207,7 +207,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
           )
         )
 
-        private val result = await(target.getFinancialTransactions(testUser, 2018))
+        private val result = await(target.getFinancialTransactions(testUser, targetYear))
         result shouldBe examplePaymentHistory
       }
     }
@@ -225,7 +225,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
           .expects(*, *, *, *).noMoreThanOnce()
           .returns(serviceResultYearOne)
 
-        val examplePaymentHistory: HttpGetResult[PaymentsHistoryViewModel] =
+        val examplePaymentHistory: ServiceResponse[PaymentsHistoryViewModel] =
           Right(PaymentsHistoryViewModel(
             Seq(2018, 2017),
             2018,
@@ -243,7 +243,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
             ))
           ))
 
-        private val result = await(target.getFinancialTransactions(testUser, 2018))
+        private val result = await(target.getFinancialTransactions(testUser, targetYear))
         result shouldBe examplePaymentHistory
       }
     }
@@ -252,9 +252,9 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "throw an exception" in new Test {
         override val authCall = false
-        override val serviceResult = Left(ServerSideError("501", "Service not implemented."))
+        override val serviceResult = Left(VatLiabilitiesError)
 
-        intercept[Exception](await(target.getFinancialTransactions(testUser, 2018)))
+        intercept[Exception](await(target.getFinancialTransactions(testUser, targetYear)))
       }
     }
   }
@@ -265,11 +265,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "return true" in new Test {
         override val authResult: Future[_] = Future.successful("")
-
         override def setup(): Any = "" // Prevent the unused mocks causing trouble
-
         val result: Boolean = target.isValidSearchYear(2018, 2018)
-
         result shouldBe true
       }
     }
@@ -278,11 +275,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "return false" in new Test {
         override val authResult: Future[_] = Future.successful("")
-
         override def setup(): Any = "" // Prevent the unused mocks causing trouble
-
         val result: Boolean = target.isValidSearchYear(2019, 2018)
-
         result shouldBe false
       }
     }
@@ -291,11 +285,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "return true" in new Test {
         override val authResult: Future[_] = Future.successful("")
-
         override def setup(): Any = "" // Prevent the unused mocks causing trouble
-
         val result: Boolean = target.isValidSearchYear(2017, 2018)
-
         result shouldBe true
       }
     }
@@ -304,11 +295,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "return false" in new Test {
         override val authResult: Future[_] = Future.successful("")
-
         override def setup(): Any = "" // Prevent the unused mocks causing trouble
-
         val result: Boolean = target.isValidSearchYear(2014, 2018)
-
         result shouldBe false
       }
     }
@@ -317,11 +305,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "return true" in new Test {
         override val authResult: Future[_] = Future.successful("")
-
         override def setup(): Any = "" // Prevent the unused mocks causing trouble
-
         val result: Boolean = target.isValidSearchYear(2017, 2018)
-
         result shouldBe true
       }
     }

--- a/test/services/PaymentsServiceSpec.scala
+++ b/test/services/PaymentsServiceSpec.scala
@@ -21,7 +21,7 @@ import java.time.LocalDate
 import connectors.httpParsers.ResponseHttpParsers.{HttpGetResult, HttpPostResult}
 import connectors.{FinancialDataConnector, PaymentsConnector}
 import models.{ServiceResponse, User}
-import models.errors.{BadRequestError, PaymentSetupError, ServerSideError, UnknownError}
+import models.errors.{BadRequestError, PaymentSetupError, ServerSideError, UnknownError, VatLiabilitiesError}
 import models.payments.{Payment, PaymentDetailsModel, Payments}
 import models.viewModels.PaymentsHistoryModel
 import org.scalamock.matchers.Matchers
@@ -38,7 +38,6 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
   "Calling the .getOpenPayments function" when {
 
     trait Test {
-
       implicit val hc: HeaderCarrier = HeaderCarrier()
       val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
       val mockPaymentsConnector: PaymentsConnector = mock[PaymentsConnector]
@@ -105,7 +104,6 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
   "Calling the .setupJourney method" when {
 
     trait Test {
-
       implicit val hc: HeaderCarrier = HeaderCarrier()
       val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
       val mockPaymentsConnector: PaymentsConnector = mock[PaymentsConnector]
@@ -139,11 +137,9 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
     "setting up the payments journey is successful" should {
 
       "return a redirect url" in new Test {
-
         val redirectUrl = "http://www.google.com"
         override val connectorResponse: HttpPostResult[String] = Right(redirectUrl)
         val expectedResult: ServiceResponse[String] = Right(redirectUrl)
-
         private val result = await(target.setupPaymentsJourney(paymentDetails))
 
         result shouldBe expectedResult
@@ -153,10 +149,8 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
     "setting up the payments journey is unsuccessful" should {
 
       "return an error" in new Test {
-
         override val connectorResponse: HttpPostResult[String] = Left(UnknownError)
         val expectedResult: ServiceResponse[String] = Left(PaymentSetupError)
-
         private val result = await(target.setupPaymentsJourney(paymentDetails))
 
         result shouldBe expectedResult
@@ -167,7 +161,6 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
   "Calling the .getPaymentsHistory method" when {
 
     trait Test {
-
       implicit val hc: HeaderCarrier = HeaderCarrier()
       val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
       val mockPaymentsConnector: PaymentsConnector = mock[PaymentsConnector]
@@ -185,42 +178,29 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
       }
     }
 
-    val amountInPence = 123456
-    val taxPeriodMonth = 2
     val taxPeriodYear = 2018
-
-    val paymentDetails = PaymentDetailsModel("vat",
-      "123456789",
-      amountInPence,
-      taxPeriodMonth,
-      taxPeriodYear,
-      "http://domain/path",
-      "http://domain/return-path"
-    )
 
     "return a seq of payment history models" in new Test {
       val paymentSeq = Right(Seq(
         PaymentsHistoryModel(
-          taxPeriodFrom = LocalDate.of(2018, 1, 1),
-          taxPeriodTo   = LocalDate.of(2018, 1 , 26),
-          amount        = 10000,
-          clearedDate   = LocalDate.of(2018, 1, 13)
+          taxPeriodFrom = LocalDate.parse("2018-01-01"),
+          taxPeriodTo = LocalDate.parse("2018-01-26"),
+          amount = 10000,
+          clearedDate = LocalDate.parse("2018-01-13")
         )
       ))
 
       override val connectorResponse: HttpGetResult[Seq[PaymentsHistoryModel]] = paymentSeq
-
-      private val result = await(target.getPaymentsHistory(User("999999999"), searchYear = 2018))
+      private val result = await(target.getPaymentsHistory(User("999999999"), taxPeriodYear))
 
       result shouldBe paymentSeq
     }
 
     "return a http error" in new Test {
       override val connectorResponse: HttpGetResult[Seq[PaymentsHistoryModel]] = Left(BadRequestError("400", ""))
+      private val result = await(target.getPaymentsHistory(User("999999999"), taxPeriodYear))
 
-      private val result = await(target.getPaymentsHistory(User("999999999"), searchYear = 2018))
-
-      result shouldBe Left(BadRequestError("400", ""))
+      result shouldBe Left(VatLiabilitiesError)
     }
   }
 }


### PR DESCRIPTION
I have not refactored the aspects of the project relating to the Account Details page which are due to be removed in a future story.