### PR TITLE
Added repayment CSS tag to charges that were missing it

### DIFF
--- a/app/views/templates/payments/PaymentMessageHelper.scala
+++ b/app/views/templates/payments/PaymentMessageHelper.scala
@@ -29,7 +29,9 @@ object PaymentMessageHelper {
   object VatReturnCreditCharge extends PaymentMessageHelper(
     ReturnCreditCharge.value,
     "chargeType.vatReturnCreditChargeTitle",
-    Some("chargeType.vatReturnCreditChargeDescription"))
+    Some("chargeType.vatReturnCreditChargeDescription"),
+    "repayment"
+  )
 
   object VatReturnDebitCharge extends PaymentMessageHelper(
     ReturnDebitCharge.value,
@@ -39,7 +41,9 @@ object PaymentMessageHelper {
   object VatOfficerAssessmentCreditCharge extends PaymentMessageHelper(
     OACreditCharge.value,
     "chargeType.officerAssessmentChargeTitle",
-    Some("chargeType.officerAssessmentCreditChargeDescription"))
+    Some("chargeType.officerAssessmentCreditChargeDescription"),
+    "repayment"
+  )
 
   object VatOfficerAssessmentDebitCharge extends PaymentMessageHelper(
     OADebitCharge.value,
@@ -65,7 +69,8 @@ object PaymentMessageHelper {
   object VatErrorCorrectionCreditCharge extends PaymentMessageHelper(
     ErrorCorrectionCreditCharge.value,
     "chargeType.vatErrorCorrectionCreditChargeTitle",
-    Some("chargeType.vatErrorCorrectionChargeDescription")
+    Some("chargeType.vatErrorCorrectionChargeDescription"),
+    "repayment"
   )
 
   object VatRepaymentSupplement extends PaymentMessageHelper(
@@ -321,7 +326,7 @@ object PaymentMessageHelper {
     "repayment"
   )
 
-  val values = Seq(
+  val values: Seq[PaymentMessageHelper] = Seq(
     VatReturnDebitCharge,
     VatReturnCreditCharge,
     VatOfficerAssessmentCreditCharge,

--- a/test/views/templates/payments/PaymentsHistoryChargeTemplateSpec.scala
+++ b/test/views/templates/payments/PaymentsHistoryChargeTemplateSpec.scala
@@ -107,7 +107,7 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
       )
 
       "display the correct table row class" in {
-        element(Selectors.tableRow).attr("class") shouldBe ""
+        element(Selectors.tableRow).attr("class") shouldBe "repayment"
       }
 
       "display the correct charge title" in {
@@ -163,7 +163,7 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
       )
 
       "display the correct table row class" in {
-        element(Selectors.tableRow).attr("class") shouldBe ""
+        element(Selectors.tableRow).attr("class") shouldBe "repayment"
       }
 
       "display the correct charge title" in {
@@ -247,7 +247,7 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
       )
 
       "display the correct table row class" in {
-        element(Selectors.tableRow).attr("class") shouldBe ""
+        element(Selectors.tableRow).attr("class") shouldBe "repayment"
       }
 
       "display the correct charge title" in {
@@ -686,6 +686,202 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
 
       "have the correct CSS applied" in {
         element(Selectors.thirdTableElement).attr("class") should include("repayment-money")
+      }
+    }
+
+    "there is a VAT POA Instalment charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        PaymentOnAccountInstalments,
+        Some(LocalDate.parse("2018-01-01")),
+        Some(LocalDate.parse("2018-02-02")),
+        500,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Payment on account instalment"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+      }
+    }
+
+    "there is a VAT POA Return Debit charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        PaymentOnAccountReturnDebitCharge,
+        Some(LocalDate.parse("2018-01-01")),
+        Some(LocalDate.parse("2018-02-02")),
+        500,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Payment on account balance"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+      }
+    }
+
+    "there is a VAT POA Return Credit charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        PaymentOnAccountReturnCreditCharge,
+        Some(LocalDate.parse("2018-01-01")),
+        Some(LocalDate.parse("2018-02-02")),
+        500,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe "repayment"
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Payment on account repayment"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+      }
+    }
+
+    "there is a VAT AA Monthly Instalment charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        AAMonthlyInstalment,
+        Some(LocalDate.parse("2018-01-01")),
+        Some(LocalDate.parse("2018-02-02")),
+        500,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Annual accounting monthly instalment"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+      }
+    }
+
+    "there is a VAT AA Quarterly Instalment charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        AAQuarterlyInstalments,
+        Some(LocalDate.parse("2018-01-01")),
+        Some(LocalDate.parse("2018-02-02")),
+        500,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Annual accounting quarterly instalment"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+      }
+    }
+
+    "there is a VAT AA Return Debit charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        AAReturnDebitCharge,
+        Some(LocalDate.parse("2018-01-01")),
+        Some(LocalDate.parse("2018-02-02")),
+        500,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Annual accounting balance"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+      }
+    }
+
+    "there is a VAT AA Return Credit charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        AAReturnCreditCharge,
+        Some(LocalDate.parse("2018-01-01")),
+        Some(LocalDate.parse("2018-02-02")),
+        500,
+        Some(LocalDate.parse("2018-10-16"))
+      )
+
+      lazy val template = paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe "repayment"
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Annual accounting repayment"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
       }
     }
   }


### PR DESCRIPTION
As part of this fix I've also added tests for the POA and AA charges in the `PaymentsHistoryChargeTemplateSpec` as these were missed.