### PR TITLE
BTAT-2988 split out vat obligations configuration and added fearure switch

### DIFF
--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -43,6 +43,7 @@ object ConfigKeys {
   val allowNineBoxFeature: String = "features.allowNineBox.enabled"
   val enableAuditingFeature: String = "features.auditing.enabled"
   val allowPaymentHistoryFeature: String = "features.allowPaymentHistory.enabled"
+  val useVatObligationsService: String = "features.useVatObligationsService.enabled"
 
   val businessTaxAccountBase: String = "business-tax-account.host"
   val businessTaxAccountUrl: String = "business-tax-account.homeUrl"

--- a/app/config/features/Features.scala
+++ b/app/config/features/Features.scala
@@ -32,5 +32,6 @@ class Features @Inject()(config: Configuration) {
   val allowNineBox = new Feature(ConfigKeys.allowNineBoxFeature, config)
   val enabledAuditing = new Feature(ConfigKeys.enableAuditingFeature, config)
   val allowPaymentHistory = new Feature(ConfigKeys.allowPaymentHistoryFeature, config)
+  val enableVatObligationsService = new Feature(ConfigKeys.useVatObligationsService, config)
 
 }

--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -43,6 +43,7 @@ trait AppConfig extends ServicesConfig {
   val signInContinueBaseUrl: String
   val features: Features
   val vatApiBaseUrl: String
+  val vatObligationsBaseUrl: String
   val vatSubscriptionBaseUrl: String
   val financialDataBaseUrl: String
   val vatSummaryPartial: String
@@ -108,6 +109,9 @@ class FrontendAppConfig @Inject()(val runModeConfiguration: Configuration, val e
   override lazy val vatSummaryPartial: String = baseUrl("selfLookup") + "/vat-summary-partials/bta-home"
 
   private lazy val vatReturnsBaseUrl: String = getString(Keys.vatReturnsBase)
+
+  override val vatObligationsBaseUrl: String = baseUrl("vat-obligations")
+
   override lazy val vatSubmittedReturnsUrl: String = vatReturnsBaseUrl + getString(Keys.vatSubmittedReturns)
   override lazy val vatReturnDeadlinesUrl: String = vatReturnsBaseUrl + getString(Keys.vatReturnDeadlines)
   override def vatReturnUrl(periodKey: String): String = vatReturnsBaseUrl + getString(Keys.vatReturn) + URLEncoder.encode(periodKey, "UTF-8")

--- a/app/connectors/VatObligationsConnector.scala
+++ b/app/connectors/VatObligationsConnector.scala
@@ -75,7 +75,7 @@ class VatObligationsConnector @Inject()(http: HttpClient,
         vatReturns
       case httpError@Left(error) =>
         metrics.getObligationsCallFailureCounter.inc()
-        Logger.warn("VatApiConnector received error: " + error.message)
+        Logger.warn("VatObligationsConnector received error: " + error.message)
         httpError
     }
   }

--- a/app/connectors/VatObligationsConnector.scala
+++ b/app/connectors/VatObligationsConnector.scala
@@ -32,16 +32,24 @@ import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class VatApiConnector @Inject()(http: HttpClient,
-                                appConfig: AppConfig,
-                                metrics: MetricsService) {
+class VatObligationsConnector @Inject()(http: HttpClient,
+                                        appConfig: AppConfig,
+                                        metrics: MetricsService) {
 
-  private[connectors] def obligationsUrl(vrn: String): String = s"${appConfig.vatApiBaseUrl}/$vrn/obligations"
+  private[connectors] def obligationsUrl(vrn: String): String = {
+    val baseUrl: String = if (appConfig.features.enableVatObligationsService()) {
+      appConfig.vatObligationsBaseUrl
+    } else {
+      appConfig.vatApiBaseUrl
+    }
+    s"$baseUrl/$vrn/obligations"
+  }
 
   def getVatReturnObligations(vrn: String,
                               from: LocalDate,
                               to: LocalDate,
-                              status: Status.Value)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[VatReturnObligations]] = {
+                              status: Status.Value)(implicit hc: HeaderCarrier,
+                              ec: ExecutionContext): Future[HttpGetResult[VatReturnObligations]] = {
 
     val timer = metrics.getObligationsTimer.time()
 

--- a/app/forms/FeatureSwitchForm.scala
+++ b/app/forms/FeatureSwitchForm.scala
@@ -32,7 +32,8 @@ object FeatureSwitchForm {
       ConfigKeys.accountDetailsFeature -> boolean,
       ConfigKeys.allowNineBoxFeature -> boolean,
       ConfigKeys.enableAuditingFeature -> boolean,
-      ConfigKeys.allowPaymentHistoryFeature -> boolean
+      ConfigKeys.allowPaymentHistoryFeature -> boolean,
+      ConfigKeys.useVatObligationsService -> boolean
     )(FeatureSwitchModel.apply)(FeatureSwitchModel.unapply)
   )
 }

--- a/app/models/FeatureSwitchModel.scala
+++ b/app/models/FeatureSwitchModel.scala
@@ -24,4 +24,5 @@ case class FeatureSwitchModel(simpleAuthEnabled: Boolean,
                               accountDetailsEnabled: Boolean,
                               allowNineBoxEnabled: Boolean,
                               auditingEnabled: Boolean,
-                              allowPaymentHistoryEnabled: Boolean)
+                              allowPaymentHistoryEnabled: Boolean,
+                              enableVatObligationsService: Boolean)

--- a/app/services/VatDetailsService.scala
+++ b/app/services/VatDetailsService.scala
@@ -19,7 +19,7 @@ package services
 import java.time.LocalDate
 
 import config.AppConfig
-import connectors.{FinancialDataConnector, VatApiConnector, VatSubscriptionConnector}
+import connectors.{FinancialDataConnector, VatObligationsConnector, VatSubscriptionConnector}
 import javax.inject.{Inject, Singleton}
 
 import models._
@@ -32,7 +32,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class VatDetailsService @Inject()(vatApiConnector: VatApiConnector,
+class VatDetailsService @Inject()(vatApiConnector: VatObligationsConnector,
                                   financialDataConnector: FinancialDataConnector,
                                   subscriptionConnector: VatSubscriptionConnector,
                                   implicit val appConfig: AppConfig,

--- a/app/services/VatDetailsService.scala
+++ b/app/services/VatDetailsService.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class VatDetailsService @Inject()(vatApiConnector: VatObligationsConnector,
+class VatDetailsService @Inject()(vatObligationsConnector: VatObligationsConnector,
                                   financialDataConnector: FinancialDataConnector,
                                   subscriptionConnector: VatSubscriptionConnector,
                                   implicit val appConfig: AppConfig,
@@ -58,7 +58,7 @@ class VatDetailsService @Inject()(vatApiConnector: VatObligationsConnector,
     val dateFrom = LocalDate.parse("2018-01-01")
     val dateTo = LocalDate.parse("2018-12-31")
 
-    vatApiConnector.getVatReturnObligations(user.vrn, dateFrom, dateTo, Outstanding).map {
+    vatObligationsConnector.getVatReturnObligations(user.vrn, dateFrom, dateTo, Outstanding).map {
       case Right(nextReturns) if nextReturns.obligations.nonEmpty => Right(Some(nextReturns))
       case Right(_) => Right(None)
       case Left(_) => Left(ObligationsError)

--- a/app/testOnly/controllers/FeatureSwitchController.scala
+++ b/app/testOnly/controllers/FeatureSwitchController.scala
@@ -38,7 +38,8 @@ class FeatureSwitchController @Inject()(val messagesApi: MessagesApi, implicit v
         accountDetailsEnabled = appConfig.features.accountDetails(),
         allowNineBoxEnabled = appConfig.features.allowNineBox(),
         auditingEnabled = appConfig.features.enabledAuditing(),
-        allowPaymentHistoryEnabled = appConfig.features.allowPaymentHistory()
+        allowPaymentHistoryEnabled = appConfig.features.allowPaymentHistory(),
+        enableVatObligationsService = appConfig.features.enableVatObligationsService()
       )
     )))
   }
@@ -60,6 +61,7 @@ class FeatureSwitchController @Inject()(val messagesApi: MessagesApi, implicit v
     appConfig.features.allowNineBox(model.allowNineBoxEnabled)
     appConfig.features.enabledAuditing(model.auditingEnabled)
     appConfig.features.allowPaymentHistory(model.allowPaymentHistoryEnabled)
+    appConfig.features.enableVatObligationsService(model.enableVatObligationsService)
     Redirect(routes.FeatureSwitchController.featureSwitch())
   }
 }

--- a/app/testOnly/views/featureSwitch.scala.html
+++ b/app/testOnly/views/featureSwitch.scala.html
@@ -39,6 +39,7 @@
         @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.allowNineBoxFeature), messages(ConfigKeys.allowNineBoxFeature))
         @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.enableAuditingFeature), messages(ConfigKeys.enableAuditingFeature))
         @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.allowPaymentHistoryFeature), messages(ConfigKeys.allowPaymentHistoryFeature))
