### PR TITLE
Btat3389

### DIFF
--- a/app/views/templates/payments/WhatYouOweChargeHelper.scala
+++ b/app/views/templates/payments/WhatYouOweChargeHelper.scala
@@ -30,21 +30,31 @@ class WhatYouOweChargeHelper @Inject()(payment: OpenPaymentsModel, hasDirectDebi
     case `vatReturnDebitCharge` =>
       s"${messages.apply("openPayments.forPeriod")} ${displayDateRange(payment.start, payment.end)}"
     case `officerAssessmentDebitCharge` => messages.apply("openPayments.officersAssessment")
-  }
+    case `vatDefaultSurcharge` =>
+      s"${messages.apply("openPayments.surcharge", {displayDateRange(payment.start, payment.end)})}"
+    case `vatCentralAssessment` =>
+      s"${messages.apply("openPayments.centralAssessment",
+        {displayDateRange(payment.start, payment.end)}).trim}${messages("openPayments.centralAssessmentSubmit")}"}
 
   val payLinkText: Option[String] = (payment.paymentType, hasDirectDebit) match {
     case (`vatReturnDebitCharge`, Some(true)) => None
     case (`vatReturnDebitCharge`, _) => Some(messages.apply("openPayments.makePayment"))
     case (`officerAssessmentDebitCharge`, _) => Some(messages.apply("openPayments.makePayment"))
+    case (`vatDefaultSurcharge`, _) => Some(messages.apply("openPayments.makePayment"))
+    case (`vatCentralAssessment`, _) => Some(messages.apply("openPayments.payEstimate"))
   }
 
   val viewReturnEnabled: Boolean = payment.paymentType match {
     case `vatReturnDebitCharge` => true
     case `officerAssessmentDebitCharge` => false
+    case `vatDefaultSurcharge` => false
+    case `vatCentralAssessment` => false
   }
 
   val overdueContext: String = payment.paymentType match {
     case `vatReturnDebitCharge` => if(payment.overdue) messages.apply("common.overdue") else ""
     case `officerAssessmentDebitCharge` => if(payment.overdue) messages.apply("common.isOverdue") else ","
+    case `vatDefaultSurcharge` => if(payment.overdue) messages.apply("common.isOverdue") else ","
+    case `vatCentralAssessment` => if(payment.overdue) messages.apply("common.isOverdue") else ","
   }
 }

--- a/conf/messages
+++ b/conf/messages
@@ -80,6 +80,11 @@ openPayments.directDebitViewAndUpdate = view your direct debit details
 openPayments.youPayByDirectDebit = You pay by direct debit
 openPayments.directDebit.heading = Direct debits
 openPayments.officersAssessment = a VAT officer''s investigation showed you underpaid by this amount
+openPayments.officersAssessment = a VAT officer''s investigation showed you underpaid by this amount
+openPayments.payEstimate = Pay estimate
+openPayments.surcharge = this is a surcharge for late payment of your {0} return
+openPayments.centralAssessment = this is our estimate for {0}
+openPayments.centralAssessmentSubmit =, submit your overdue return to update this amount
 
 noPayments.title = Your VAT payment
 noPayments.heading = What you owe

--- a/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
@@ -44,8 +44,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
               "items" -> Json.arr(
                 Json.obj("dueDate" -> "2017-10-25")
               ),
-              "outstandingAmount" -> 1000,
-              "periodKey" -> "#003"
+              "outstandingAmount" -> 1000.50,
+              "periodKey" -> "#001"
             ),
             Json.obj(
               "mainType" -> FinancialTransactionsConstants.vatReturnCharge,
@@ -55,8 +55,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
               "items" -> Json.arr(
                 Json.obj("dueDate" -> "2018-10-25")
               ),
-              "outstandingAmount" -> 1000,
-              "periodKey" -> "#004"
+              "outstandingAmount" -> 1000.51,
+              "periodKey" -> "#002"
             ),
             Json.obj(
               "mainType" -> FinancialTransactionsConstants.officerAssessmentCharge,
@@ -66,8 +66,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
               "items" -> Json.arr(
                 Json.obj("dueDate" -> "2017-10-25")
               ),
-              "outstandingAmount" -> 1000,
-              "periodKey" -> "#004"
+              "outstandingAmount" -> 1000.52,
+              "periodKey" -> "#003"
             ),
             Json.obj(
               "mainType" -> FinancialTransactionsConstants.officerAssessmentCharge,
@@ -77,9 +77,32 @@ class PaymentsHttpParserSpec extends UnitSpec {
               "items" -> Json.arr(
                 Json.obj("dueDate" -> "2017-10-25")
               ),
-              "outstandingAmount" -> 1000,
+              "outstandingAmount" -> 1000.53,
               "periodKey" -> "#004"
+            ),
+            Json.obj(
+              "mainType" -> FinancialTransactionsConstants.vatCentralAssessment,
+              "chargeType" -> FinancialTransactionsConstants.vatCentralAssessment,
+              "taxPeriodFrom" -> "2016-12-01",
+              "taxPeriodTo" -> "2017-01-01",
+              "items" -> Json.arr(
+                Json.obj("dueDate" -> "2016-10-25")
+              ),
+              "outstandingAmount" -> 1000.25,
+              "periodKey" -> "#005"
+            ),
+            Json.obj(
+              "mainType" -> FinancialTransactionsConstants.vatDefaultSurcharge,
+              "chargeType" -> FinancialTransactionsConstants.vatDefaultSurcharge,
+              "taxPeriodFrom" -> "2015-12-01",
+              "taxPeriodTo" -> "2014-01-01",
+              "items" -> Json.arr(
+                Json.obj("dueDate" -> "2015-10-25")
+              ),
+              "outstandingAmount" -> 1000.27,
+              "periodKey" -> "#006"
             )
+
           )
         )
       ))
