### PR TITLE
BTAT-4897

### DIFF
--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -197,6 +197,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.vatMpRepeatedPre2009ChargeDescription")
   )
 
+  object VatInaccuraciesReturnReplacedCharge extends PaymentsHistoryChargeHelper(
+    InaccuraciesReturnReplacedCharge.value,
+    "paymentsHistory.vatInaccuraciesReturnReplacedChargeTitle",
+    Some("paymentsHistory.vatInaccuraciesReturnReplacedChargeDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -227,7 +233,8 @@ object PaymentsHistoryChargeHelper {
     VatOAInaccuracies2009,
     VatInaccuracyAssessmentsPenCharge,
     VatMpPre2009Charge,
-    VatMpRepeatedPre2009Charge
+    VatMpRepeatedPre2009Charge,
+    VatInaccuraciesReturnReplacedCharge
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -185,6 +185,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.vatInaccuracyAssessmentsPenChargeDescription")
   )
 
+  object VatMpPre2009Charge extends PaymentsHistoryChargeHelper(
+    MpPre2009Charge.value,
+    "paymentsHistory.vatMpPre2009ChargeTitle",
+    Some("paymentsHistory.vatMpPre2009ChargeDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -213,7 +219,8 @@ object PaymentsHistoryChargeHelper {
     VatFailureToSubmitECSales,
     FtnEachPartner,
     VatOAInaccuracies2009,
-    VatInaccuracyAssessmentsPenCharge
+    VatInaccuracyAssessmentsPenCharge,
+    VatMpPre2009Charge
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -203,6 +203,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.vatInaccuraciesReturnReplacedChargeDescription")
   )
 
+  object VatWrongDoingPenaltyCharge extends PaymentsHistoryChargeHelper(
+    WrongDoingPenaltyCharge.value,
+    "paymentsHistory.vatWrongDoingPenaltyChargeTitle",
+    Some("paymentsHistory.vatWrongDoingPenaltyChargeDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -234,7 +240,8 @@ object PaymentsHistoryChargeHelper {
     VatInaccuracyAssessmentsPenCharge,
     VatMpPre2009Charge,
     VatMpRepeatedPre2009Charge,
-    VatInaccuraciesReturnReplacedCharge
+    VatInaccuraciesReturnReplacedCharge,
+    VatWrongDoingPenaltyCharge
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -191,6 +191,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.vatMpPre2009ChargeDescription")
   )
 
+  object VatMpRepeatedPre2009Charge extends PaymentsHistoryChargeHelper(
+    MpRepeatedPre2009Charge.value,
+    "paymentsHistory.vatMpRepeatedPre2009ChargeTitle",
+    Some("paymentsHistory.vatMpRepeatedPre2009ChargeDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -220,7 +226,8 @@ object PaymentsHistoryChargeHelper {
     FtnEachPartner,
     VatOAInaccuracies2009,
     VatInaccuracyAssessmentsPenCharge,
-    VatMpPre2009Charge
+    VatMpPre2009Charge,
+    VatMpRepeatedPre2009Charge
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -137,7 +137,6 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.VatStatutoryInterestDescription"),
     "repayment"
   )
-
   object VatSecurityDepositRequest extends PaymentsHistoryChargeHelper(
     VatSecurityDepositRequestCharge.value,
     "paymentsHistory.vatSecurityDepositRequestTitle",
@@ -180,6 +179,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.vatOAInaccuraciesFrom2009Description")
   )
 
+  object VatInaccuracyAssessmentsPenCharge extends PaymentsHistoryChargeHelper(
+    InaccuraciesAssessmentsPenCharge.value,
+    "paymentsHistory.vatInaccuracyAssessmentsPenChargeTitle",
+    Some("paymentsHistory.vatInaccuracyAssessmentsPenChargeDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -207,7 +212,8 @@ object PaymentsHistoryChargeHelper {
     VatInaccuraciesInECSales,
     VatFailureToSubmitECSales,
     FtnEachPartner,
-    VatOAInaccuracies2009
+    VatOAInaccuracies2009,
+    VatInaccuracyAssessmentsPenCharge
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/conf/messages
+++ b/conf/messages
@@ -202,6 +202,8 @@ paymentsHistory.vatInaccuracyAssessmentsPenChargeTitle = Inaccuracies penalty
 paymentsHistory.vatInaccuracyAssessmentsPenChargeDescription = because you submitted an inaccurate document for the period {0}
 paymentsHistory.vatMpPre2009ChargeTitle = Misdeclaration penalty
 paymentsHistory.vatMpPre2009ChargeDescription = because you have made an incorrect declaration
+paymentsHistory.vatMpRepeatedPre2009ChargeTitle = Misdeclaration repeat penalty
+paymentsHistory.vatMpRepeatedPre2009ChargeDescription = because you have repeatedly made incorrect declarations
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/conf/messages
+++ b/conf/messages
@@ -198,6 +198,8 @@ paymentsHistory.ftnEachPartnerTitle = Failure to notify penalty
 paymentsHistory.ftnEachPartnerDescription = because you did not tell us about all the partners and changes in your partnership
 paymentsHistory.vatOAInaccuraciesFrom2009Title = Inaccuracies penalty
 paymentsHistory.vatOAInaccuraciesFrom2009Description = because you submitted an inaccurate document for the period {0}
+paymentsHistory.vatInaccuracyAssessmentsPenChargeTitle = Inaccuracies penalty
+paymentsHistory.vatInaccuracyAssessmentsPenChargeDescription = because you submitted an inaccurate document for the period {0}
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/conf/messages
+++ b/conf/messages
@@ -206,6 +206,8 @@ paymentsHistory.vatMpRepeatedPre2009ChargeTitle = Misdeclaration repeat penalty
 paymentsHistory.vatMpRepeatedPre2009ChargeDescription = because you have repeatedly made incorrect declarations
 paymentsHistory.vatInaccuraciesReturnReplacedChargeTitle = Inaccuracies penalty
 paymentsHistory.vatInaccuraciesReturnReplacedChargeDescription = this is because you have submitted inaccurate information for the period {0}
+paymentsHistory.vatWrongDoingPenaltyChargeTitle = Wrongdoing penalty
+paymentsHistory.vatWrongDoingPenaltyChargeDescription = because you charged VAT when you should not have done
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/conf/messages
+++ b/conf/messages
@@ -200,6 +200,8 @@ paymentsHistory.vatOAInaccuraciesFrom2009Title = Inaccuracies penalty
 paymentsHistory.vatOAInaccuraciesFrom2009Description = because you submitted an inaccurate document for the period {0}
 paymentsHistory.vatInaccuracyAssessmentsPenChargeTitle = Inaccuracies penalty
 paymentsHistory.vatInaccuracyAssessmentsPenChargeDescription = because you submitted an inaccurate document for the period {0}
+paymentsHistory.vatMpPre2009ChargeTitle = Misdeclaration penalty
+paymentsHistory.vatMpPre2009ChargeDescription = because you have made an incorrect declaration
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/conf/messages
+++ b/conf/messages
@@ -204,6 +204,8 @@ paymentsHistory.vatMpPre2009ChargeTitle = Misdeclaration penalty
 paymentsHistory.vatMpPre2009ChargeDescription = because you have made an incorrect declaration
 paymentsHistory.vatMpRepeatedPre2009ChargeTitle = Misdeclaration repeat penalty
 paymentsHistory.vatMpRepeatedPre2009ChargeDescription = because you have repeatedly made incorrect declarations
+paymentsHistory.vatInaccuraciesReturnReplacedChargeTitle = Inaccuracies penalty
+paymentsHistory.vatInaccuraciesReturnReplacedChargeDescription = this is because you have submitted inaccurate information for the period {0}
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -62,7 +62,10 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     VatOAInaccuracies2009.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString")),
     VatInaccuracyAssessmentsPenCharge.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString")),
     VatMpPre2009Charge.name -> (("Misdeclaration penalty", "because you have made an incorrect declaration")),
-    VatMpRepeatedPre2009Charge.name -> (("Misdeclaration repeat penalty", "because you have repeatedly made incorrect declarations"))
+    VatMpRepeatedPre2009Charge.name -> (("Misdeclaration repeat penalty", "because you have repeatedly made incorrect declarations")),
+    VatInaccuraciesReturnReplacedCharge.name -> ((
+      "Inaccuracies penalty",
+      s"this is because you have submitted inaccurate information for the period $datePeriodString"))
   )
 
   object Selectors {

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -65,7 +65,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     VatMpRepeatedPre2009Charge.name -> (("Misdeclaration repeat penalty", "because you have repeatedly made incorrect declarations")),
     VatInaccuraciesReturnReplacedCharge.name -> ((
       "Inaccuracies penalty",
-      s"this is because you have submitted inaccurate information for the period $datePeriodString"))
+      s"this is because you have submitted inaccurate information for the period $datePeriodString")),
+    VatWrongDoingPenaltyCharge.name -> (("Wrongdoing penalty", "because you charged VAT when you should not have done"))
   )
 
   object Selectors {
@@ -350,7 +351,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     "supplying with the following charge types" should {
       case class testModel(chargeType: ChargeType, expectedTitle: String, expectedDescription: String)
 
-      PaymentsHistoryChargeHelper.values.map { case historyChargeHelper =>
+      PaymentsHistoryChargeHelper.values.map { historyChargeHelper =>
         (PaymentsHistoryViewModel(
           historyYears,
           historyYears.head,
@@ -376,7 +377,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
         lazy val view = views.html.payments.paymentHistory(paymentHistoryModel)
         lazy implicit val document: Document = Jsoup.parse(view.body)
 
-        s"contain a ${chargeTypeTitle} that" should {
+        s"contain a $chargeTypeTitle that" should {
 
           "contain the correct amount in row 1" in {
             elementText(Selectors.amountPaidTableContent(1)) shouldBe "- £1,000"
@@ -481,43 +482,6 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
 
         "contain the correct date" in {
           elementText(Selectors.paymentDateTableContent(1)) shouldBe "1 Mar 2018"
-        }
-      }
-    }
-
-    "supplying with a Vat Wrong Doing Penalty Charge type" should {
-
-      val paymentsHistoryModel: PaymentsHistoryViewModel = PaymentsHistoryViewModel(
-        historyYears,
-        historyYears.head,
-        Seq(PaymentsHistoryModel(
-          chargeType = WrongDoingPenaltyCharge,
-          taxPeriodFrom = Some(LocalDate.parse("2018-10-09")),
-          taxPeriodTo = Some(LocalDate.parse("2018-11-10")),
-          amount = 510.00,
-          clearedDate = Some(LocalDate.parse("2018-11-11"))
-        ))
-      )
-
-      lazy val view = views.html.payments.paymentHistory(paymentsHistoryModel)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "contain a Vat Inaccuracies Return Replaced Charge type" should {
-
-        "contain the correct amount" in {
-          elementText(Selectors.amountPaidTableContent(1)) shouldBe "- £510"
-        }
-
-        "contain the correct title" in {
-          elementText(Selectors.descriptionTableChargeType(1)) shouldBe "Wrongdoing penalty"
-        }
-
-        "not contain a description" in {
-          elementText(Selectors.descriptionTableContent(1)) shouldBe "because you charged VAT when you should not have done"
-        }
-
-        "contain the correct date" in {
-          elementText(Selectors.paymentDateTableContent(1)) shouldBe "11 Nov 2018"
         }
       }
     }

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -61,7 +61,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     FtnEachPartner.name -> (("Failure to notify penalty", "because you did not tell us about all the partners and changes in your partnership")),
     VatOAInaccuracies2009.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString")),
     VatInaccuracyAssessmentsPenCharge.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString")),
-    VatMpPre2009Charge.name -> (("Misdeclaration penalty", "because you have made an incorrect declaration"))
+    VatMpPre2009Charge.name -> (("Misdeclaration penalty", "because you have made an incorrect declaration")),
+    VatMpRepeatedPre2009Charge.name -> (("Misdeclaration repeat penalty", "because you have repeatedly made incorrect declarations"))
   )
 
   object Selectors {

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -484,5 +484,42 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
         }
       }
     }
+
+    "supplying with a Vat Wrong Doing Penalty Charge type" should {
+
+      val paymentsHistoryModel: PaymentsHistoryViewModel = PaymentsHistoryViewModel(
+        historyYears,
+        historyYears.head,
+        Seq(PaymentsHistoryModel(
+          chargeType = WrongDoingPenaltyCharge,
+          taxPeriodFrom = Some(LocalDate.parse("2018-10-09")),
+          taxPeriodTo = Some(LocalDate.parse("2018-11-10")),
+          amount = 510.00,
+          clearedDate = Some(LocalDate.parse("2018-11-11"))
+        ))
+      )
+
+      lazy val view = views.html.payments.paymentHistory(paymentsHistoryModel)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "contain a Vat Inaccuracies Return Replaced Charge type" should {
+
+        "contain the correct amount" in {
+          elementText(Selectors.amountPaidTableContent(1)) shouldBe "- £510"
+        }
+
+        "contain the correct title" in {
+          elementText(Selectors.descriptionTableChargeType(1)) shouldBe "Wrongdoing penalty"
+        }
+
+        "not contain a description" in {
+          elementText(Selectors.descriptionTableContent(1)) shouldBe "because you charged VAT when you should not have done"
+        }
+
+        "contain the correct date" in {
+          elementText(Selectors.paymentDateTableContent(1)) shouldBe "11 Nov 2018"
+        }
+      }
+    }
   }
 }

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -59,7 +59,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     VatInaccuraciesInECSales.name -> (("Inaccuracies penalty", "because you have provided inaccurate information in your EC sales list")),
     VatFailureToSubmitECSales.name -> (("EC sales list penalty", "because you have not submitted an EC sales list or you have submitted it late")),
     FtnEachPartner.name -> (("Failure to notify penalty", "because you did not tell us about all the partners and changes in your partnership")),
-    VatOAInaccuracies2009.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString"))
+    VatOAInaccuracies2009.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString")),
+    VatInaccuracyAssessmentsPenCharge.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString"))
   )
 
   object Selectors {

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -60,7 +60,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     VatFailureToSubmitECSales.name -> (("EC sales list penalty", "because you have not submitted an EC sales list or you have submitted it late")),
     FtnEachPartner.name -> (("Failure to notify penalty", "because you did not tell us about all the partners and changes in your partnership")),
     VatOAInaccuracies2009.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString")),
-    VatInaccuracyAssessmentsPenCharge.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString"))
+    VatInaccuracyAssessmentsPenCharge.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString")),
+    VatMpPre2009Charge.name -> (("Misdeclaration penalty", "because you have made an incorrect declaration"))
   )
 
   object Selectors {

--- a/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
@@ -30,6 +30,13 @@ class PaymentsHistoryChargeHelperSpec extends UnitSpec {
           result shouldBe Some(paymentHistoryChargeType)
         }
       }
+
+      "return a Vat Inaccuracy Assessments Pen charge type" in {
+
+        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Inaccuracy Assessments pen")
+
+        result shouldBe Some(PaymentsHistoryChargeHelper.VatInaccuracyAssessmentsPenCharge)
+      }
     }
 
     "the lookup String is an invalid charge type" should {

--- a/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
@@ -61,6 +61,14 @@ class PaymentsHistoryChargeHelperSpec extends UnitSpec {
         result shouldBe Some(PaymentsHistoryChargeHelper.VatInaccuraciesReturnReplacedCharge)
 
       }
+
+      "return a Vat Wrong Doing Penalty Charge type" in {
+
+        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Wrong Doing Penalty")
+
+        result shouldBe Some(PaymentsHistoryChargeHelper.VatWrongDoingPenaltyCharge)
+
+      }
     }
 
     "the lookup String is an invalid charge type" should {

--- a/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
@@ -45,6 +45,14 @@ class PaymentsHistoryChargeHelperSpec extends UnitSpec {
         result shouldBe Some(PaymentsHistoryChargeHelper.VatMpPre2009Charge)
 
       }
+
+      "return a Vat Mp Repeated Pre 2009 Charge type" in {
+
+        val result = PaymentsHistoryChargeHelper.getChargeType("VAT MP (R) pre 2009")
+
+        result shouldBe Some(PaymentsHistoryChargeHelper.VatMpRepeatedPre2009Charge)
+
+      }
     }
 
     "the lookup String is an invalid charge type" should {

--- a/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
@@ -53,6 +53,14 @@ class PaymentsHistoryChargeHelperSpec extends UnitSpec {
         result shouldBe Some(PaymentsHistoryChargeHelper.VatMpRepeatedPre2009Charge)
 
       }
+
+      "return a Vat Inaccuracies Return Replaced Charge type" in {
+
+        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Inaccuracy rturn replaced")
+
+        result shouldBe Some(PaymentsHistoryChargeHelper.VatInaccuraciesReturnReplacedCharge)
+
+      }
     }
 
     "the lookup String is an invalid charge type" should {

--- a/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
@@ -30,45 +30,6 @@ class PaymentsHistoryChargeHelperSpec extends UnitSpec {
           result shouldBe Some(paymentHistoryChargeType)
         }
       }
-
-      "return a Vat Inaccuracy Assessments Pen charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Inaccuracy Assessments pen")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatInaccuracyAssessmentsPenCharge)
-      }
-
-      "return a Vat Mp Pre 2009 Charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT MP pre 2009")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatMpPre2009Charge)
-
-      }
-
-      "return a Vat Mp Repeated Pre 2009 Charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT MP (R) pre 2009")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatMpRepeatedPre2009Charge)
-
-      }
-
-      "return a Vat Inaccuracies Return Replaced Charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Inaccuracy rturn replaced")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatInaccuraciesReturnReplacedCharge)
-
-      }
-
-      "return a Vat Wrong Doing Penalty Charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Wrong Doing Penalty")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatWrongDoingPenaltyCharge)
-
-      }
     }
 
     "the lookup String is an invalid charge type" should {

--- a/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
@@ -37,6 +37,14 @@ class PaymentsHistoryChargeHelperSpec extends UnitSpec {
 
         result shouldBe Some(PaymentsHistoryChargeHelper.VatInaccuracyAssessmentsPenCharge)
       }
+
+      "return a Vat Mp Pre 2009 Charge type" in {
+
+        val result = PaymentsHistoryChargeHelper.getChargeType("VAT MP pre 2009")
+
+        result shouldBe Some(PaymentsHistoryChargeHelper.VatMpPre2009Charge)
+
+      }
     }
 
     "the lookup String is an invalid charge type" should {

--- a/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
@@ -572,7 +572,34 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
         elementText(Selectors.description) shouldBe "this is because you have submitted inaccurate information for" +
           " the period 12 Sep to 13 Oct 2018"
       }
