### PR TITLE
Added the below charge types

### DIFF
--- a/app/connectors/httpParsers/PaymentsHttpParser.scala
+++ b/app/connectors/httpParsers/PaymentsHttpParser.scala
@@ -58,6 +58,8 @@ object PaymentsHttpParser extends ResponseHttpParsers {
       MpPre2009Charge.value,
       MpRepeatedPre2009Charge.value,
       CivilEvasionPenaltyCharge.value,
+      VatInaccuraciesInECSalesCharge.value,
+      VatFailureToSubmitECSalesCharge.value,
       AAInterestCharge.value
     )
 

--- a/app/models/payments/ChargeType.scala
+++ b/app/models/payments/ChargeType.scala
@@ -104,6 +104,12 @@ case object MpRepeatedPre2009Charge extends ChargeType {
 case object CivilEvasionPenaltyCharge extends ChargeType {
   override val value: String = "VAT Civil Evasion Penalty"
 }
+case object VatInaccuraciesInECSalesCharge extends ChargeType {
+  override val value: String = "VAT Inaccuracies in EC Sales"
+}
+case object VatFailureToSubmitECSalesCharge extends ChargeType {
+  override val value: String = "VAT Failure to Submit EC Sales"
+}
 
 object ChargeType {
 
@@ -135,6 +141,8 @@ object ChargeType {
     case MpPre2009Charge.value => MpPre2009Charge
     case MpRepeatedPre2009Charge.value => MpRepeatedPre2009Charge
     case CivilEvasionPenaltyCharge.value => CivilEvasionPenaltyCharge
+    case VatInaccuraciesInECSalesCharge.value => VatInaccuraciesInECSalesCharge
+    case VatFailureToSubmitECSalesCharge.value => VatFailureToSubmitECSalesCharge
     case _ => throw new IllegalArgumentException("Invalid Charge Type")
   }
 

--- a/app/models/payments/OpenPaymentsModel.scala
+++ b/app/models/payments/OpenPaymentsModel.scala
@@ -44,6 +44,9 @@ sealed trait OpenPaymentsModel {
     case MpPre2009Charge => messages("openPayments.vatMpPre2009")
     case MpRepeatedPre2009Charge => messages("openPayments.vatMpRepeatedPre2009")
     case CivilEvasionPenaltyCharge => messages("openPayments.vatCivilEvasionPenalty")
+    case VatInaccuraciesInECSalesCharge => messages("openPayments.vatInaccuraciesECSales")
+    case VatFailureToSubmitECSalesCharge => messages("openPayments.vatFailureToSubmitECSales")
+
     case _ => throw new IllegalArgumentException("Invalid Charge Type")
   }
 
@@ -111,6 +114,8 @@ case class OpenPaymentsModelWithPeriod(chargeType: ChargeType,
     case BnpRegPre2010Charge => messages("openPayments.vatBNPofRegPre2010", displayDateRange(start, end))
     case AAFurtherInterestCharge => messages("openPayments.vatAAFurtherInterest", displayDateRange(start, end))
     case AACharge => messages("openPayments.vatAdditionalAssessment", displayDateRange(start, end))
+    case VatInaccuraciesInECSalesCharge=> messages("openPayments.vatInaccuraciesECSales",displayDateRange(start, end))
+    case VatFailureToSubmitECSalesCharge=> messages("openPayments.vatFailureToSubmitECSales",displayDateRange(start, end))
     case _ => super.whatYouOweDescription
   }
 

--- a/conf/messages
+++ b/conf/messages
@@ -105,6 +105,8 @@ openPayments.vatMpPre2009 = because you have made an incorrect declaration
 openPayments.vatMpRepeatedPre2009 = this is because you have repeatedly made incorrect declarations
 openPayments.vatCivilEvasionPenalty = because we have identified irregularities involving dishonesty
 openPayments.AADefaultInterestDescription = interest charged on additional tax assessed for the period {0}
+openPayments.vatInaccuraciesECSales = because you have provided inaccurate information in your EC sales list
+openPayments.vatFailureToSubmitECSales = because you have not submitted an EC sales list or you have submitted it late
 
 noPayments.heading = What you owe
 noPayments.oweNothing = You do not owe anything right now.

--- a/test/views/payments/OpenPaymentsViewSpec.scala
+++ b/test/views/payments/OpenPaymentsViewSpec.scala
@@ -203,6 +203,24 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
       LocalDate.parse("2015-03-31"),
       "#015",
       overdue = true
+    ),
+    OpenPaymentsModelWithPeriod(
+      VatInaccuraciesInECSalesCharge,
+      1600.00,
+      LocalDate.parse("2016-04-05"),
+      LocalDate.parse("2016-01-01"),
+      LocalDate.parse("2016-03-31"),
+      "#016",
+      overdue = true
+    ),
+    OpenPaymentsModelWithPeriod(
+      VatFailureToSubmitECSalesCharge,
+      1700.00,
+      LocalDate.parse("2017-04-05"),
+      LocalDate.parse("2017-01-01"),
+      LocalDate.parse("2017-03-31"),
+      "#017",
+      overdue = true
     )
   )
 
@@ -618,6 +636,52 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
 
       "not display a view return link text for the 15th payment" in {
         document.select(Selectors.paymentViewReturnText(15)).size shouldBe 0
+      }
+    }
+
+    "for the 16th payment" should {
+
+      "render the correct amount for the 16th payment" in {
+        elementText(Selectors.paymentAmount(16)) shouldBe "£1,600"
+      }
+
+      "render the correct amount for the 16th payment amount data attribute" in {
+        elementText(Selectors.paymentAmountData(16)) shouldBe "£1,600"
+      }
+
+      "render the correct due period for the 16th payment" in {
+        elementText(Selectors.paymentDue(16)) shouldBe "due by 5 April 2016"
+      }
+
+      "render the correct due period for the 16th payment period data attribute" in {
+        elementText(Selectors.paymentDueData(16)) shouldBe "due by 5 April 2016"
+      }
+
+      "not display a view return link text for the 16th payment" in {
+        document.select(Selectors.paymentViewReturnText(16)).size shouldBe 0
+      }
+    }
+
+    "for the 17th payment" should {
+
+      "render the correct amount for the 17th payment" in {
+        elementText(Selectors.paymentAmount(17)) shouldBe "£1,700"
+      }
+
+      "render the correct amount for the 17th payment amount data attribute" in {
+        elementText(Selectors.paymentAmountData(17)) shouldBe "£1,700"
+      }
+
+      "render the correct due period for the 17th payment" in {
+        elementText(Selectors.paymentDue(17)) shouldBe "due by 5 April 2017"
+      }
+
+      "render the correct due period for the 17th payment period data attribute" in {
+        elementText(Selectors.paymentDueData(17)) shouldBe "due by 5 April 2017"
+      }
+
+      "not display a view return link text for the 16th payment" in {
+        document.select(Selectors.paymentViewReturnText(17)).size shouldBe 0
       }
     }
 


### PR DESCRIPTION
1. chargeType = "VAT Inaccuracies in EC Sales"
Label text = "because you have provided innacurate information in your EC sales list"
Follows the existing pattern to show the charges based on their due dates in descending order.
Includes a 'pay now' link, and associated pay-api hand-off to OPS.

2. chargeType = "VAT Failure to Submit EC Sales"
Label text = "because you have not submitted an EC sales list or you have submitted it late"
Follow the existing pattern to show the charges based on their due dates in descending order.
Include a 'pay now' link, and associated pay-api hand-off to OPS.