### PR TITLE
BTAT-3408 Added logic to sort items on payment history page

### DIFF
--- a/app/services/PaymentsService.scala
+++ b/app/services/PaymentsService.scala
@@ -51,7 +51,7 @@ class PaymentsService @Inject()(financialDataConnector: FinancialDataConnector,
     val to: LocalDate = LocalDate.parse(s"$searchYear-12-31")
 
     financialDataConnector.getVatLiabilities(user.vrn, from, to).map {
-      case Right(liabilities) => Right(liabilities)
+      case Right(liabilities) => Right(liabilities.sortBy(_.clearedDate.toString).reverse)
       case Left(_) => Left(VatLiabilitiesError)
     }
   }

--- a/test/services/PaymentsServiceSpec.scala
+++ b/test/services/PaymentsServiceSpec.scala
@@ -212,22 +212,46 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
 
     val taxPeriodYear: Int = 2018
 
-    "return a seq of payment history models" in new Test {
-      val paymentSeq = Right(Seq(
-        PaymentsHistoryModel(
-          chargeType = "VAT Return charge",
-          taxPeriodFrom = Some(LocalDate.parse("2018-01-01")),
-          taxPeriodTo = Some(LocalDate.parse("2018-01-26")),
-          amount = exampleAmount,
-          clearedDate = Some(LocalDate.parse("2018-01-13"))
-        )
-      ))
+    "return a seq of payment history models sorted by clearing date in descending order" in new Test {
 
+      val paymentModel1 = PaymentsHistoryModel(
+        chargeType = "VAT Return charge",
+        taxPeriodFrom = Some(LocalDate.parse("2018-01-01")),
+        taxPeriodTo = Some(LocalDate.parse("2018-01-01")),
+        amount = exampleAmount,
+        clearedDate = Some(LocalDate.parse("2018-01-30"))
+      )
+      val paymentModel2 = PaymentsHistoryModel(
+        chargeType = "VAT Return charge",
+        taxPeriodFrom = Some(LocalDate.parse("2018-01-01")),
+        taxPeriodTo = Some(LocalDate.parse("2018-01-01")),
+        amount = exampleAmount,
+        clearedDate = Some(LocalDate.parse("2018-02-28"))
+      )
+      val paymentModel3 = PaymentsHistoryModel(
+        chargeType = "VAT Return charge",
+        taxPeriodFrom = Some(LocalDate.parse("2018-01-01")),
+        taxPeriodTo = Some(LocalDate.parse("2018-01-01")),
+        amount = exampleAmount,
+        clearedDate = Some(LocalDate.parse("2018-03-01"))
+      )
+      val paymentModel4 = PaymentsHistoryModel(
+        chargeType = "VAT Return charge",
+        taxPeriodFrom = Some(LocalDate.parse("2018-01-01")),
+        taxPeriodTo = Some(LocalDate.parse("2018-01-01")),
+        amount = exampleAmount,
+        clearedDate = Some(LocalDate.parse("2018-01-31"))
+      )
+
+      val paymentSeq: HttpGetResult[Seq[PaymentsHistoryModel]] =
+        Right(Seq(paymentModel1, paymentModel2, paymentModel3, paymentModel4))
+      val sortedPayments: ServiceResponse[Seq[PaymentsHistoryModel]] =
+        Right(Seq(paymentModel3, paymentModel2, paymentModel4, paymentModel1))
       override val connectorResponse: HttpGetResult[Seq[PaymentsHistoryModel]] = paymentSeq
       private val result: ServiceResponse[Seq[PaymentsHistoryModel]] =
         await(target.getPaymentsHistory(User("999999999"), taxPeriodYear))
 
-      result shouldBe paymentSeq
+      result shouldBe sortedPayments
     }
 
     "return a http error" in new Test {


### PR DESCRIPTION
If you wish to test this visually, here's a handy bit of JSON with jumbled up clearing dates:
```
{
  "_id" : "/enterprise/financial-data/VRN/987654321/VATC?dateFrom=2018-01-01&dateTo=2018-12-31",
  "schemaId" : "getFinancialData",
  "method" : "GET",
  "status" : 200,
  "response" : {
    "idType" : "VRN",
    "idNumber" : "987654321",
    "regimeType" : "VATC",
    "processingDate" : "2018-01-01T01:01:01.000Z",
    "financialTransactions" : [
      {
        "chargeType" : "VAT OA Debit Charge",
        "mainType" : "VAT Officer's Assessment",
        "taxPeriodFrom" : "2018-01-01",
        "taxPeriodTo" : "2018-01-01",
        "outstandingAmount" : 0.00,
        "clearedAmount" : 1500.00,
        "items" : [
          {
            "dueDate" : "2018-03-03",
            "amount" : 1500.00,
            "clearingDate" : "2018-03-04"
          }
        ]
      },
      {
        "chargeType" : "VAT OA Debit Charge",
        "mainType" : "VAT Officer's Assessment",
        "taxPeriodFrom" : "2018-01-01",
        "taxPeriodTo" : "2018-01-01",
        "outstandingAmount" : 0.00,
        "clearedAmount" : 1500.00,
        "items" : [
          {
            "dueDate" : "2018-03-03",
            "amount" : 1500.00,
            "clearingDate" : "2018-12-01"
          }
        ]
      },
      {
        "chargeType" : "VAT OA Debit Charge",
        "mainType" : "VAT Officer's Assessment",
        "taxPeriodFrom" : "2018-01-01",
        "taxPeriodTo" : "2018-01-01",
        "outstandingAmount" : 0.00,
        "clearedAmount" : 1500.00,
        "items" : [
          {
            "dueDate" : "2018-03-03",
            "amount" : 1500.00,
            "clearingDate" : "2018-01-01"
          }
        ]
      },
      {
        "chargeType" : "VAT OA Debit Charge",
        "mainType" : "VAT Officer's Assessment",
        "taxPeriodFrom" : "2018-01-01",
        "taxPeriodTo" : "2018-01-01",
        "outstandingAmount" : 0.00,
        "clearedAmount" : 1500.00,
        "items" : [
          {
            "dueDate" : "2018-03-03",
            "amount" : 1500.00,
            "clearingDate" : "2018-03-03"
          }
        ]
      }
    ]
  }
}
```
Post that to the financial transactions stub at `http://localhost:9086/setup/data`, log in to our service as user 987654321 and go to the Payment History page.