### PR TITLE
BTAT-6217 Updated payments sub item parser to read 'paymentAmount'

### DIFF
--- a/app/common/FinancialTransactionsConstants.scala
+++ b/app/common/FinancialTransactionsConstants.scala
@@ -22,7 +22,7 @@ object FinancialTransactionsConstants {
   val chargeType = "chargeType"
   val taxPeriodFrom = "taxPeriodFrom"
   val clearingDate = "clearingDate"
-  val amount = "amount"
+  val paymentAmount = "paymentAmount"
   val clearingReason = "clearingReason"
   val items = "items"
   val taxPeriodTo = "taxPeriodTo"

--- a/app/models/payments/TransactionSubItem.scala
+++ b/app/models/payments/TransactionSubItem.scala
@@ -21,7 +21,7 @@ import play.api.libs.functional.syntax._
 import common.FinancialTransactionsConstants
 import play.api.libs.json._
 
-case class TransactionSubItem(amount: BigDecimal,
+case class TransactionSubItem(paymentAmount: Option[BigDecimal] = None,
                               clearingDate: Option[LocalDate] = None,
                               clearingReason: Option[String] = None,
                               dueDate: Option[LocalDate] = None)
@@ -29,7 +29,7 @@ case class TransactionSubItem(amount: BigDecimal,
 object TransactionSubItem {
 
   implicit val reads: Reads[TransactionSubItem] = (
-    (JsPath \ FinancialTransactionsConstants.amount).read[BigDecimal] and
+    (JsPath \ FinancialTransactionsConstants.paymentAmount).readNullable[BigDecimal] and
     (JsPath \ FinancialTransactionsConstants.clearingDate).readNullable[LocalDate] and
     (JsPath \ FinancialTransactionsConstants.clearingReason).readNullable[String] and
     (JsPath \ FinancialTransactionsConstants.dueDate).readNullable[LocalDate]

--- a/it/connectors/FinancialDataConnectorISpec.scala
+++ b/it/connectors/FinancialDataConnectorISpec.scala
@@ -41,7 +41,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
   "calling getOpenPayments with a status of 'O'" should {
 
     "return all outstanding payments for a given period" in new Test {
-      override def setupStubs(): StubMapping = FinancialDataStub.stubAllOutstandingOpenPayments
+      override def setupStubs(): StubMapping = FinancialDataStub.stubOutstandingTransactions
 
       val expected = Right(Payments(Seq(
         PaymentWithPeriod(
@@ -100,8 +100,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
   "calling getVatLiabilities" should {
 
     "return a PaymentsHistoryModel" in new Test {
-      override def setupStubs(): StubMapping = FinancialDataStub.stubAllOutstandingPayments
-
+      override def setupStubs(): StubMapping = FinancialDataStub.stubPaidTransactions
 
       val expected = Right(Seq(
         PaymentsHistoryModel(
@@ -115,7 +114,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           chargeType    =  ReturnCreditCharge,
           taxPeriodFrom = Some(LocalDate.parse("2018-05-01")),
           taxPeriodTo   = Some(LocalDate.parse("2018-07-31")),
-          amount        = 600,
+          amount        = -600,
           clearedDate   = Some(LocalDate.parse("2018-03-10"))
         )
       ))

--- a/it/pages/LanguageSpec.scala
+++ b/it/pages/LanguageSpec.scala
@@ -32,7 +32,7 @@ class LanguageSpec extends IntegrationBaseSpec {
       obligationsStub.stubOutstandingObligations
       CustomerInfoStub.stubCustomerInfo()
       CustomerInfoStub.stubCustomerMandationStatus()
-      FinancialDataStub.stubAllOutstandingOpenPayments
+      FinancialDataStub.stubOutstandingTransactions
       ServiceInfoStub.stubServiceInfoPartial
       buildRequest("/vat-overview")
     }

--- a/it/pages/PaymentsPageSpec.scala
+++ b/it/pages/PaymentsPageSpec.scala
@@ -45,7 +45,7 @@ class PaymentsPageSpec extends IntegrationBaseSpec {
           AuthStub.authorised()
           CustomerInfoStub.stubCustomerInfo()
           FinancialDataStub.stubSuccessfulDirectDebit
-          FinancialDataStub.stubAllOutstandingOpenPayments
+          FinancialDataStub.stubOutstandingTransactions
         }
 
         val response: WSResponse = await(request().get())
@@ -58,7 +58,7 @@ class PaymentsPageSpec extends IntegrationBaseSpec {
           AuthStub.authorised()
           CustomerInfoStub.stubCustomerInfo()
           FinancialDataStub.stubSuccessfulDirectDebit
-          FinancialDataStub.stubAllOutstandingOpenPayments
+          FinancialDataStub.stubOutstandingTransactions
         }
 
         val response: WSResponse = await(request().get())

--- a/it/pages/VatDetailsPageSpec.scala
+++ b/it/pages/VatDetailsPageSpec.scala
@@ -53,7 +53,7 @@ class VatDetailsPageSpec extends IntegrationBaseSpec {
           obligationsStub.stubOutstandingObligations
           CustomerInfoStub.stubCustomerInfo()
           CustomerInfoStub.stubCustomerMandationStatus()
-          FinancialDataStub.stubAllOutstandingOpenPayments
+          FinancialDataStub.stubOutstandingTransactions
           ServiceInfoStub.stubServiceInfoPartial
         }
         val response: WSResponse = await(request().get())
@@ -70,7 +70,7 @@ class VatDetailsPageSpec extends IntegrationBaseSpec {
             obligationsStub.stubOutstandingObligations
             CustomerInfoStub.stubCustomerInfo()
             CustomerInfoStub.stubCustomerMandationStatus(Json.obj("mandationStatus" -> "Non MTDfB"))
-            FinancialDataStub.stubAllOutstandingOpenPayments
+            FinancialDataStub.stubOutstandingTransactions
             ServiceInfoStub.stubServiceInfoPartial
           }
 
@@ -89,7 +89,7 @@ class VatDetailsPageSpec extends IntegrationBaseSpec {
             obligationsStub.stubOutstandingObligations
             CustomerInfoStub.stubCustomerInfo()
             CustomerInfoStub.stubCustomerMandationStatus(Json.obj("code" -> "AN ERROR", "errorResponse" -> "HAS OCCURRED"), BAD_REQUEST)
-            FinancialDataStub.stubAllOutstandingOpenPayments
+            FinancialDataStub.stubOutstandingTransactions
             ServiceInfoStub.stubServiceInfoPartial
           }
 

--- a/it/stubs/FinancialDataStub.scala
+++ b/it/stubs/FinancialDataStub.scala
@@ -27,16 +27,16 @@ object FinancialDataStub extends WireMockMethods {
   private val financialDataUri = "/financial-transactions/vat/([0-9]+)"
   private val financialDataDirectDebitUri = "/financial-transactions/has-direct-debit/([0-9]+)"
 
-  def stubAllOutstandingOpenPayments: StubMapping = {
+  def stubOutstandingTransactions: StubMapping = {
     when(method = GET, uri = financialDataUri, queryParams = Map("onlyOpenItems" -> "true"))
-      .thenReturn(status = OK, body = allOutStandingOpenPayments)
+      .thenReturn(status = OK, body = outstandingTransactions)
   }
 
-  def stubAllOutstandingPayments: StubMapping = {
+  def stubPaidTransactions: StubMapping = {
     when(method = GET, uri = financialDataUri, queryParams = Map(
       "dateFrom" -> "2018-01-01",
       "dateTo" -> "2018-12-31"))
-      .thenReturn(status = OK, body = allOutStandingPayments)
+      .thenReturn(status = OK, body = paidTransactions)
   }
 
   def stubNoPayments: StubMapping = {
@@ -64,7 +64,7 @@ object FinancialDataStub extends WireMockMethods {
       .thenReturn(BAD_REQUEST, body = invalidVrn)
   }
 
-  private val allOutStandingPayments: JsValue = Json.parse(
+  private val paidTransactions: JsValue = Json.parse(
     s"""{
        |    "idType" : "VRN",
        |    "idNumber" : "555555555",
@@ -72,8 +72,8 @@ object FinancialDataStub extends WireMockMethods {
        |    "processingDate" : "2018-03-07T09:30:00.000Z",
        |    "financialTransactions" : [
        |      {
-       |        "chargeType" : "${ReturnDebitCharge}",
-       |       "mainType" : "VAT Return Charge",
+       |        "chargeType" : "$ReturnDebitCharge",
+       |        "mainType" : "VAT Return Charge",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
        |        "taxPeriodFrom" : "2018-08-01",
@@ -89,18 +89,17 @@ object FinancialDataStub extends WireMockMethods {
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
        |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-01-10",
        |            "dueDate" : "2018-12-07",
-       |            "amount" : 150
+       |            "paymentAmount" : 150
        |          }
        |        ]
        |      },
        |      {
-       |        "chargeType" : "${ReturnCreditCharge}",
+       |        "chargeType" : "$ReturnCreditCharge",
        |        "mainType" : "VAT Return Charge",
        |        "periodKey" : "17BB",
        |        "periodKeyDescription" : "ABCD",
@@ -116,14 +115,13 @@ object FinancialDataStub extends WireMockMethods {
        |        "chargeReference" : "XD002750002155",
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
-       |        "originalAmount" : 600,
-       |        "outstandingAmount" : 600,
+       |        "originalAmount" : -600,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-03-10",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 600
+       |            "paymentAmount" : -600
        |          }
        |        ]
        |      }
@@ -131,15 +129,15 @@ object FinancialDataStub extends WireMockMethods {
        |  }""".stripMargin
   )
 
-  private val allOutStandingOpenPayments = Json.parse(
-    """{
+  private val outstandingTransactions = Json.parse(
+    s"""{
       |    "idType" : "VRN",
       |    "idNumber" : 555555555,
       |    "regimeType" : "VATC",
       |    "processingDate" : "2017-03-07T09:30:00.000Z",
       |    "financialTransactions" : [
       |      {
-      |        "chargeType" : "VAT Return Debit Charge",
+      |        "chargeType" : "$ReturnDebitCharge",
       |        "mainType" : "VAT Return Charge",
       |        "periodKey" : "15AC",
       |        "periodKeyDescription" : "March 2015",
@@ -157,7 +155,6 @@ object FinancialDataStub extends WireMockMethods {
       |        "subTransaction" : "1174",
       |        "originalAmount" : 10000,
       |        "outstandingAmount" : 10000,
-      |        "clearedAmount" : 10000,
       |        "items" : [
       |          {
       |            "subItem" : "000",
@@ -167,7 +164,7 @@ object FinancialDataStub extends WireMockMethods {
       |        ]
       |      },
       |      {
-      |        "chargeType" : "VAT Return Debit Charge",
+      |        "chargeType" : "$ReturnDebitCharge",
       |        "mainType" : "VAT Return Charge",
       |        "periodKey" : "15AC",
       |        "periodKeyDescription" : "March 2015",
@@ -185,7 +182,6 @@ object FinancialDataStub extends WireMockMethods {
       |        "subTransaction" : "1174",
       |        "originalAmount" : 10000,
       |        "outstandingAmount" : 10000,
-      |        "clearedAmount" : 10000,
       |        "items" : [
       |          {
       |            "subItem" : "000",

--- a/test/connectors/httpParsers/PaymentsHistoryHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHistoryHttpParserSpec.scala
@@ -38,7 +38,7 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |    "processingDate" : "2018-03-07T09:30:00.000Z",
        |    "financialTransactions" : [
        |      {
-       |        "chargeType" : "${ReturnDebitCharge}",
+       |        "chargeType" : "$ReturnDebitCharge",
        |        "mainType" : "VAT Return Charge",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
@@ -55,18 +55,17 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
        |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-01-10",
        |            "dueDate" : "2018-12-07",
-       |            "amount" : 150
+       |            "paymentAmount" : 150
        |          }
        |        ]
        |      },
        |      {
-       |        "chargeType" : "${ReturnCreditCharge}",
+       |        "chargeType" : "$ReturnCreditCharge",
        |        "mainType" : "VAT Return Charge",
        |        "periodKey" : "17BB",
        |        "periodKeyDescription" : "ABCD",
@@ -82,19 +81,18 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "chargeReference" : "XD002750002155",
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
-       |        "originalAmount" : 600,
-       |        "outstandingAmount" : 600,
+       |        "originalAmount" : -600,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-03-10",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 600
+       |            "paymentAmount" : -600
        |          }
        |        ]
        |      },
        |      {
-       |        "chargeType" : "${OADebitCharge}",
+       |        "chargeType" : "$OADebitCharge",
        |        "mainType" : "VAT Officer's Assessment",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
@@ -110,19 +108,18 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "chargeReference" : "XD002750002155",
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
-       |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
+       |        "originalAmount" : 200,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-04-14",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 200
+       |            "paymentAmount" : 200
        |          }
        |        ]
        |      },
        |      {
-       |        "chargeType" : "${OACreditCharge}",
+       |        "chargeType" : "$OACreditCharge",
        |        "mainType" : "VAT Officer's Assessment",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
@@ -138,20 +135,19 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "chargeReference" : "XD002750002155",
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
-       |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
+       |        "originalAmount" : -550,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-06-28",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 550
+       |            "paymentAmount" : -550
        |          }
        |        ]
        |      },
        |      {
-       |        "chargeType" : "${DefaultSurcharge}",
-       |        "mainType" : "${DefaultSurcharge}",
+       |        "chargeType" : "$DefaultSurcharge",
+       |        "mainType" : "$DefaultSurcharge",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
        |        "taxPeriodFrom" : "2018-06-10",
@@ -167,19 +163,18 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
        |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-11-10",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 150
+       |            "paymentAmount" : 150
        |          }
        |        ]
        |      },
        |      {
-       |        "chargeType" : "${CentralAssessmentCharge}",
-       |        "mainType" : "${CentralAssessmentCharge}",
+       |        "chargeType" : "$CentralAssessmentCharge",
+       |        "mainType" : "$CentralAssessmentCharge",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
        |        "taxPeriodFrom" : "2018-08-01",
@@ -195,18 +190,17 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
        |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-11-10",
        |            "dueDate" : "2018-11-10",
-       |            "amount" : 150
+       |            "paymentAmount" : 150
        |          }
        |        ]
        |      },
        |      {
-       |        "chargeType" : "${ErrorCorrectionCreditCharge}",
+       |        "chargeType" : "$ErrorCorrectionCreditCharge",
        |        "mainType" : "VAT Error Correction",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
@@ -222,19 +216,18 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "chargeReference" : "XD002750002155",
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
-       |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
+       |        "originalAmount" : -150,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-06-10",
        |            "dueDate" : "2018-06-10",
-       |            "amount" : 150
+       |            "paymentAmount" : -150
        |          }
        |        ]
        |      },
        |       {
-       |        "chargeType" : "${ErrorCorrectionDebitCharge}",
+       |        "chargeType" : "$ErrorCorrectionDebitCharge",
        |        "mainType" : "VAT Error Correction",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
@@ -250,20 +243,19 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "chargeReference" : "XD002750002155",
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
-       |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
+       |        "originalAmount" : 1000,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-12-15",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 1000
+       |            "paymentAmount" : 1000
        |          }
        |        ]
        |      },
        |      {
-       |        "chargeType" : "${OADefaultInterestCharge}",
-       |        "mainType" : "${OADefaultInterestCharge}",
+       |        "chargeType" : "$OADefaultInterestCharge",
+       |        "mainType" : "$OADefaultInterestCharge",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
        |        "taxPeriodFrom" : "2018-10-12",
@@ -278,14 +270,13 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "chargeReference" : "XD002750002155",
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
-       |        "originalAmount" : 150,
-       |        "outstandingAmount" : 150,
+       |        "originalAmount" : 1000,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-12-15",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 1000
+       |            "paymentAmount" : 1000
        |          }
        |        ]
        |      },
@@ -307,13 +298,12 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
        |        "originalAmount" : 150,
-       |        "outstandingAmount" : 0,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-12-15",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 150
+       |            "paymentAmount" : 150
        |          }
        |        ]
        |      },
@@ -335,13 +325,12 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
        |        "originalAmount" : 400,
-       |        "outstandingAmount" : 0,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-12-15",
        |            "dueDate" : "2018-09-07",
-       |            "amount" : 400
+       |            "paymentAmount" : 400
        |          }
        |        ]
        |      },
@@ -363,13 +352,12 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
        |        "originalAmount" : 555,
-       |        "outstandingAmount" : 0,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-10-07",
        |            "dueDate" : "2018-10-08",
-       |            "amount" : 555
+       |            "paymentAmount" : 555
        |          }
        |        ]
        |      },
@@ -391,13 +379,12 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        "mainTransaction" : "1234",
        |        "subTransaction" : "5678",
        |        "originalAmount" : -555,
-       |        "outstandingAmount" : 0,
        |        "items" : [
        |          {
        |            "subItem" : "000",
        |            "clearingDate" : "2018-10-07",
        |            "dueDate" : "2018-10-08",
-       |            "amount" : -555
+       |            "paymentAmount" : -555
        |          }
        |        ]
        |      }
@@ -417,7 +404,7 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
       chargeType = ReturnCreditCharge,
       taxPeriodFrom = Some(LocalDate.of(2018, 5, 1)),
       taxPeriodTo = Some(LocalDate.of(2018, 7, 31)),
-      amount = 600,
+      amount = -600,
       clearedDate = Some(LocalDate.of(2018, 3, 10))
     ),
     PaymentsHistoryModel(
@@ -431,7 +418,7 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
       chargeType = OACreditCharge,
       taxPeriodFrom = Some(LocalDate.of(2018, 5, 1)),
       taxPeriodTo = Some(LocalDate.of(2018, 7, 31)),
-      amount = 550,
+      amount = -550,
       clearedDate = Some(LocalDate.of(2018, 6, 28))
     ),
     PaymentsHistoryModel(
@@ -452,7 +439,7 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
       chargeType = ErrorCorrectionCreditCharge,
       taxPeriodFrom = Some(LocalDate.of(2018, 2, 1)),
       taxPeriodTo = Some(LocalDate.of(2018, 5, 20)),
-      amount = 150,
+      amount = -150,
       clearedDate = Some(LocalDate.of(2018, 6, 10))
     ),
     PaymentsHistoryModel(
@@ -531,19 +518,12 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
          |        "mainTransaction" : "1234",
          |        "subTransaction" : "5678",
          |        "originalAmount" : 150,
-         |        "outstandingAmount" : 150,
          |        "items" : [
-         |          {
-         |            "subItem" : "000",
-         |            "clearingDate" : "2018-01-10",
-         |            "dueDate" : "2018-12-07",
-         |            "amount" : 150
-         |          },
          |          {
          |            "subItem" : "000",
          |            "clearingDate" : "2018-03-10",
          |            "dueDate" : "2018-12-07",
-         |            "amount" : 100
+         |            "paymentAmount" : 100
          |          }
          |        ]
          |      },
