### PR TITLE
Changed obligations route to sit in the right place

### DIFF
--- a/app/connectors/VatObligationsConnector.scala
+++ b/app/connectors/VatObligationsConnector.scala
@@ -38,11 +38,11 @@ class VatObligationsConnector @Inject()(http: HttpClient,
 
   private[connectors] def obligationsUrl(vrn: String): String = {
     val baseUrl: String = if (appConfig.features.enableVatObligationsService()) {
-      appConfig.vatObligationsBaseUrl
+      appConfig.vatObligationsBaseUrl + "/vat-obligations"
     } else {
       appConfig.vatApiBaseUrl
     }
-    s"$baseUrl/vat-obligations/$vrn/obligations"
+    s"$baseUrl/$vrn/obligations"
   }
 
   def getVatReturnObligations(vrn: String,

--- a/it/stubs/VatObligationsStub.scala
+++ b/it/stubs/VatObligationsStub.scala
@@ -27,7 +27,7 @@ import play.api.libs.json.{Json, Writes}
 
 object VatObligationsStub extends WireMockMethods {
 
-  private val obligationsUri = "/vat-obligations/([0-9]+)/obligations"
+  private val obligationsUri = "/([0-9]+)/obligations"
   private val dateRegex = "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))"
 
   private implicit def obligationsWrites: Writes[VatReturnObligations] = Json.writes[VatReturnObligations]

--- a/test/connectors/VatObligationsConnectorSpec.scala
+++ b/test/connectors/VatObligationsConnectorSpec.scala
@@ -27,7 +27,7 @@ class VatObligationsConnectorSpec extends ControllerBaseSpec {
   "VatObligationsConnector" should {
     "generate the correct obligations url when not using vat-obligations" in {
       mockAppConfig.features.enableVatObligationsService(false)
-      connector.obligationsUrl("111") shouldEqual "/vat-obligations/111/obligations"
+      connector.obligationsUrl("111") shouldEqual "/111/obligations"
     }
 
     "generate the correct returns url with a period key when using vat-obligations" in {


### PR DESCRIPTION
There was initially some confusion around this but for now this needs to be split up so we can continue to use vat-api but also have the correct backend route in place.