+    }
 
+    "there is a Vat Wrong Doing Penalty Charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        WrongDoingPenaltyCharge,
+        Some(LocalDate.parse("2018-09-12")),
+        Some(LocalDate.parse("2018-10-13")),
+        390.00,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = views.html.templates.paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Wrongdoing penalty"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "because you charged VAT when you should not have done"
+      }
     }
   }
 }

--- a/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
@@ -321,6 +321,8 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
         Some(LocalDate.parse("2018-03-24")),
         1500.00,
         Some(LocalDate.parse("2018-04-18"))
+
+
       )
 
       lazy val template = views.html.templates.paymentsHistoryCharge(model)
@@ -454,6 +456,34 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
 
       "display the correct description" in {
         elementText(Selectors.description) shouldBe "interest paid because of an error by HMRC"
+      }
+    }
+
+    "there is a Vat Inaccuracy Assessments Pen charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        InaccuraciesAssessmentsPenCharge,
+        Some(LocalDate.parse("2018-09-10")),
+        Some(LocalDate.parse("2018-10-11")),
+        1000.00,
+        Some(LocalDate.parse("2018-10-15"))
+      )
+
+      lazy val template = views.html.templates.paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Inaccuracies penalty"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "because you submitted an inaccurate document for the period 10 Sep to 11 Oct 2018"
       }
     }
   }