@@ -564,19 +544,12 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
          |        "mainTransaction" : "1234",
          |        "subTransaction" : "5678",
          |        "originalAmount" : 150,
-         |        "outstandingAmount" : 150,
          |        "items" : [
-         |          {
-         |            "subItem" : "000",
-         |            "clearingDate" : "2018-01-10",
-         |            "dueDate" : "2018-12-07",
-         |            "amount" : 150
-         |          },
          |          {
          |            "subItem" : "000",
          |            "clearingDate" : "2018-03-10",
          |            "dueDate" : "2018-12-07",
-         |            "amount" : 100
+         |            "paymentAmount" : 150
          |          }
          |        ]
          |      }

--- a/test/models/PaymentsHistoryModelSpec.scala
+++ b/test/models/PaymentsHistoryModelSpec.scala
@@ -18,7 +18,6 @@ package models
 
 import java.time.LocalDate
 
-import common.FinancialTransactionsConstants
 import models.payments._
 import models.viewModels.PaymentsHistoryModel
 import play.api.libs.json._
@@ -59,14 +58,13 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
+           |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 150
-           |          }
+           |            "clearingDate" : "2018-01-10"
+         |            }
            |        ]
            |      },
            |      {
@@ -86,15 +84,14 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "chargeReference" : "XD002750002155",
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
-           |        "originalAmount" : 600,
-           |        "outstandingAmount" : 600,
+           |        "originalAmount" : -600,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-03-10",
+           |            "paymentAmount" : -600,
            |            "dueDate" : "2018-09-07",
-           |            "amount" : 600
-           |          }
+           |            "clearingDate" : "2018-03-10"
+         |            }
            |        ]
            |      }
            |    ]