+        @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.useVatObligationsService), messages(ConfigKeys.useVatObligationsService))
       </fieldset>
     </div>
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,6 +71,10 @@ microservice {
       host = localhost
       port = 9154
     }
+    vat-obligations {
+      host = localhost
+      port = 9155
+    }
     vat-subscription {
       host = localhost
       port = 9154
@@ -104,6 +108,7 @@ features {
   allowNineBox.enabled = true
   auditing.enabled = true
   allowPaymentHistory.enabled = false
+  useVatObligationsService.enabled = false
 }
 
 timeout {

--- a/conf/messages
+++ b/conf/messages
@@ -122,6 +122,7 @@ features.accountDetails.enabled = Show account details
 features.allowNineBox.enabled = Nine box page allowed
 features.auditing.enabled = Auditing service enabled
 features.allowPaymentHistory.enabled = Payment history page enabled
+features.useVatObligationsService.enabled = Use vat-obligations microservice
 
 banner.newService = This is a new service – your
 banner.feedback = feedback

--- a/it/connectors/VatObligationsConnectorISpec.scala
+++ b/it/connectors/VatObligationsConnectorISpec.scala
@@ -24,24 +24,24 @@ import models.errors.{ApiSingleError, BadRequestError, MultipleErrors}
 import models.obligations.Obligation.Status
 import models.obligations.{VatReturnObligation, VatReturnObligations}
 import play.api.libs.json.Json
-import stubs.VatApiStub
+import stubs.VatObligationsStub
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class VatApiConnectorISpec extends IntegrationBaseSpec {
+class VatObligationsConnectorISpec extends IntegrationBaseSpec {
 
   private trait Test {
     def setupStubs(): StubMapping
 
-    val connector: VatApiConnector = app.injector.instanceOf[VatApiConnector]
+    val connector: VatObligationsConnector = app.injector.instanceOf[VatObligationsConnector]
     implicit val hc: HeaderCarrier = HeaderCarrier()
   }
 
   "calling getVatReturnObligations with a status of 'A'" should {
 
     "return all obligations for a given period" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubAllObligations
+      override def setupStubs(): StubMapping = VatObligationsStub.stubAllObligations
 
       val expected = Right(VatReturnObligations(
         Seq(
@@ -78,7 +78,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "calling getVatReturnObligations with a status of 'O'" should {
 
     "return all obligations for a given period" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubOutstandingObligations
+      override def setupStubs(): StubMapping = VatObligationsStub.stubOutstandingObligations
 
       val expected = Right(VatReturnObligations(
         Seq(
@@ -107,7 +107,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "calling getVatReturnObligations with a status of 'F'" should {
 
     "return all obligations for a given period" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubFulfilledObligations
+      override def setupStubs(): StubMapping = VatObligationsStub.stubFulfilledObligations
 
       val expected = Right(VatReturnObligations(
         Seq(
@@ -136,7 +136,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "calling getVatReturnObligations with an invalid VRN" should {
 
     "return an BadRequestError" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubInvalidVrn
+      override def setupStubs(): StubMapping = VatObligationsStub.stubInvalidVrn
 
       val expected = Left(BadRequestError(
         code = "VRN_INVALID",
@@ -157,7 +157,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "calling getVatReturnObligations with an invalid 'from' date" should {
 
     "return an BadRequestError" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubInvalidFromDate
+      override def setupStubs(): StubMapping = VatObligationsStub.stubInvalidFromDate
 
       val expected = Left(BadRequestError(
         code = "INVALID_DATE_FROM",
@@ -178,7 +178,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "calling getVatReturnObligations with an invalid 'to' date" should {
 
     "return an BadRequestError" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubInvalidToDate
+      override def setupStubs(): StubMapping = VatObligationsStub.stubInvalidToDate
 
       val expected = Left(BadRequestError(
         code = "INVALID_DATE_TO",
@@ -199,7 +199,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "calling getVatReturnObligations with an invalid date range" should {
 
     "return an BadRequestError" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubInvalidDateRange
+      override def setupStubs(): StubMapping = VatObligationsStub.stubInvalidDateRange
 
       val expected = Left(BadRequestError(
         code = "INVALID_DATE_RANGE",
@@ -220,7 +220,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "calling getVatReturnObligations with an invalid obligation status" should {
 
     "return an BadRequestError" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubInvalidStatus
+      override def setupStubs(): StubMapping = VatObligationsStub.stubInvalidStatus
 
       val expected = Left(BadRequestError(
         code = "INVALID_STATUS",
@@ -241,7 +241,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "Calling getVatReturnObligations with multiple errors" should {
 
     "return a MultipleErrors" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubMultipleErrors
+      override def setupStubs(): StubMapping = VatObligationsStub.stubMultipleErrors
 
       val errors = Seq(ApiSingleError("ERROR_1", "MESSAGE_1"), ApiSingleError("ERROR_2", "MESSAGE_2"))
       val expected = Left(MultipleErrors("BAD_REQUEST", Json.toJson(errors).toString()))
@@ -258,7 +258,7 @@ class VatApiConnectorISpec extends IntegrationBaseSpec {
   "calling getVatReturnObligations with multiple errors" should {
 
     "return an MultipleErrors" in new Test {
-      override def setupStubs(): StubMapping = VatApiStub.stubMultipleErrors
+      override def setupStubs(): StubMapping = VatObligationsStub.stubMultipleErrors
 
       val errors = Seq(ApiSingleError("ERROR_1", "MESSAGE_1"), ApiSingleError("ERROR_2", "MESSAGE_2"))
       val expected = Left(MultipleErrors("BAD_REQUEST", Json.toJson(errors).toString()))

--- a/it/helpers/IntegrationBaseSpec.scala
+++ b/it/helpers/IntegrationBaseSpec.scala
@@ -44,7 +44,9 @@ trait IntegrationBaseSpec extends UnitSpec with WireMockHelper with GuiceOneServ
     "microservice.services.pay-api.host" -> mockHost,
     "microservice.services.pay-api.port" -> mockPort,
     "microservice.services.vat-subscription.host" -> mockHost,
-    "microservice.services.vat-subscription.port" -> mockPort
+    "microservice.services.vat-subscription.port" -> mockPort,
+    "microservice.services.vat-obligations.host" -> mockHost,
+    "microservice.services.vat-obligations.port" -> mockPort
   )
 
   override implicit lazy val app: Application = new GuiceApplicationBuilder()

--- a/it/partials/VatDetailsPageSpec.scala
+++ b/it/partials/VatDetailsPageSpec.scala
@@ -40,7 +40,7 @@ class VatDetailsPageSpec extends IntegrationBaseSpec {
       "return 200" in new Test {
         override def setupStubs(): StubMapping = {
           AuthStub.authorised()
-          VatApiStub.stubOutstandingObligations
+          VatObligationsStub.stubOutstandingObligations
           CustomerInfoStub.stubCustomerInfo
           FinancialDataStub.stubAllOutstandingPayments
         }

--- a/it/stubs/VatObligationsStub.scala
+++ b/it/stubs/VatObligationsStub.scala
@@ -25,7 +25,7 @@ import models.obligations.{VatReturnObligation, VatReturnObligations}
 import play.api.http.Status._
 import play.api.libs.json.{Json, Writes}
 
-object VatApiStub extends WireMockMethods {
+object VatObligationsStub extends WireMockMethods {
 
   private val obligationsUri = "/([0-9]+)/obligations"
   private val dateRegex = "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))"

--- a/test/connectors/VatObligationsConnectorSpec.scala
+++ b/test/connectors/VatObligationsConnectorSpec.scala
@@ -25,12 +25,12 @@ class VatObligationsConnectorSpec extends ControllerBaseSpec {
   lazy val connector = new VatObligationsConnector(mock[HttpClient], mockAppConfig, MockMetricsService)
 
   "VatObligationsConnector" should {
-    "generate the correct obligations url" in {
+    "generate the correct obligations url when not using vat-obligations" in {
       mockAppConfig.features.enableVatObligationsService(false)
       connector.obligationsUrl("111") shouldEqual "/111/obligations"
     }
 
-    "generate the correct returns url with a period key when not using vat-obligations" in {
+    "generate the correct returns url with a period key when using vat-obligations" in {
       mockAppConfig.features.enableVatObligationsService(true)
       connector.obligationsUrl("111") shouldBe "/obligations-api/111/obligations"
     }

--- a/test/connectors/VatObligationsConnectorSpec.scala
+++ b/test/connectors/VatObligationsConnectorSpec.scala
@@ -24,7 +24,7 @@ class VatObligationsConnectorSpec extends ControllerBaseSpec {
 
   lazy val connector = new VatObligationsConnector(mock[HttpClient], mockAppConfig, MockMetricsService)
 
-  "VatApiConnector" should {
+  "VatObligationsConnector" should {
     "generate the correct obligations url" in {
       mockAppConfig.features.enableVatObligationsService(false)
       connector.obligationsUrl("111") shouldEqual "/111/obligations"

--- a/test/connectors/VatObligationsConnectorSpec.scala
+++ b/test/connectors/VatObligationsConnectorSpec.scala
@@ -20,12 +20,19 @@ import controllers.ControllerBaseSpec
 import mocks.MockMetricsService
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
-class VatApiConnectorSpec extends ControllerBaseSpec {
+class VatObligationsConnectorSpec extends ControllerBaseSpec {
+
+  lazy val connector = new VatObligationsConnector(mock[HttpClient], mockAppConfig, MockMetricsService)
 
   "VatApiConnector" should {
     "generate the correct obligations url" in {
-      val connector = new VatApiConnector(mock[HttpClient], mockAppConfig, MockMetricsService)
+      mockAppConfig.features.enableVatObligationsService(false)
       connector.obligationsUrl("111") shouldEqual "/111/obligations"
+    }
+
+    "generate the correct returns url with a period key when not using vat-obligations" in {
+      mockAppConfig.features.enableVatObligationsService(true)
+      connector.obligationsUrl("111") shouldBe "/obligations-api/111/obligations"
     }
   }
 

--- a/test/connectors/VatSubscriptionConnectorSpec.scala
+++ b/test/connectors/VatSubscriptionConnectorSpec.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
 class VatSubscriptionConnectorSpec extends ControllerBaseSpec {
 
-  "VatApiConnector" should {
+  "VatSubscriptionConnector" should {
     "generate the correct customer information url" in {
       val connector = new VatSubscriptionConnector(mock[HttpClient], mockAppConfig, MockMetricsService)
       connector.customerInfoUrl("111") shouldEqual "/vat-subscription/111/customer-details"

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -42,6 +42,7 @@ class MockAppConfig(val runModeConfiguration: Configuration, val mode: Mode = Mo
   override val vatSubmittedReturnsUrl: String = "returns-url"
   override val vatReturnDeadlinesUrl: String = ""
   override def vatReturnUrl(periodKey: String): String = s"/submitted/${URLEncoder.encode(periodKey, "UTF-8")}"
+  override val vatObligationsBaseUrl: String = "/obligations-api"
   override val financialDataBaseUrl = ""
   override val btaHomeUrl: String = "bta-url"
   override val paymentsServiceUrl: String = "payments-url"

--- a/test/services/VatDetailsServiceSpec.scala
+++ b/test/services/VatDetailsServiceSpec.scala
@@ -50,13 +50,13 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
     )
 
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    val mockVatApiConnector: VatObligationsConnector = mock[VatObligationsConnector]
+    val mockObligationsConnector: VatObligationsConnector = mock[VatObligationsConnector]
     val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
     val mockSubscriptionConnector: VatSubscriptionConnector = mock[VatSubscriptionConnector]
     val mockDateService: DateService = mock[DateService]
     (mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01"))
 
-    lazy val vatDetailsService = new VatDetailsService(mockVatApiConnector,
+    lazy val vatDetailsService = new VatDetailsService(mockObligationsConnector,
                                                        mockFinancialDataConnector,
                                                        mockSubscriptionConnector,
                                                        mockAppConfig,
@@ -119,7 +119,7 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
 
       "return the most recent outstanding obligation" in new Test {
 
-        (mockVatApiConnector.getVatReturnObligations(_: String, _: LocalDate, _: LocalDate, _: Obligation.Status.Value)
+        (mockObligationsConnector.getVatReturnObligations(_: String, _: LocalDate, _: LocalDate, _: Obligation.Status.Value)
         (_: HeaderCarrier, _: ExecutionContext))
           .expects(*, *, *, *, *, *)
           .returns(Future.successful(Right(VatReturnObligations(Seq(currentObligation)))))
@@ -135,7 +135,7 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
 
       "return nothing" in new Test {
 
-        (mockVatApiConnector.getVatReturnObligations(_: String, _: LocalDate, _: LocalDate, _: Obligation.Status.Value)
+        (mockObligationsConnector.getVatReturnObligations(_: String, _: LocalDate, _: LocalDate, _: Obligation.Status.Value)
         (_: HeaderCarrier, _: ExecutionContext))
           .expects(*, *, *, *, *, *)
           .returns(Future.successful(Right(VatReturnObligations(Seq.empty))))
@@ -152,7 +152,7 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
 
       "return the error" in new Test {
 
-        (mockVatApiConnector.getVatReturnObligations(_: String, _: LocalDate, _: LocalDate, _: Obligation.Status.Value)
+        (mockObligationsConnector.getVatReturnObligations(_: String, _: LocalDate, _: LocalDate, _: Obligation.Status.Value)
         (_: HeaderCarrier, _: ExecutionContext))
           .expects(*, *, *, *, *, *)
           .returns(Future.successful(Left(BadRequestError("TEST_FAIL", "this is a test"))))
@@ -169,7 +169,7 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
 
       "return a failed Future containing the exception" in new Test {
 
-        (mockVatApiConnector.getVatReturnObligations(_: String, _: LocalDate, _: LocalDate, _: Obligation.Status.Value)
+        (mockObligationsConnector.getVatReturnObligations(_: String, _: LocalDate, _: LocalDate, _: Obligation.Status.Value)
         (_: HeaderCarrier, _: ExecutionContext))
           .expects(*, *, *, *, *, *)
           .returns(Future.failed(new RuntimeException("test")))

--- a/test/services/VatDetailsServiceSpec.scala
+++ b/test/services/VatDetailsServiceSpec.scala
@@ -18,7 +18,7 @@ package services
 
 import java.time.LocalDate
 
-import connectors.{FinancialDataConnector, VatApiConnector, VatSubscriptionConnector}
+import connectors.{FinancialDataConnector, VatObligationsConnector, VatSubscriptionConnector}
 import controllers.ControllerBaseSpec
 import models._
 import models.errors.{BadRequestError, CustomerInformationError, NextPaymentError, ObligationsError}
@@ -50,7 +50,7 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
     )
 
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    val mockVatApiConnector: VatApiConnector = mock[VatApiConnector]
+    val mockVatApiConnector: VatObligationsConnector = mock[VatObligationsConnector]
     val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
     val mockSubscriptionConnector: VatSubscriptionConnector = mock[VatSubscriptionConnector]
     val mockDateService: DateService = mock[DateService]


### PR DESCRIPTION
Implemented feature switch and configuration for vat-obligations (there is no returns split required here)