### PR TITLE
financialDataPopulationRoutes

### DIFF
--- a/app/testOnly/connectors/DynamicStubConnector.scala
+++ b/app/testOnly/connectors/DynamicStubConnector.scala
@@ -18,7 +18,7 @@ package testOnly.connectors
 
 import javax.inject.Inject
 import testOnly.TestOnlyAppConfig
-import testOnly.models.DataModel
+import testOnly.models.{DataModel, SchemaModel}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
@@ -28,7 +28,18 @@ class DynamicStubConnector @Inject()(val http: HttpClient, val appConfig: TestOn
 
   def populateStub(dataModel: DataModel, serviceName: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     lazy val url = s"${appConfig.dynamicStubUrl(serviceName)}/setup/data"
+
     http.POST[DataModel, HttpResponse](url, dataModel)
+  }
+
+  def populateSchema(schemaModel: SchemaModel, serviceName: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
+    lazy val url = s"${appConfig.dynamicStubUrl(serviceName)}/setup/schema"
+    http.POST[SchemaModel, HttpResponse](url, schemaModel)
+  }
+
+  def clearSchemas(serviceName: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
+    lazy val url = s"${appConfig.dynamicStubUrl(serviceName)}/setup/all-schemas"
+    http.DELETE[HttpResponse](url)
   }
 
   def clearStub(serviceName: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {

--- a/app/testOnly/models/SchemaModel.scala
+++ b/app/testOnly/models/SchemaModel.scala
@@ -16,14 +16,17 @@
 
 package testOnly.models
 
-import play.api.libs.json.{Format, JsValue, Json}
+import play.api.libs.json.{Format, JsValue, Json, OFormat}
 
-case class DataModel(_id: String,
-                     schemaId: Option[String],
-                     method: String,
-                     status: Int,
-                     response: Option[JsValue])
+case class SchemaModel(
+                        _id: String,
+                        url: String,
+                        method: String,
+                        responseSchema: JsValue,
+                        requestSchema: Option[JsValue] = None
+                      )
 
-object DataModel {
-  implicit val formats: Format[DataModel] = Json.format[DataModel]
+object SchemaModel {
+  implicit val formats: OFormat[SchemaModel] = Json.format[SchemaModel]
 }
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -79,6 +79,10 @@ microservice {
       host = localhost
       port = 9158
     }
+    financial-transactions-dynamic-stub {
+      host = localhost
+      port = 9086
+    }
     vat-returns-dynamic-stub {
       host = localhost
       port = 9159

--- a/conf/testOnly.routes
+++ b/conf/testOnly.routes
@@ -14,12 +14,18 @@
 GET         /vat-through-software/test-only/feature-switch  @testOnly.controllers.FeatureSwitchController.featureSwitch
 POST        /vat-through-software/test-only/feature-switch  @testOnly.controllers.FeatureSwitchController.submitFeatureSwitch
 
+# NOCSRF
+POST        /vat-through-software/test-only/populate-schema/:serviceName              @testOnly.controllers.DynamicStubController.populateSchema(serviceName: String)
 
 # NOCSRF
 POST        /vat-through-software/test-only/populate-stub/:serviceName                @testOnly.controllers.DynamicStubController.populateStub(serviceName: String)
 
 # NOCSRF
 DELETE      /vat-through-software/test-only/clear-stub/:serviceName                   @testOnly.controllers.DynamicStubController.clearStub(serviceName: String)
+
+# NOCSRF
+DELETE      /vat-through-software/test-only/clear-schemas/:serviceName                @testOnly.controllers.DynamicStubController.clearSchemas(serviceName: String)
+
 
 GET         /vat-through-software/test-only/payments-stub                             @testOnly.controllers.PaymentsStubController.stub
 GET         /vat-through-software/test-only/direct-debit-stub                         @testOnly.controllers.DirectDebitStubController.stub

--- a/it/testOnly/connectors/DynamicStubConnectorISpec.scala
+++ b/it/testOnly/connectors/DynamicStubConnectorISpec.scala
@@ -4,7 +4,8 @@ package testOnly.connectors
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import helpers.IntegrationBaseSpec
 import play.api.http.Status._
-import testOnly.models.DataModel
+import play.api.libs.json.{JsValue, Json}
+import testOnly.models.{DataModel, SchemaModel}
 import testOnly.stubs.DynamicStub
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
@@ -43,10 +44,70 @@ class DynamicStubConnectorISpec extends IntegrationBaseSpec {
         override def setupStubs(): StubMapping = DynamicStub.populateStubOkResponse()
 
         setupStubs()
-        val result: Future[HttpResponse] = connector.populateStub(DataModel("/test", "GET", OK, None), exampleService)
+        val result: Future[HttpResponse] = connector.populateStub(DataModel("/test", None, "GET", OK, None), exampleService)
 
         result.status shouldBe OK
       }
     }
   }
+
+  "Calling populateSchema" when {
+
+    val jsonSchema: JsValue = Json.parse(
+           """{
+           |   "$schema": "http://json-schema.org/draft-04/schema#",
+           |   "title": "test API schemea",
+           |   "description": "A test schema",
+           |   "type": "object",
+           |
+           |   "properties": {
+           |
+           |      "id": {
+           |         "description": "The unique identifier for a product",
+           |         "type": "integer"
+           |      },
+           |
+           |      "name": {
+           |         "description": "Name",
+           |         "type": "string"
+           |      },
+           |
+           |      "price": {
+           |         "type": "number",
+           |         "minimum": 0,
+           |         "exclusiveMinimum": true
+           |      }
+           |   },
+           |
+           |   "required": ["id", "name", "price"]
+           |}""".stripMargin)
+
+    "the stub returns 200 OK" should {
+
+      "return a 200 OK HttpResponse" in new Test {
+        override def setupStubs(): StubMapping = DynamicStub.populateSchemaOkResponse()
+
+        setupStubs()
+        val result: Future[HttpResponse] = connector.populateSchema(SchemaModel("getFinancialData", "/test", "GET", jsonSchema, None), exampleService)
+
+        result.status shouldBe OK
+      }
+    }
+  }
+
+  "Calling clearSchemas" when {
+
+    "the stub returns 200 OK" should {
+
+      "return a 200 OK HttpResponse" in new Test {
+        override def setupStubs(): StubMapping = DynamicStub.clearSchemasOkResponse()
+
+        setupStubs()
+        val result: Future[HttpResponse] = connector.clearSchemas(exampleService)
+
+        result.status shouldBe OK
+      }
+    }
+  }
+
 }

--- a/it/testOnly/stubs/DynamicStub.scala
+++ b/it/testOnly/stubs/DynamicStub.scala
@@ -8,12 +8,20 @@ import play.api.http.Status._
 object DynamicStub extends WireMockMethods {
 
   private val clearDataUri = "/setup/all-data"
+  private val clearSchemasUri = "/setup/all-schemas"
   private val populateDataUri = "/setup/data"
+  private val populateSchemaUri = "/setup/schema"
 
   def clearStubOkResponse(): StubMapping = when(method = DELETE, uri = clearDataUri)
     .thenReturn(OK)
 
   def populateStubOkResponse(): StubMapping = when(method = POST, uri = populateDataUri)
+    .thenReturn(OK)
+
+  def clearSchemasOkResponse(): StubMapping = when(method = DELETE, uri = clearSchemasUri)
+    .thenReturn(OK)
+
+  def populateSchemaOkResponse(): StubMapping = when(method = POST, uri = populateSchemaUri)
     .thenReturn(OK)
 
 }


### PR DESCRIPTION
added test only routes to support populating FT stub and schemas