@@ -113,7 +110,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
           chargeType = ReturnCreditCharge,
           taxPeriodFrom = Some(LocalDate.of(2018, 5, 1)),
           taxPeriodTo = Some(LocalDate.of(2018, 7, 31)),
-          amount = 600,
+          amount = -600,
           clearedDate = Some(LocalDate.of(2018, 3, 10))
         )
       )
@@ -134,7 +131,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |    "financialTransactions" : [
            |      {
            |        "chargeType" : "$ReturnDebitCharge",
-           |       "mainType" : "VAT Return Charge",
+           |        "mainType" : "VAT Return Charge",
            |        "periodKey" : "17AA",
            |        "periodKeyDescription" : "ABCD",
            |        "taxPeriodFrom" : "2018-08-01",
@@ -150,19 +147,18 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
+           |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 150
+           |            "clearingDate" : "2018-01-10"
            |          }
            |        ]
            |      },
            |      {
            |        "chargeType" : "$DefaultSurcharge",
-           |       "mainType" : "$DefaultSurcharge",
+           |        "mainType" : "$DefaultSurcharge",
            |        "periodKey" : "17AA",
            |        "periodKeyDescription" : "ABCD",
            |        "taxPeriodFrom" : "2018-08-01",
@@ -178,19 +174,18 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
+           |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 150
+           |            "clearingDate" : "2018-01-10"
            |          }
            |        ]
            |      },
            |      {
            |        "chargeType" : "$CentralAssessmentCharge",
-           |       "mainType" : "$CentralAssessmentCharge",
+           |        "mainType" : "$CentralAssessmentCharge",
            |        "periodKey" : "17AA",
            |        "periodKeyDescription" : "ABCD",
            |        "taxPeriodFrom" : "2018-08-01",
@@ -206,18 +201,17 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
+           |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 150
+           |            "clearingDate" : "2018-01-10"
            |          }
            |        ]
            |      },
            |      {
-           |        "chargeType" : "${ReturnCreditCharge}",
+           |        "chargeType" : "$ReturnCreditCharge",
            |        "mainType" : "VAT Return Charge",
            |        "periodKey" : "17BB",
            |        "periodKeyDescription" : "ABCD",
@@ -233,14 +227,13 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "chargeReference" : "XD002750002155",
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
-           |        "originalAmount" : 600,
-           |        "outstandingAmount" : 600,
+           |        "originalAmount" : -600,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-03-10",
+           |            "paymentAmount" : -600,
            |            "dueDate" : "2018-09-07",
-           |            "amount" : 600
+           |            "clearingDate" : "2018-03-10"
            |          }
            |        ]
            |      },
