### PR TITLE
BTAT-6135 Updated BTA nav link partial config

### DIFF
--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -44,7 +44,8 @@ object ConfigKeys {
   val submitReturnFeatures: String = "features.submitReturnFeatures.enabled"
   val agentAccessFeature: String = "features.agentAccess.enabled"
 
-  val businessTaxAccountBase: String = "business-tax-account.host"
+  val businessTaxAccountBase: String = "business-tax-account"
+  val businessTaxAccountHost: String = "business-tax-account.host"
   val businessTaxAccountUrl: String = "business-tax-account.homeUrl"
   val businessTaxAccountMessagesUrl: String = "business-tax-account.messagesUrl"
   val businessTaxAccountManageAccountUrl: String = "business-tax-account.manageAccountUrl"

--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -53,6 +53,7 @@ trait AppConfig extends ServicesConfig {
   val vatSubmittedReturnsUrl: String
   val vatReturnDeadlinesUrl: String
   def vatReturnUrl(periodKey: String): String
+  val btaBaseUrl: String
   val btaHomeUrl: String
   val btaMessagesUrl: String
   val btaManageAccountUrl: String
@@ -144,8 +145,8 @@ class FrontendAppConfig @Inject()(val runModeConfiguration: Configuration, val e
 
   private lazy val helpAndContactFrontendUrl: String = getString(Keys.helpAndContactFrontendBase)
 
-  private lazy val btaBaseUrl: String = getString(Keys.businessTaxAccountBase)
-  override lazy val btaHomeUrl: String = btaBaseUrl + getString(Keys.businessTaxAccountUrl)
+  override lazy val btaBaseUrl: String = baseUrl(Keys.businessTaxAccountBase)
+  override lazy val btaHomeUrl: String = getString(Keys.businessTaxAccountHost) + getString(Keys.businessTaxAccountUrl)
   override lazy val btaMessagesUrl: String = btaHomeUrl + getString(Keys.businessTaxAccountMessagesUrl)
   override lazy val btaManageAccountUrl: String = btaHomeUrl + getString(Keys.businessTaxAccountManageAccountUrl)
   override lazy val btaHelpAndContactUrl: String = helpAndContactFrontendUrl + getString(Keys.helpAndContactHelpUrl)

--- a/app/connectors/ServiceInfoPartialConnector.scala
+++ b/app/connectors/ServiceInfoPartialConnector.scala
@@ -35,7 +35,7 @@ class ServiceInfoPartialConnector @Inject()(val http: HttpClient,
                                             val config: AppConfig) extends HtmlPartialHttpReads with I18nSupport {
   import hcForPartials._
 
-  lazy val btaUrl: String = config.btaHomeUrl + "/partial/service-info"
+  lazy val btaUrl: String = config.btaBaseUrl + "/business-account/partial/service-info"
 
   def getServiceInfoPartial()(implicit request: Request[_], executionContext: ExecutionContext): Future[Html] =
     http.GET[HtmlPartial](btaUrl) recover connectionExceptionsAsHtmlPartialFailure map {

--- a/app/views/certificate/vatCertificate.scala.html
+++ b/app/views/certificate/vatCertificate.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@(serviceInfoContent: Html)(implicit messages: Messages, appConfig: config.AppConfig, request: Request[_], user: User)
+@(serviceInfoContent: Html = HtmlFormat.empty)(implicit messages: Messages, appConfig: config.AppConfig, request: Request[_], user: User)
 
 @views.html.main_template(
   messages("vatCertificate.title"),

--- a/app/views/payments/noPayments.scala.html
+++ b/app/views/payments/noPayments.scala.html
@@ -16,7 +16,7 @@
 
 @import views.html.templates.formatters.breadcrumbs._
 
-@(user: models.User, hasDirectDebit: Option[Boolean], serviceInfoContent: Html)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(user: models.User, hasDirectDebit: Option[Boolean], serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
   @views.html.main_template(
     title = messages("openPayments.title"),

--- a/app/views/payments/openPayments.scala.html
+++ b/app/views/payments/openPayments.scala.html
@@ -20,7 +20,7 @@
 @import views.html.templates.expandingHelpSection
 @import views.html.templates.formatters.breadcrumbs._
 
-@(user: User, model: OpenPaymentsViewModel, serviceInfoContent: Html)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, lang: Lang)
+@(user: User, model: OpenPaymentsViewModel, serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, lang: Lang)
 
 @hiddenHelpTextContent = {
   <p>@messages("openPayments.incorrect")

--- a/app/views/payments/paymentHistory.scala.html
+++ b/app/views/payments/paymentHistory.scala.html
@@ -21,7 +21,7 @@
 @import models.viewModels.PaymentsHistoryViewModel
 @import java.time.LocalDate
 
-@(model: PaymentsHistoryViewModel, serviceInfoContent: Html)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, lang: Lang, user: User)
+@(model: PaymentsHistoryViewModel, serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, lang: Lang, user: User)
 
 @views.html.main_template(
   title = messages("paymentsHistory.title"),

--- a/app/views/vatDetails/details.scala.html
+++ b/app/views/vatDetails/details.scala.html
@@ -19,14 +19,14 @@
 @import views.html.templates.formatters.breadcrumbs._
 @import views.html.templates.formatters.links._
 
-@(detailsViewModel: VatDetailsViewModel, serviceInfoContent: Html)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, user: User, lang: Lang)
+@(detailsViewModel: VatDetailsViewModel, serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, user: User, lang: Lang)
 
 @views.html.main_template(
     title = messages("vatDetails.title"),
     appConfig = appConfig,
     serviceInfoContent = serviceInfoContent,
-    user = Some(user)) {
-
+    user = Some(user)
+) {
 
     @navigationBreadcrumb(
         links = Map(appConfig.btaHomeUrl -> messages("breadcrumbs.bta")),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,6 +64,10 @@ microservice {
       host = localhost
       port = 8500
     }
+    business-tax-account {
+      host = localhost
+      port = 9020
+    }
     financial-transactions {
       host = localhost
       port = 9085

--- a/test/connectors/ServiceInfoPartialConnectorSpec.scala
+++ b/test/connectors/ServiceInfoPartialConnectorSpec.scala
@@ -49,7 +49,7 @@ class ServiceInfoPartialConnectorSpec extends ControllerBaseSpec {
 
   "ServiceInfoPartialConnector" should {
     "generate the correct url" in new Test {
-      connector.btaUrl shouldBe "bta-url/partial/service-info"
+      connector.btaUrl shouldBe "/business-account/partial/service-info"
     }
   }
 

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -48,11 +48,11 @@ class MockAppConfig(val runModeConfiguration: Configuration, val mode: Mode = Mo
   override def vatReturnUrl(periodKey: String): String = s"/submitted/${URLEncoder.encode(periodKey, "UTF-8")}"
   override val vatObligationsBaseUrl: String = "/obligations-api"
   override val financialDataBaseUrl = ""
+  override val btaBaseUrl: String = ""
   override val btaHomeUrl: String = "bta-url"
   override val btaHelpAndContactUrl: String = "bta-help-and-contact-url"
   override val btaManageAccountUrl: String = "bta-manage-account-url"
   override val btaMessagesUrl: String = "bta-messages-url"
-
   override val paymentsServiceUrl: String = "payments-url"
   override val setupPaymentsJourneyPath: String = "/payment/start"
   override val directDebitServiceUrl: String = "direct-debits-url"

--- a/test/views/certificate/VatCertificateViewSpec.scala
+++ b/test/views/certificate/VatCertificateViewSpec.scala
@@ -18,7 +18,6 @@ package views.certificate
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.twirl.api.Html
 import views.ViewBaseSpec
 
 class VatCertificateViewSpec extends ViewBaseSpec {
@@ -29,7 +28,7 @@ class VatCertificateViewSpec extends ViewBaseSpec {
 
   "The VAT Certificate page" should {
 
-    lazy val view = views.html.certificate.vatCertificate( Html(""))
+    lazy val view = views.html.certificate.vatCertificate()
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     "have the correct title" in {

--- a/test/views/payments/NoPaymentsViewSpec.scala
+++ b/test/views/payments/NoPaymentsViewSpec.scala
@@ -19,7 +19,6 @@ package views.payments
 import models.User
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.twirl.api.Html
 import views.ViewBaseSpec
 
 class NoPaymentsViewSpec extends ViewBaseSpec {
@@ -46,7 +45,7 @@ class NoPaymentsViewSpec extends ViewBaseSpec {
 
     "the user has a direct debit" should {
 
-      lazy val view = views.html.payments.noPayments(user, hasDirectDebit = Some(true), Html(""))
+      lazy val view = views.html.payments.noPayments(user, hasDirectDebit = Some(true))
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "have the correct document title" in {
@@ -117,7 +116,7 @@ class NoPaymentsViewSpec extends ViewBaseSpec {
 
     "the user does not have a direct debit" should {
 
-      lazy val view = views.html.payments.noPayments(user, hasDirectDebit = Some(false),  Html(""))
+      lazy val view = views.html.payments.noPayments(user, hasDirectDebit = Some(false))
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "have the correct message regarding setting up a direct debit" in {
@@ -140,7 +139,7 @@ class NoPaymentsViewSpec extends ViewBaseSpec {
 
     "the call to the direct debit service fails" should {
 
-      lazy val view = views.html.payments.noPayments(user, hasDirectDebit = None,  Html(""))
+      lazy val view = views.html.payments.noPayments(user, hasDirectDebit = None)
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "not display a direct debit message" in {

--- a/test/views/payments/OpenPaymentsViewSpec.scala
+++ b/test/views/payments/OpenPaymentsViewSpec.scala
@@ -24,7 +24,6 @@ import models.payments._
 import models.viewModels.OpenPaymentsViewModel
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.twirl.api.Html
 import views.ViewBaseSpec
 import views.templates.payments.PaymentMessageHelper
 
@@ -95,7 +94,7 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
 
     val hasDirectDebit = Some(true)
     val viewModel = OpenPaymentsViewModel(payments, hasDirectDebit)
-    lazy val view = views.html.payments.openPayments(user, viewModel, Html(""))
+    lazy val view = views.html.payments.openPayments(user, viewModel)
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     "have the correct document title" in {
@@ -237,7 +236,7 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
 
     val hasDirectDebit = Some(false)
     val viewModel = OpenPaymentsViewModel(payments, hasDirectDebit)
-    lazy val view = views.html.payments.openPayments(user, viewModel, Html(""))
+    lazy val view = views.html.payments.openPayments(user, viewModel)
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     "render the Pay now text" in {
@@ -272,7 +271,7 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
 
     val hasDirectDebit = None
     val viewModel = OpenPaymentsViewModel(payments, hasDirectDebit)
-    lazy val view = views.html.payments.openPayments(user, viewModel, Html(""))
+    lazy val view = views.html.payments.openPayments(user, viewModel)
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     "render the correct text for the processing time" in {
@@ -315,7 +314,7 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
       )
     }.foreach { case (openPaymentsViewModel, chargeTypeTitle, expectedTitle, expectedDescription) =>
 
-      lazy val view = views.html.payments.openPayments(user, openPaymentsViewModel, Html(""))
+      lazy val view = views.html.payments.openPayments(user, openPaymentsViewModel)
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       s"contain a $chargeTypeTitle which" should {

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -85,7 +85,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
 
         "the user does not have the VATDEC enrolment" should {
 
-          lazy val view: Html = views.html.payments.paymentHistory(model, Html(""))
+          lazy val view: Html = views.html.payments.paymentHistory(model)
           lazy implicit val document: Document = Jsoup.parse(view.body)
 
           "have the correct document title" in {
@@ -156,7 +156,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
           "they migrated to MTD less than 15 months ago" should {
 
             lazy val view: Html = views.html.payments.paymentHistory(
-              model.copy(tabOne = Some(currentYear), previousPaymentsTab = true), Html("")
+              model.copy(tabOne = Some(currentYear), previousPaymentsTab = true)
             )(request, messages, mockConfig, messages.lang, vatDecUser)
             lazy implicit val document: Document = Jsoup.parse(view.body)
 
@@ -180,7 +180,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
           "they migrated to MTD 15 months ago or longer" should {
 
             lazy val view: Html =
-              views.html.payments.paymentHistory(model, Html(""))(request, messages, mockConfig, messages.lang, vatDecUser)
+              views.html.payments.paymentHistory(model)(request, messages, mockConfig, messages.lang, vatDecUser)
             lazy implicit val document: Document = Jsoup.parse(view.body)
 
             "not display a current year tab" in {
@@ -206,7 +206,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
 
         "the user does not have the VATDEC enrolment" when {
 
-          lazy val view: Html = views.html.payments.paymentHistory(baseModel, Html(""))
+          lazy val view: Html = views.html.payments.paymentHistory(baseModel)
           lazy implicit val document: Document = Jsoup.parse(view.body)
 
           "not display a current year tab" in {
@@ -235,7 +235,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
           "they migrated to MTD less than 15 months ago" should {
 
             lazy val view: Html = views.html.payments.paymentHistory(
-              baseModel.copy(tabOne = Some(currentYear), previousPaymentsTab = true), Html("")
+              baseModel.copy(tabOne = Some(currentYear), previousPaymentsTab = true)
             )(request, messages, mockConfig, messages.lang, vatDecUser)
             lazy implicit val document: Document = Jsoup.parse(view.body)
 
@@ -263,7 +263,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
           "they migrated to MTD 15 months ago or longer" should {
 
             lazy val view: Html =
-              views.html.payments.paymentHistory(baseModel, Html(""))(request, messages, mockConfig, messages.lang, vatDecUser)
+              views.html.payments.paymentHistory(baseModel)(request, messages, mockConfig, messages.lang, vatDecUser)
             lazy implicit val document: Document = Jsoup.parse(view.body)
 
             "not display a current year tab" in {
@@ -292,7 +292,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
       "the user has clicked the Previous Payments tab" should {
 
         lazy val view: Html = views.html.payments.paymentHistory(
-          baseModel.copy(tabOne = Some(currentYear), selectedYear = None, previousPaymentsTab = true), Html("")
+          baseModel.copy(tabOne = Some(currentYear), selectedYear = None, previousPaymentsTab = true)
         )(request, messages, mockConfig, messages.lang, vatDecUser)
         lazy implicit val document: Document = Jsoup.parse(view.body)
 
@@ -331,7 +331,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
 
       "the user does not have the VATDEC enrolment" when {
 
-        lazy val view: Html = views.html.payments.paymentHistory(model, Html(""))
+        lazy val view: Html = views.html.payments.paymentHistory(model)
         lazy implicit val document: Document = Jsoup.parse(view.body)
 
         "display a current year tab" in {
@@ -359,7 +359,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
 
         "they migrated to MTD less than 15 months ago" should {
 
-          lazy val view: Html = views.html.payments.paymentHistory(model.copy(previousPaymentsTab = true), Html(""))(
+          lazy val view: Html = views.html.payments.paymentHistory(model.copy(previousPaymentsTab = true))(
             request, messages, mockConfig, messages.lang, vatDecUser)
           lazy implicit val document: Document = Jsoup.parse(view.body)
 
@@ -387,7 +387,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
         "they migrated to MTD 15 months ago or longer" should {
 
           lazy val view: Html =
-            views.html.payments.paymentHistory(model, Html(""))(request, messages, mockConfig, messages.lang, vatDecUser)
+            views.html.payments.paymentHistory(model)(request, messages, mockConfig, messages.lang, vatDecUser)
           lazy implicit val document: Document = Jsoup.parse(view.body)
 
           "display a current year tab" in {

--- a/test/views/vatDetails/VatDetailsViewSpec.scala
+++ b/test/views/vatDetails/VatDetailsViewSpec.scala
@@ -179,7 +179,7 @@ class VatDetailsViewSpec extends ViewBaseSpec {
 
       "if the user is NOT Hybrid" should {
 
-        lazy val view = views.html.vatDetails.details(detailsModel, Html(""))
+        lazy val view = views.html.vatDetails.details(detailsModel)
         lazy implicit val document: Document = Jsoup.parse(view.body)
 
         lazy val submittedReturns = element(Selectors.paymentHistory)
@@ -195,7 +195,7 @@ class VatDetailsViewSpec extends ViewBaseSpec {
 
       "if the user is Hybrid" should {
 
-        lazy val view = views.html.vatDetails.details(hybridDetailsModel, Html(""))
+        lazy val view = views.html.vatDetails.details(hybridDetailsModel)
         lazy implicit val document: Document = Jsoup.parse(view.body)
 
         lazy val submittedReturns = element(Selectors.paymentHistory)


### PR DESCRIPTION
As part of this PR I have also made the serviceInfoContent parameter in the views defaulted to empty HTML, for future proofing of the app in case agents are allowed into these pages going forward, and also to make the view specs a little nicer as we don't have to provide any extra HTML.