### PR TITLE
BTAT-5476 Fixed {0} issue for charge descriptions that require a date

### DIFF
--- a/app/views/templates/payments/WhatYouOweChargeHelper.scala
+++ b/app/views/templates/payments/WhatYouOweChargeHelper.scala
@@ -18,6 +18,7 @@ package views.templates.payments
 
 import javax.inject.Inject
 import models.payments._
+import play.api.Logger
 import play.api.i18n.Messages
 import views.templates.formatters.dates.DisplayDateRangeHelper.displayDateRange
 
@@ -32,7 +33,14 @@ class WhatYouOweChargeHelper @Inject()(payment: OpenPaymentsModel,
       case (payment: OpenPaymentsModelWithPeriod, Some(desc)) =>
         Some(PaymentMessageHelper.getFullDescription(desc, Some(payment.start), Some(payment.end), useShortDayFormat = false))
       case (_: OpenPaymentsModelNoPeriod, Some(desc)) =>
-        Some(PaymentMessageHelper.getFullDescription(desc, None, None))
+        val descriptionText = PaymentMessageHelper.getFullDescription(desc, None, None)
+        if (descriptionText.contains("{0}")) {
+          Logger.warn("[WhatYouOweChargeHelper][description] - " +
+            s"No date period was found for ${payment.chargeType}. Omitting description.")
+          None
+        } else {
+          Some(descriptionText)
+        }
       case (_, _) => None
     }
   }

--- a/app/views/templates/payments/whatYouOweChargeRow.scala.html
+++ b/app/views/templates/payments/whatYouOweChargeRow.scala.html
@@ -22,12 +22,13 @@
 @(payment: OpenPaymentsModel, count: Int, hasDirectDebit: Option[Boolean])(implicit messages: Messages, appConfig: config.AppConfig, lang: Lang)
 
 @chargeDetails = @{new WhatYouOweChargeHelper(payment, hasDirectDebit, messages)}
+@defining(chargeDetails.description()) { chargeDescription =>
 
 <tr id="payment-@{count + 1}">
     <td scope="row">
 
         <h2 class="bold heading-small">@chargeDetails.title</h2>
-        @chargeDetails.description.map { description => <div>@description</div> }
+        @chargeDescription.map { description => <div>@description</div> }
 
         <div data-due="@(payment.due.toString)" class="form-hint">
             @messages("openPayments.dueBy") @displayDate(payment.due)
@@ -50,7 +51,7 @@
                         <span class="visuallyhidden">
                             @displayMoney(payment.amount)
                             @chargeDetails.overdueContext
-                            @chargeDetails.description.getOrElse("")
+                            @chargeDescription.getOrElse("")
                         </span>
                     </a>
                 }
@@ -70,3 +71,4 @@
         }
     </td>
 </tr>
+}