@@ -261,14 +254,13 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "chargeReference" : "XD002750002155",
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
-           |        "originalAmount" : 600,
-           |        "outstandingAmount" : 600,
+           |        "originalAmount" : -600,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-03-10",
+           |            "paymentAmount" : -600,
            |            "dueDate" : "2018-09-07",
-           |            "amount" : 600
+           |            "clearingDate" : "2018-03-10"
            |          }
            |        ]
            |      },
@@ -290,13 +282,12 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 600,
-           |        "outstandingAmount" : 600,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-03-10",
+           |            "paymentAmount" : 600,
            |            "dueDate" : "2018-09-07",
-           |            "amount" : 600
+           |            "clearingDate" : "2018-03-10"
            |          }
            |        ]
            |      }
@@ -330,14 +321,14 @@ class PaymentsHistoryModelSpec extends UnitSpec {
           chargeType = ReturnCreditCharge,
           taxPeriodFrom = Some(LocalDate.of(2018, 5, 1)),
           taxPeriodTo = Some(LocalDate.of(2018, 7, 31)),
-          amount = 600,
+          amount = -600,
           clearedDate = Some(LocalDate.of(2018, 3, 10))
         ),
         PaymentsHistoryModel(
           chargeType = ErrorCorrectionCreditCharge,
           taxPeriodFrom = Some(LocalDate.of(2018, 5, 1)),
           taxPeriodTo = Some(LocalDate.of(2018, 7, 31)),
-          amount = 600,
+          amount = -600,
           clearedDate = Some(LocalDate.of(2018, 3, 10))
         ),
         PaymentsHistoryModel(
@@ -380,13 +371,12 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
+           |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 150
+           |            "clearingDate" : "2018-01-10"
            |          }
            |        ]
            |      },