@@ -90,18 +113,35 @@ class PaymentsHttpParserSpec extends UnitSpec {
           start = LocalDate.parse("2016-12-01"),
           end = LocalDate.parse("2017-01-01"),
           due = LocalDate.parse("2017-10-25"),
-          outstandingAmount = BigDecimal(1000.00),
-          periodKey = "#003"
+          outstandingAmount = BigDecimal(1000.50),
+          periodKey = "#001"
         ),
         Payment(
           FinancialTransactionsConstants.officerAssessmentDebitCharge,
           start = LocalDate.parse("2017-12-01"),
           end = LocalDate.parse("2018-01-01"),
           due = LocalDate.parse("2017-10-25"),
-          outstandingAmount = BigDecimal(1000.00),
+          outstandingAmount = BigDecimal(1000.53),
           periodKey = "#004"
+        ),
+        Payment(
+          FinancialTransactionsConstants.vatCentralAssessment,
+          start = LocalDate.parse("2016-12-01"),
+          end = LocalDate.parse("2017-01-01"),
+          due = LocalDate.parse("2016-10-25"),
+          outstandingAmount = BigDecimal(1000.25),
+          periodKey = "#005"
+        ),
+        Payment(
+          FinancialTransactionsConstants.vatDefaultSurcharge,
+          start = LocalDate.parse("2015-12-01"),
+          end = LocalDate.parse("2014-01-01"),
+          due = LocalDate.parse("2015-10-25"),
+          outstandingAmount = BigDecimal(1000.27),
+          periodKey = "#006"
         )
       )))
+
 
       val result = PaymentsReads.read("", "", httpResponse)
 

--- a/test/views/templates/payments/WhatYouOweChargeTemplateSpec.scala
+++ b/test/views/templates/payments/WhatYouOweChargeTemplateSpec.scala
@@ -182,4 +182,112 @@ class WhatYouOweChargeTemplateSpec extends ViewBaseSpec {
       }
     }
   }
+
+  "Rendering a default surcharge charge" when {
+
+    def generateModel(overdue: Boolean): OpenPaymentsModel = {
+      OpenPaymentsModel(
+        vatDefaultSurcharge,
+        BigDecimal(300.00),
+        LocalDate.parse("2000-05-10"),
+        LocalDate.parse("2000-02-01"),
+        LocalDate.parse("2000-03-28"),
+        "#004",
+        overdue
+      )
+    }
+
+    "the payment is not overdue" should {
+
+      val model = generateModel(overdue = false)
+      lazy val view = views.html.templates.payments.whatYouOweCharge(model, 0, Some(true))
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "display the correct description text" in {
+        elementText(Selectors.description) shouldBe
+          "this is a surcharge for late payment of your 1 February to 28 March 2000 return"
+      }
+
+      "display the correct pay text" in {
+        elementText(Selectors.payText) shouldBe "Pay now"
+      }
+
+      "have the correct pay link context" in {
+        elementText(Selectors.payContext) shouldBe
+          "£300 , this is a surcharge for late payment of your 1 February to 28 March 2000 return"
+      }
+
+      "not display the view return link" in {
+        intercept[org.scalatest.exceptions.TestFailedException](element(Selectors.viewReturnLink))
+      }
+    }
+
+    "the payment is overdue" should {
+
+      val model = generateModel(overdue = true)
+      lazy val view = views.html.templates.payments.whatYouOweCharge(model, 0, Some(true))
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "have the correct pay link context" in {
+        elementText(Selectors.payContext) shouldBe
+          "£300 is overdue, this is a surcharge for late payment of your 1 February to 28 March 2000 return"
+      }
+    }
+  }
+
+  "Rendering a central assessment charge" when {
+
+    def generateModel(overdue: Boolean): OpenPaymentsModel = {
+      OpenPaymentsModel(
+        vatCentralAssessment,
+        BigDecimal(200.00),
+        LocalDate.parse("2001-05-10"),
+        LocalDate.parse("2001-02-01"),
+        LocalDate.parse("2001-03-28"),
+        "#005",
+        overdue
+      )
+    }
+
+    "the payment is not overdue" should {
+
+      val model = generateModel(overdue = false)
+      lazy val view = views.html.templates.payments.whatYouOweCharge(model, 0, Some(true))
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "display the correct description text" in {
+        elementText(Selectors.description) shouldBe
+          "this is our estimate for 1 February to 28 March 2001, " +
+        "submit your overdue return to update this amount"
+      }
+
+      "display the correct pay text" in {
+        elementText(Selectors.payText) shouldBe "Pay estimate"
+      }
+
+      "have the correct pay link context" in {
+        elementText(Selectors.payContext) shouldBe
+          "£200 , this is our estimate for 1 February to 28 March 2001, " +
+        "submit your overdue return to update this amount"
+      }
+
+      "not display the view return link" in {
+        intercept[org.scalatest.exceptions.TestFailedException](element(Selectors.viewReturnLink))
+      }
+    }
+
+    "the payment is overdue" should {
+
+      val model = generateModel(overdue = true)
+      lazy val view = views.html.templates.payments.whatYouOweCharge(model, 0, Some(true))
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "have the correct pay link context" in {
+        elementText(Selectors.payContext) shouldBe
+          "£200 is overdue, this is our estimate for 1 February to 28 March 2001, " +
+            "submit your overdue return to update this amount"
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Add central assessment and surcharge charges to payments parser and what you owe page

NOTE: TEST DATE FOR THIS IS HERE:

https://github.com/hmrc/view-vat-acceptance-tests/pull/101