### PR TITLE
Added githooks to repo to help with ensuring a clean history

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+fl=("VRN" "HMRC" "BTAT" "Intellij" "intellij")
+
+br="$(git rev-parse --abbrev-ref HEAD)"
+cf="${1}"
+
+die() {
+  printf "fatal: ${1}\n" "${2}" >&2
+  printf "hint: use '--no-verify' to disable this check\n"
+
+  exit 1
+}
+
+filter() {
+  local s="${1}"
+
+  for i in "${fl[@]}"; do
+    [ "${i}" = "${s}" ] && return 0
+  done
+
+  return 1
+}
+
+verify_no_merge_master() {
+  [ "$(cat "${cf}" | grep -ci "merge branch 'master'")" = "0" ] \
+    || die "refusing to merge 'origin/master' into local branch '${br}'\
+            \nuse 'git rebase master' instead\n"
+}
+
+verify_spelling() {
+  sp="$(cat "${cf}" | sed 's/\([A-Z]\)/ \1/g' | aspell --list)"
+
+  for w in ${sp}; do
+    filter "${w}" || wd+=" - ${w}\n"
+  done
+
+  cn="$(printf "${wd}" | wc -l)"
+  [ "${cn}" = "0" ] \
+    || die "commit message contains ${cn} mispelled words:\n${wd}"
+}
+
+main() {
+  verify_no_merge_master
+  verify_spelling
+}
+
+main

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+br="$(git rev-parse --abbrev-ref HEAD)"
+
+die() {
+  printf "fatal: ${1}\n" "${2}" >&2
+  printf "hint: use '--no-verify' to disable this check\n"
+
+  exit 1
+}
+
+verify_up_to_date() {
+  git fetch \
+    && cn="$(git log HEAD..origin/master --oneline | wc -l)"
+
+  [ "${cn}" = "0" ] \
+    || die "branch '${br}' is behind 'origin/master' by ${cn} commits.\
+           \nrun 'git rebase master' and try again\n"
+}
+
+verify_branch() {
+  [ "${br}" = "master" ] && [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ] \
+    && exit 0
+
+  [ "${br}" = "master" ] \
+    && die "refusing to commit directly to default branch 'master'\n"
+
+  [[ "${br}" =~ ^BTAT-[0\-9]{4}$ ]] \
+    || die "branch name '${br}' is incorrectly formatted \
+           \nhint: branch names should reflect their jira issue, eg. BTAT-1234\n"
+}
+
+main() {
+  verify_branch
+  verify_up_to_date
+}
+
+main


### PR DESCRIPTION
After today's discussion during standup I decided to make a PR containing the git hooks I created and see everyone's opinion on including them.

To install them, run `ln -sf $(git rev-parse --show-toplevel)/githooks/* .git/hooks/` from the top level of the repository.

These will not impede any quick repo changes we might have to make, for example, a push to force a jenkins rebuild as you always have the option of using `--no-verify` to disable the check. 

Feel free to ask questions if you have any.