@@ -407,14 +397,13 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "chargeReference" : "XD002750002155",
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
-           |        "originalAmount" : 600,
-           |        "outstandingAmount" : 600,
+           |        "originalAmount" : -600,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-04-10",
+           |            "paymentAmount" : -600,
            |            "dueDate" : "2018-09-07",
-           |            "amount" : 600
+           |            "clearingDate" : "2018-04-10"
            |          }
            |        ]
            |      }
@@ -434,7 +423,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
           chargeType = ReturnCreditCharge,
           taxPeriodFrom = Some(LocalDate.of(2018, 5, 1)),
           taxPeriodTo = Some(LocalDate.of(2018, 7, 31)),
-          amount = 600,
+          amount = -600,
           clearedDate = Some(LocalDate.of(2018, 4, 10))
         )
       )
@@ -444,7 +433,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
       }
     }
 
-    "there is multiple items in one period" should {
+    "there are multiple payments against one charge" should {
 
       val testJson: JsValue = Json.parse(
         s"""{
@@ -470,20 +459,19 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "chargeReference" : "XD002750002155",
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
-           |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
+           |        "originalAmount" : 250,
            |        "items" : [
            |          {
-           |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
+           |            "subItem" : "001",
+           |            "paymentAmount" : 100,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 150
+           |            "clearingDate" : "2018-03-10"
            |          },
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-03-10",
+           |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 100
+           |            "clearingDate" : "2018-01-10"
            |          }
            |        ]
            |      }
@@ -497,15 +485,15 @@ class PaymentsHistoryModelSpec extends UnitSpec {
           chargeType = ReturnDebitCharge,
           taxPeriodFrom = Some(LocalDate.of(2018, 8, 1)),
           taxPeriodTo = Some(LocalDate.of(2018, 10, 31)),
-          amount = 150,
-          clearedDate = Some(LocalDate.of(2018, 1, 10))
+          amount = 100,
+          clearedDate = Some(LocalDate.of(2018, 3, 10))
         ),
         PaymentsHistoryModel(
           chargeType = ReturnDebitCharge,
           taxPeriodFrom = Some(LocalDate.of(2018, 8, 1)),
           taxPeriodTo = Some(LocalDate.of(2018, 10, 31)),
-          amount = 100,
-          clearedDate = Some(LocalDate.of(2018, 3, 10))
+          amount = 150,
+          clearedDate = Some(LocalDate.of(2018, 1, 10))
         )
       )
 
@@ -579,7 +567,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
       }
     }
 
-    "there is no amount" should {
+    "there is no paymentAmount" should {
       val testJson = Json.parse(
         s"""{
            |    "idType" : "VRN",
@@ -605,12 +593,11 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
-           |            "dueDate" : "2018-12-07"
+           |            "dueDate" : "2018-12-07",
+           |            "clearingDate" : "2018-01-10"
            |          }
            |        ]
            |      }
@@ -618,8 +605,8 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |  }""".stripMargin
       )
 
-      "throw a JsResultException" in {
-        intercept[JsResultException](Json.fromJson(testJson)(reads))
+      "return an empty sequence" in {
+        Json.fromJson(testJson)(reads) shouldBe JsSuccess(Seq())
       }
     }
 
@@ -649,13 +636,12 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
+           |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 150
+           |            "clearingDate" : "2018-01-10"
            |          }
            |        ]
            |      }
@@ -703,13 +689,12 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        "mainTransaction" : "1234",
            |        "subTransaction" : "5678",
            |        "originalAmount" : 150,
-           |        "outstandingAmount" : 150,
            |        "items" : [
            |          {
            |            "subItem" : "000",
-           |            "clearingDate" : "2018-01-10",
+           |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
-           |            "amount" : 150
+           |            "clearingDate" : "2018-01-10"
            |          }
            |        ]
            |      }
@@ -754,18 +739,13 @@ class PaymentsHistoryModelSpec extends UnitSpec {
              |        "sapDocumentNumberItem" : "0",
              |        "mainTransaction" : "1234",
              |        "subTransaction" : "5678",
-             |        "originalAmount" : -5050,
-             |        "outstandingAmount" : -5050,
+             |        "originalAmount" : 5050,
+             |        "outstandingAmount" : 5050,
              |        "items" : [
              |          {
-             |            "subItem": "000",
-             |            "dueDate": "2010-12-04",
-             |            "amount": -4,
-             |            "paymentReference": "654378944",
-             |            "paymentAmount": 6000,
-             |            "paymentMethod": "BANK GIRO RECEIPTS",
-             |            "paymentLot": "RP11",
-             |            "paymentLotItem": "000001"
+             |            "subItem" : "000",
+             |            "dueDate" : "2018-12-04",
+             |            "amount" : 5050
              |          }
              |        ]
              |      }
@@ -778,8 +758,8 @@ class PaymentsHistoryModelSpec extends UnitSpec {
             UnallocatedPayment,
             None,
             None,
-            -5050,
-            Some(LocalDate.of(2010, 12, 4)))
+            5050,
+            Some(LocalDate.of(2018, 12, 4)))
         )
 
         s"return $UnallocatedPayment as the charge type" in {
@@ -809,19 +789,18 @@ class PaymentsHistoryModelSpec extends UnitSpec {
              |        "mainTransaction" : "1234",
              |        "subTransaction" : "5678",
              |        "originalAmount" : -5050,
-             |        "outstandingAmount" : -5050,
              |        "items" : [
              |          {
              |            "subItem": "000",
-             |            "dueDate": "2010-12-04",
              |            "amount": -5050,
              |            "paymentReference": "654378944",
-             |            "paymentAmount": 6000,
+             |            "paymentAmount": -5050,
              |            "paymentMethod": "BANK GIRO RECEIPTS",
              |            "paymentLot": "RP11",
              |            "paymentLotItem": "000001",
-             |            "clearingDate": "2018-05-04",
-             |            "clearingReason": "some clearing reason"
+             |            "dueDate": "2018-12-04",
+             |            "clearingDate": "2017-12-04",
+             |            "clearingReason": "Some clearing reason"
              |          }
              |        ]
              |      }
@@ -835,7 +814,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
             None,
             None,
             -5050,
-            Some(LocalDate.of(2018, 5, 4)))
+            Some(LocalDate.of(2017, 12, 4)))
         )
 
         s"return $Refund as the charge type " in {
@@ -850,7 +829,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
     "Charge type is not Payment on account" should {
 
       val chargeType = ReturnDebitCharge
-      val subItem = TransactionSubItem(9, Some(LocalDate.of(2018, 1, 1)), None)
+      val subItem = TransactionSubItem(Some(9), Some(LocalDate.of(2018, 1, 1)), None)
       val transaction: JsValue = Json.parse(
         """ {
           |   "taxPeriodFrom" : "2018-08-01",
@@ -874,7 +853,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
       }
 
       "return the amount of the sub item" in {
-        result.amount shouldBe subItem.amount
+        result.amount shouldBe subItem.paymentAmount.get
       }
 
       "return the cleared date of the sub item" in {
@@ -888,7 +867,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
 
       "clearing reason is defined" should {
 
-        val subItem = TransactionSubItem(9000, Some(LocalDate.of(2018, 1, 1)), Some("some clearing reason"))
+        val subItem = TransactionSubItem(Some(9000), Some(LocalDate.of(2018, 1, 1)), Some("some clearing reason"))
         val transaction: JsValue = Json.parse(
           """ {
             |   "taxPeriodFrom" : "2018-08-01",
@@ -912,7 +891,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
         }
 
         "return the correct amount" in {
-          result.amount shouldBe subItem.amount
+          result.amount shouldBe subItem.paymentAmount.get
         }
 
         "return a clearing date" in {
@@ -922,7 +901,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
 
       "clearing reason is not defined" should {
 
-        val subItem = TransactionSubItem(9, None, None, Some(LocalDate.of(2018, 1, 1)))
+        val subItem = TransactionSubItem(Some(9), None, None, Some(LocalDate.of(2018, 1, 1)))
         val transaction: JsValue = Json.parse(
           """ {
             |   "outstandingAmount" : "1000"


### PR DESCRIPTION
The unit and IT test data for FinancialData has also been slightly updated to be more accurate with regards to how the real data is returned.

**NOTE** - this change will break the acceptance tests until the stub data has been updated as part of BTAT-6214