--- a/test/views/templates/payments/WhatYouOweChargeHelperSpec.scala
+++ b/test/views/templates/payments/WhatYouOweChargeHelperSpec.scala
@@ -42,35 +42,35 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
 
   "WhatYouOweChargeHelper .description" when {
 
-    "payment has a to and from date" should {
+    "the charge has a to and from date" should {
 
       val helper = new WhatYouOweChargeHelper(paymentModel(ReturnDebitCharge), Some(false), messages)
 
-      "return the description of the payment" in {
+      "return the description of the charge" in {
         helper.description shouldBe Some("for the period 1 January to 2 February 2018")
       }
     }
 
-    "payment should have a no to and from date to form the description, but doesn't" should {
+    "the charge should have a to and from date to form the description, but they are not retrieved" should {
 
       val model = paymentModelNoPeriod(ReturnDebitCharge)
       val helper = new WhatYouOweChargeHelper(model, Some(false), messages)
 
-      "omit the description of the payment" in {
+      "omit the description of the charge" in {
         helper.description shouldBe None
       }
     }
 
-    "payment has a no to and from date" should {
+    "the charge does not have to and from date" should {
 
       val helper = new WhatYouOweChargeHelper(paymentModel(OADefaultInterestCharge), Some(false), messages)
 
-      "return the description of the payment" in {
+      "return the description of the charge" in {
         helper.description shouldBe Some("interest charged on the officer's assessment")
       }
     }
 
-    "payment has no description" should {
+    "the charge has no description" should {
 
       val helper = new WhatYouOweChargeHelper(paymentModel(MiscPenaltyCharge), Some(false), messages)
 
@@ -191,7 +191,7 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
 
   "WhatYouOweChargeHelper .viewReturnContext" when {
 
-    "payment has a to and from period" when {
+    "the charge has a to and from period" when {
 
       "charge type is Return Debit Charge" should {
 
@@ -221,7 +221,7 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
       }
     }
 
-    "payment is has no to or from period" should {
+    "the charge has no to or from period" should {
 
       val helper = new WhatYouOweChargeHelper(paymentModelNoPeriod(MpRepeatedPre2009Charge), Some(true), messages)
 
@@ -233,7 +233,7 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
 
   "WhatYouOweChargeHelper .viewReturnGAEvent" when {
 
-    "payment has a to and from period" should {
+    "the charge has a to and from period" should {
 
       val helper = new WhatYouOweChargeHelper(paymentModel(OAFurtherInterestCharge), Some(true), messages)
 
@@ -242,7 +242,7 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
       }
     }
 
-    "payment has no to and from period" should {
+    "the charge has no to and from period" should {
 
       val helper = new WhatYouOweChargeHelper(paymentModelNoPeriod(MpRepeatedPre2009Charge), Some(true), messages)
 

--- a/test/views/templates/payments/WhatYouOweChargeHelperSpec.scala
+++ b/test/views/templates/payments/WhatYouOweChargeHelperSpec.scala
@@ -33,6 +33,13 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
     overdue
   )
 
+  def paymentModelNoPeriod(chargeType: ChargeType): OpenPaymentsModel = OpenPaymentsModelNoPeriod(
+    chargeType,
+    BigDecimal(100.00),
+    LocalDate.parse("2018-03-03"),
+    "18AA"
+  )
+
   "WhatYouOweChargeHelper .description" when {
 
     "payment has a to and from date" should {
@@ -41,6 +48,16 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
 
       "return the description of the payment" in {
         helper.description shouldBe Some("for the period 1 January to 2 February 2018")
+      }
+    }
+
+    "payment should have a no to and from date to form the description, but doesn't" should {
+
+      val model = paymentModelNoPeriod(ReturnDebitCharge)
+      val helper = new WhatYouOweChargeHelper(model, Some(false), messages)
+
+      "omit the description of the payment" in {
+        helper.description shouldBe None
       }
     }
 
@@ -206,14 +223,7 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
 
     "payment is has no to or from period" should {
 
-      val model = OpenPaymentsModelNoPeriod(
-        MpRepeatedPre2009Charge,
-        BigDecimal(100.00),
-        LocalDate.parse("2018-03-03"),
-        "18AA"
-      )
-
-      val helper = new WhatYouOweChargeHelper(model, Some(true), messages)
+      val helper = new WhatYouOweChargeHelper(paymentModelNoPeriod(MpRepeatedPre2009Charge), Some(true), messages)
 
       "return empty string" in {
         helper.viewReturnContext shouldBe ""
@@ -234,14 +244,7 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
 
     "payment has no to and from period" should {
 
-      val model = OpenPaymentsModelNoPeriod(
-        MpRepeatedPre2009Charge,
-        BigDecimal(100.00),
-        LocalDate.parse("2018-03-03"),
-        "18AA"
-      )
-
-      val helper = new WhatYouOweChargeHelper(model, Some(true), messages)
+      val helper = new WhatYouOweChargeHelper(paymentModelNoPeriod(MpRepeatedPre2009Charge), Some(true), messages)
 
       "return 'returns:view-return:open-payments'" in {
         helper.viewReturnGAEvent shouldBe "returns:view-return:open-payments"


### PR DESCRIPTION
Some of the charge types require a date period (from - to) for their charge type descriptions. Currently if we don't receive period dates from the API, these descriptions render with a literal {0}. This fix logs the error and hides the description in those scenarios.