### PR TITLE
Btat 3980 - Adding ChargeTypes to Payment History page

### DIFF
--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -168,6 +168,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.vatFailureToSubmitECSalesDescription")
   )
 
+  object FtnEachPartner extends PaymentsHistoryChargeHelper(
+    FtnEachPartnerCharge.value,
+    "paymentsHistory.ftnEachPartnerTitle",
+    Some("paymentsHistory.ftnEachPartnerDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -193,7 +199,8 @@ object PaymentsHistoryChargeHelper {
     VatStatutoryInterestCharge,
     CivilEvasionPenalty,
     VatInaccuraciesInECSales,
-    VatFailureToSubmitECSales
+    VatFailureToSubmitECSales,
+    FtnEachPartner
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -162,6 +162,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.vatInaccuraciesInECSalesDescription")
   )
 
+  object VatFailureToSubmitECSales extends PaymentsHistoryChargeHelper(
+    VatFailureToSubmitECSalesCharge.value,
+    "paymentsHistory.vatFailureToSubmitECSalesTitle",
+    Some("paymentsHistory.vatFailureToSubmitECSalesDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -186,7 +192,8 @@ object PaymentsHistoryChargeHelper {
     VatAAFurtherInterest,
     VatStatutoryInterestCharge,
     CivilEvasionPenalty,
-    VatInaccuraciesInECSales
+    VatInaccuraciesInECSales,
+    VatFailureToSubmitECSales
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -156,6 +156,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.civilEvasionPenaltyDescription")
   )
 
+  object VatInaccuraciesInECSales extends PaymentsHistoryChargeHelper(
+    VatInaccuraciesInECSalesCharge.value,
+    "paymentsHistory.vatInaccuraciesInECSalesTitle",
+    Some("paymentsHistory.vatInaccuraciesInECSalesDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -179,7 +185,8 @@ object PaymentsHistoryChargeHelper {
     VatAADefaultInterest,
     VatAAFurtherInterest,
     VatStatutoryInterestCharge,
-    CivilEvasionPenalty
+    CivilEvasionPenalty,
+    VatInaccuraciesInECSales
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -174,6 +174,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.ftnEachPartnerDescription")
   )
 
+  object VatOAInaccuracies2009 extends PaymentsHistoryChargeHelper(
+    VatOAInaccuraciesFrom2009.value,
+    "paymentsHistory.vatOAInaccuraciesFrom2009Title",
+    Some("paymentsHistory.vatOAInaccuraciesFrom2009Description")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -200,7 +206,8 @@ object PaymentsHistoryChargeHelper {
     CivilEvasionPenalty,
     VatInaccuraciesInECSales,
     VatFailureToSubmitECSales,
-    FtnEachPartner
+    FtnEachPartner,
+    VatOAInaccuracies2009
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/app/views/templates/PaymentsHistoryChargeHelper.scala
+++ b/app/views/templates/PaymentsHistoryChargeHelper.scala
@@ -150,6 +150,12 @@ object PaymentsHistoryChargeHelper {
     Some("paymentsHistory.vatEcNoticeFurtherInterestDescription")
   )
 
+  object CivilEvasionPenalty extends PaymentsHistoryChargeHelper(
+    CivilEvasionPenaltyCharge.value,
+    "paymentsHistory.civilEvasionPenaltyTitle",
+    Some("paymentsHistory.civilEvasionPenaltyDescription")
+  )
+
   val values = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
@@ -172,7 +178,8 @@ object PaymentsHistoryChargeHelper {
     VatAdditionalAssessment,
     VatAADefaultInterest,
     VatAAFurtherInterest,
-    VatStatutoryInterestCharge
+    VatStatutoryInterestCharge,
+    CivilEvasionPenalty
   )
 
   def getChargeType(lookupName: String): Option[PaymentsHistoryChargeHelper] = {

--- a/conf/messages
+++ b/conf/messages
@@ -196,6 +196,8 @@ paymentsHistory.vatInaccuraciesInECSalesTitle = Inaccuracies penalty
 paymentsHistory.vatInaccuraciesInECSalesDescription = because you have provided inaccurate information in your EC sales list
 paymentsHistory.vatFailureToSubmitECSalesTitle = EC sales list penalty
 paymentsHistory.vatFailureToSubmitECSalesDescription = because you have not submitted an EC sales list or you have submitted it late
+paymentsHistory.ftnEachPartnerTitle = Failure to notify penalty
+paymentsHistory.ftnEachPartnerDescription = because you did not tell us about all the partners and changes in your partnership
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/conf/messages
+++ b/conf/messages
@@ -194,6 +194,8 @@ paymentsHistory.civilEvasionPenaltyTitle = VAT civil evasion penalty
 paymentsHistory.civilEvasionPenaltyDescription = because we have identified irregularities involving dishonesty
 paymentsHistory.vatInaccuraciesInECSalesTitle = Inaccuracies penalty
 paymentsHistory.vatInaccuraciesInECSalesDescription = because you have provided inaccurate information in your EC sales list
+paymentsHistory.vatFailureToSubmitECSalesTitle = EC sales list penalty
+paymentsHistory.vatFailureToSubmitECSalesDescription = because you have not submitted an EC sales list or you have submitted it late
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/conf/messages
+++ b/conf/messages
@@ -198,6 +198,8 @@ paymentsHistory.vatFailureToSubmitECSalesTitle = EC sales list penalty
 paymentsHistory.vatFailureToSubmitECSalesDescription = because you have not submitted an EC sales list or you have submitted it late
 paymentsHistory.ftnEachPartnerTitle = Failure to notify penalty
 paymentsHistory.ftnEachPartnerDescription = because you did not tell us about all the partners and changes in your partnership
+paymentsHistory.vatOAInaccuraciesFrom2009Title = Inaccuracies penalty
+paymentsHistory.vatOAInaccuraciesFrom2009Description = because you submitted an inaccurate document for the period {0}
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/conf/messages
+++ b/conf/messages
@@ -192,6 +192,8 @@ paymentsHistory.vatEcNoticeFurtherInterestTitle = Error correction further inter
 paymentsHistory.vatEcNoticeFurtherInterestDescription = further interest charged on assessed amount
 paymentsHistory.civilEvasionPenaltyTitle = VAT civil evasion penalty
 paymentsHistory.civilEvasionPenaltyDescription = because we have identified irregularities involving dishonesty
+paymentsHistory.vatInaccuraciesInECSalesTitle = Inaccuracies penalty
+paymentsHistory.vatInaccuraciesInECSalesDescription = because you have provided inaccurate information in your EC sales list
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/conf/messages
+++ b/conf/messages
@@ -188,10 +188,10 @@ paymentsHistory.VatStatutoryInterestTitle = Statutory interest
 paymentsHistory.VatStatutoryInterestDescription = interest paid because of an error by HMRC
 paymentsHistory.vatSecurityDepositRequestTitle = Security deposit requirement
 paymentsHistory.vatSecurityDepositRequestDescription = because you have not paid VAT in your current or previous business(es)
-paymentsHistory.vatErrorCorrectionNoticeDefaultInterestTitle = Error correction default interest
-paymentsHistory.vatErrorCorrectionNoticeDefaultInterestDescription = interest charged on assessed amount
 paymentsHistory.vatEcNoticeFurtherInterestTitle = Error correction further interest
 paymentsHistory.vatEcNoticeFurtherInterestDescription = further interest charged on assessed amount
+paymentsHistory.civilEvasionPenaltyTitle = VAT civil evasion penalty
+paymentsHistory.civilEvasionPenaltyDescription = because we have identified irregularities involving dishonesty
 
 notFound.title = Page not found
 notFound.heading = This page cannot be found

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -56,7 +56,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     VatSecurityDepositRequest.name -> (("Security deposit requirement", "because you have not paid VAT in your current or previous business(es)")),
     VatEcNoticeFurtherInterest.name -> (("Error correction further interest", "further interest charged on assessed amount")),
     CivilEvasionPenalty.name -> (("VAT civil evasion penalty", "because we have identified irregularities involving dishonesty")),
-    VatInaccuraciesInECSales.name -> (("Inaccuracies penalty", "because you have provided inaccurate information in your EC sales list"))
+    VatInaccuraciesInECSales.name -> (("Inaccuracies penalty", "because you have provided inaccurate information in your EC sales list")),
+    VatFailureToSubmitECSales.name -> (("EC sales list penalty", "because you have not submitted an EC sales list or you have submitted it late"))
   )
 
   object Selectors {

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -55,7 +55,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     VatStatutoryInterestCharge.name -> (("Statutory interest", "interest paid because of an error by HMRC")),
     VatSecurityDepositRequest.name -> (("Security deposit requirement", "because you have not paid VAT in your current or previous business(es)")),
     VatEcNoticeFurtherInterest.name -> (("Error correction further interest", "further interest charged on assessed amount")),
-    CivilEvasionPenalty.name -> (("VAT civil evasion penalty", "because we have identified irregularities involving dishonesty"))
+    CivilEvasionPenalty.name -> (("VAT civil evasion penalty", "because we have identified irregularities involving dishonesty")),
+    VatInaccuraciesInECSales.name -> (("Inaccuracies penalty", "because you have provided inaccurate information in your EC sales list"))
   )
 
   object Selectors {

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -57,7 +57,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     VatEcNoticeFurtherInterest.name -> (("Error correction further interest", "further interest charged on assessed amount")),
     CivilEvasionPenalty.name -> (("VAT civil evasion penalty", "because we have identified irregularities involving dishonesty")),
     VatInaccuraciesInECSales.name -> (("Inaccuracies penalty", "because you have provided inaccurate information in your EC sales list")),
-    VatFailureToSubmitECSales.name -> (("EC sales list penalty", "because you have not submitted an EC sales list or you have submitted it late"))
+    VatFailureToSubmitECSales.name -> (("EC sales list penalty", "because you have not submitted an EC sales list or you have submitted it late")),
+    FtnEachPartner.name -> (("Failure to notify penalty", "because you did not tell us about all the partners and changes in your partnership"))
   )
 
   object Selectors {

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -54,7 +54,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
       s"further interest charged on additional tax assessed for the period $datePeriodString")),
     VatStatutoryInterestCharge.name -> (("Statutory interest", "interest paid because of an error by HMRC")),
     VatSecurityDepositRequest.name -> (("Security deposit requirement", "because you have not paid VAT in your current or previous business(es)")),
-    VatEcNoticeFurtherInterest.name -> (("Error correction further interest", "further interest charged on assessed amount"))
+    VatEcNoticeFurtherInterest.name -> (("Error correction further interest", "further interest charged on assessed amount")),
+    CivilEvasionPenalty.name -> (("VAT civil evasion penalty", "because we have identified irregularities involving dishonesty"))
   )
 
   object Selectors {

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -58,7 +58,8 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     CivilEvasionPenalty.name -> (("VAT civil evasion penalty", "because we have identified irregularities involving dishonesty")),
     VatInaccuraciesInECSales.name -> (("Inaccuracies penalty", "because you have provided inaccurate information in your EC sales list")),
     VatFailureToSubmitECSales.name -> (("EC sales list penalty", "because you have not submitted an EC sales list or you have submitted it late")),
-    FtnEachPartner.name -> (("Failure to notify penalty", "because you did not tell us about all the partners and changes in your partnership"))
+    FtnEachPartner.name -> (("Failure to notify penalty", "because you did not tell us about all the partners and changes in your partnership")),
+    VatOAInaccuracies2009.name -> (("Inaccuracies penalty", s"because you submitted an inaccurate document for the period $datePeriodString"))
   )
 
   object Selectors {

--- a/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
+++ b/test/views/templates/PaymentsHistoryChargeHelperSpec.scala
@@ -23,79 +23,12 @@ class PaymentsHistoryChargeHelperSpec extends UnitSpec {
 
     "the lookup string is a valid charge type" should {
 
-      "return the charge type associated with the lookup string" in {
+      PaymentsHistoryChargeHelper.values.foreach { paymentHistoryChargeType =>
+        lazy val result = PaymentsHistoryChargeHelper.getChargeType(paymentHistoryChargeType.name)
 
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Return Debit Charge")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatReturnDebitCharge)
-
-      }
-
-      "return a central assessment charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Central Assessment")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatCentralAssessment)
-
-      }
-
-      "return a default surcharge charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Default Surcharge")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatDefaultSurcharge)
-
-      }
-
-      "return a VAT OA default interest charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT OA Default Interest")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.OADefaultInterest)
-
-      }
-
-      "return a VAT Officers Assessment Further Interest charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT OA Further Interest")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatOfficersAssessmentFurtherInterest)
-      }
-
-      "return a VAT Additional Assessment charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Additional Assessment")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatAdditionalAssessment)
-      }
-
-      "return a VAT AA Default Interest charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT AA Default Interest")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatAADefaultInterest)
-      }
-
-      "return a VAT AA Further Interest charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT AA Further Interest")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatAAFurtherInterest)
-      }
-
-      "return a VAT Statutory Interest charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Statutory Interest")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatStatutoryInterestCharge)
-      }
-
-      "return a VAT Security Deposit Request charge type" in {
-
-        val result = PaymentsHistoryChargeHelper.getChargeType("VAT Security Deposit Request")
-
-        result shouldBe Some(PaymentsHistoryChargeHelper.VatSecurityDepositRequest)
-
+        s"return the charge type associated with ${paymentHistoryChargeType.name}" in {
+          result shouldBe Some(paymentHistoryChargeType)
+        }
       }
     }
 


### PR DESCRIPTION
Added:
- CivilEvasionPenalty
- Inaccuracy Pentalty
- Failure to Submit ECSales
- FtnEachpartner
- InaccuraciesFrom2009