--- a/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
@@ -486,5 +486,34 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
         elementText(Selectors.description) shouldBe "because you submitted an inaccurate document for the period 10 Sep to 11 Oct 2018"
       }
     }
+
+    "there is a Vat Mp Pre 2009 Charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        MpPre2009Charge,
+        Some(LocalDate.parse("2018-09-10")),
+        Some(LocalDate.parse("2018-10-11")),
+        1100.00,
+        Some(LocalDate.parse("2018-10-15"))
+      )
+
+      lazy val template = views.html.templates.paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Misdeclaration penalty"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "because you have made an incorrect declaration"
+      }
+
+    }
   }
 }

--- a/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
@@ -515,5 +515,34 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
       }
 
     }
+
+    "there is a Vat Mp Repeated Pre 2009 Charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        MpRepeatedPre2009Charge,
+        Some(LocalDate.parse("2018-09-10")),
+        Some(LocalDate.parse("2018-10-11")),
+        1100.00,
+        Some(LocalDate.parse("2018-10-15"))
+      )
+
+      lazy val template = views.html.templates.paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Misdeclaration repeat penalty"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "because you have repeatedly made incorrect declarations"
+      }
+
+    }
   }
 }

--- a/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeTemplateSpec.scala
@@ -544,5 +544,35 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
       }
 
     }
+
+    "there is a Vat Inaccuracies Return Replaced Charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        InaccuraciesReturnReplacedCharge,
+        Some(LocalDate.parse("2018-09-12")),
+        Some(LocalDate.parse("2018-10-13")),
+        390.00,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = views.html.templates.paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Inaccuracies penalty"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "this is because you have submitted inaccurate information for" +
+          " the period 12 Sep to 13 Oct 2018"
+      }
+
+    }
   }
 }


### PR DESCRIPTION
Added several charge types for the payments history page

- VAT inaccuracry assessment pen charge 
- VAT Misdeclaration penalty pre 2009 charge
- VAT MP Repeated Pre 2009 charge 
- VAT Inaccuracy Return Replaced charge
- VAT Wrongdoing penalty