### PR TITLE
No active session auto redirects to sign in

### DIFF
--- a/app/controllers/AuthorisedController.scala
+++ b/app/controllers/AuthorisedController.scala
@@ -57,11 +57,10 @@ class AuthorisedController @Inject()(val messagesApi: MessagesApi,
             Logger.warn("[AuthorisedController][authorisedAction] - Missing affinity group")
             Future.successful(InternalServerError)
         } recoverWith {
-          case _: NoActiveSession => Future.successful(Unauthorized(views.html.errors.sessionTimeout()))
-          case _: InsufficientEnrolments => {
+          case _: NoActiveSession => Future.successful(Redirect(appConfig.signInUrl))
+          case _: InsufficientEnrolments =>
             Logger.warn(s"[AuthorisedController][authorisedAction] insufficient enrolment exception encountered")
             Future.successful(Forbidden(views.html.errors.unauthorised()))
-          }
           case _: AuthorisationException =>
             Logger.warn(s"[AuthorisedController][authorisedAction] encountered unauthorisation exception")
             Future.successful(Forbidden(views.html.errors.unauthorised()))

--- a/app/controllers/AuthorisedController.scala
+++ b/app/controllers/AuthorisedController.scala
@@ -49,8 +49,8 @@ class AuthorisedController @Inject()(val messagesApi: MessagesApi,
             if(allowAgentAccess) {
               agentPredicate.authoriseAsAgent(block)
             } else {
-              Logger.debug("[AuthorisedController][authorisedAction] User is agent and agent access is forbidden. Rendering unauthorised page.")
-              Future.successful(Forbidden(views.html.errors.unauthorised()))
+              Logger.debug("[AuthorisedController][authorisedAction] User is agent and agent access is forbidden. Redirecting to VACLUF")
+              Future.successful(Redirect(appConfig.agentClientLookupActionUrl))
             }
           case enrolments ~ Some(_) => authoriseAsNonAgent(block, enrolments, checkMigrationStatus)
           case _ =>

--- a/it/pages/VatDetailsPageSpec.scala
+++ b/it/pages/VatDetailsPageSpec.scala
@@ -101,14 +101,15 @@ class VatDetailsPageSpec extends IntegrationBaseSpec {
       }
     }
 
-    "the user is not authenticated" should {
+    "the user is not signed in" should {
 
       def setupStubsForScenario(): StubMapping = AuthStub.unauthorisedNotLoggedIn()
 
-      "return 401 (Unauthorised)" in new Test {
+      "return 303 (SEE_OTHER)" in new Test {
         override def setupStubs(): StubMapping = setupStubsForScenario()
         val response: WSResponse = await(request().get())
-        response.status shouldBe Status.UNAUTHORIZED
+
+        response.status shouldBe Status.SEE_OTHER
       }
     }
   }

--- a/test/controllers/DirectDebitControllerSpec.scala
+++ b/test/controllers/DirectDebitControllerSpec.scala
@@ -130,10 +130,12 @@ class DirectDebitControllerSpec extends ControllerBaseSpec {
 
     "user is an Agent" should {
 
-      "return 403 (Forbidden)" in new DirectDebitDetailsTest {
+      "redirect to Agent Action page" in new DirectDebitDetailsTest {
         override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = agentAuthResult
         val result: Future[Result] = target.directDebits()(fakeRequest)
-        status(result) shouldBe Status.FORBIDDEN
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.agentClientLookupActionUrl)
       }
     }
 

--- a/test/controllers/DirectDebitControllerSpec.scala
+++ b/test/controllers/DirectDebitControllerSpec.scala
@@ -108,12 +108,13 @@ class DirectDebitControllerSpec extends ControllerBaseSpec {
     }
 
     "the user is not logged in" should {
-      "return 401 (Unauthorised)" in new DirectDebitDetailsTest {
+      "return SEE_OTHER" in new DirectDebitDetailsTest {
         lazy val result: Future[Result] = target.directDebits()(fakeRequest)
 
         override val authResult: Future[Nothing] = Future.failed(MissingBearerToken())
 
-        status(result) shouldBe Status.UNAUTHORIZED
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
       }
     }
 

--- a/test/controllers/MakePaymentControllerSpec.scala
+++ b/test/controllers/MakePaymentControllerSpec.scala
@@ -160,10 +160,12 @@ class MakePaymentControllerSpec extends ControllerBaseSpec {
 
     "user is an Agent" should {
 
-      "return 403 (Forbidden)" in new MakePaymentDetailsTest {
+      "redirect to Agent Action page" in new MakePaymentDetailsTest {
         override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = agentAuthResult
         val result: Future[Result] = target.makePayment(testAmountInPence, testMonth, testYear, testChargeType, testDueDate)(fakeRequest)
-        status(result) shouldBe Status.FORBIDDEN
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.agentClientLookupActionUrl)
       }
     }
   }

--- a/test/controllers/MakePaymentControllerSpec.scala
+++ b/test/controllers/MakePaymentControllerSpec.scala
@@ -129,7 +129,8 @@ class MakePaymentControllerSpec extends ControllerBaseSpec {
     }
 
     "the user is not logged in" should {
-      "return 401 (Unauthorised)" in new MakePaymentDetailsTest {
+
+      "redirect to sign in" in new MakePaymentDetailsTest {
         lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] = fakeRequestToPOSTWithSession(
           ("amountInPence", "10000"),
           ("taxPeriodMonth", "02"),
@@ -138,7 +139,8 @@ class MakePaymentControllerSpec extends ControllerBaseSpec {
 
         override val authResult: Future[Nothing] = Future.failed(MissingBearerToken())
 
-        status(result) shouldBe Status.UNAUTHORIZED
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
       }
     }
 
@@ -211,7 +213,8 @@ class MakePaymentControllerSpec extends ControllerBaseSpec {
     }
 
     "the user is not logged in" should {
-      "return 401 (Unauthorised)" in new MakePaymentDetailsTest {
+
+      "redirect to sign in" in new MakePaymentDetailsTest {
         lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] = fakeRequestToPOSTWithSession(
           ("amountInPence", "10000"),
           ("taxPeriodMonth", "02"),
@@ -220,7 +223,8 @@ class MakePaymentControllerSpec extends ControllerBaseSpec {
 
         override val authResult: Future[Nothing] = Future.failed(MissingBearerToken())
 
-        status(result) shouldBe Status.UNAUTHORIZED
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
       }
     }
 

--- a/test/controllers/OpenPaymentsControllerSpec.scala
+++ b/test/controllers/OpenPaymentsControllerSpec.scala
@@ -280,12 +280,14 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
         }
       }
 
-      "the user is not authenticated" should {
+      "the user is not signed in" should {
 
-        "return 401 (Unauthorised)" in new Test {
+        "redirect to sign in" in new Test {
           override val authResult: Future[Nothing] = Future.failed(MissingBearerToken())
           private val result = target.openPayments()(fakeRequest)
-          status(result) shouldBe Status.UNAUTHORIZED
+
+          status(result) shouldBe Status.SEE_OTHER
+          redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
         }
       }
 

--- a/test/controllers/OpenPaymentsControllerSpec.scala
+++ b/test/controllers/OpenPaymentsControllerSpec.scala
@@ -273,10 +273,12 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
 
       "user is an Agent" should {
 
-        "return 403 (Forbidden)" in new Test {
+        "redirect to Agent Action page" in new Test {
           override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = agentAuthResult
           val result: Future[Result] = target.openPayments()(fakeRequest)
-          status(result) shouldBe Status.FORBIDDEN
+
+          status(result) shouldBe Status.SEE_OTHER
+          redirectLocation(result) shouldBe Some(mockAppConfig.agentClientLookupActionUrl)
         }
       }
 

--- a/test/controllers/PaymentHistoryControllerSpec.scala
+++ b/test/controllers/PaymentHistoryControllerSpec.scala
@@ -242,11 +242,13 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
     "user is an Agent" should {
 
-      "return 403 (Forbidden)" in new Test {
+      "redirect to Agent Action page" in new Test {
         override val authCall = true
         override lazy val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = agentAuthResult
         val result: Future[Result] = target.paymentHistory(currentYear)(fakeRequest)
-        status(result) shouldBe Status.FORBIDDEN
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.agentClientLookupActionUrl)
       }
     }
 

--- a/test/controllers/PaymentHistoryControllerSpec.scala
+++ b/test/controllers/PaymentHistoryControllerSpec.scala
@@ -220,11 +220,13 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
     "the user is not logged in" should {
 
-      "return 401 (Unauthorised)" in new Test {
+      "return SEE_OTHER" in new Test {
         override val authCall = true
         override lazy val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
         val result: Future[Result] = target.paymentHistory(currentYear)(fakeRequestWithSession)
-        status(result) shouldBe Status.UNAUTHORIZED
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
       }
     }
 
@@ -334,11 +336,13 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
     "the user is not logged in" should {
 
-      "return 401 (Unauthorised)" in new Test {
+      "return SEE_OTHER" in new Test {
         override val authCall = true
         override lazy val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
         val result: Future[Result] = target.paymentHistory(currentYear)(fakeRequestWithSession)
-        status(result) shouldBe Status.UNAUTHORIZED
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
       }
     }
 

--- a/test/controllers/VatCertificateControllerSpec.scala
+++ b/test/controllers/VatCertificateControllerSpec.scala
@@ -225,7 +225,7 @@ class VatCertificateControllerSpec extends ControllerBaseSpec {
 
       "the user is not logged in" should {
 
-        "return Unauthorised (401)" in new Test {
+        "return SEE_OTHER" in new Test {
           override def setup(): Unit = {
             (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
               .expects(*, *, *, *)
@@ -235,10 +235,10 @@ class VatCertificateControllerSpec extends ControllerBaseSpec {
 
           override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
           private val result = target.show()(fakeRequest)
-          status(result) shouldBe Status.UNAUTHORIZED
+          status(result) shouldBe Status.SEE_OTHER
         }
 
-        "return HTML" in new Test {
+        "redirect to sign in" in new Test {
           override def setup(): Unit = {
             (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
               .expects(*, *, *, *)
@@ -247,7 +247,7 @@ class VatCertificateControllerSpec extends ControllerBaseSpec {
           }
 
           private val result = target.show()(fakeRequest)
-          contentType(result) shouldBe Some("text/html")
+          redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
         }
       }
     }
@@ -337,19 +337,22 @@ class VatCertificateControllerSpec extends ControllerBaseSpec {
 
       }
 
-      "the user is unauthorised" should {
-        "return Unauthorised (401)" in new Test {
+      "the user is not signed in" should {
+
+        "return SEE_OTHER" in new Test {
           override val customerInfoCallExpected: Boolean = false
           override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
           private val result = target.changeClient()(fakeRequest)
-          status(result) shouldBe Status.UNAUTHORIZED
+
+          status(result) shouldBe Status.SEE_OTHER
         }
 
-        "return HTML" in new Test {
+        "redirect to sign in" in new Test {
           override val customerInfoCallExpected: Boolean = false
           override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
           private val result = target.changeClient()(fakeRequest)
-          contentType(result) shouldBe Some("text/html")
+
+          redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
         }
       }
     }
@@ -409,19 +412,21 @@ class VatCertificateControllerSpec extends ControllerBaseSpec {
 
       }
 
-      "the user is unauthorised" should {
-        "return Unauthorised (401)" in new Test {
+      "the user is not signed in" should {
+        "return SEE_OTHER" in new Test {
           override val customerInfoCallExpected: Boolean = false
           override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
           private val result = target.changeClientAction()(fakeRequest)
-          status(result) shouldBe Status.UNAUTHORIZED
+
+          status(result) shouldBe Status.SEE_OTHER
         }
 
-        "return HTML" in new Test {
+        "redirect to sign in" in new Test {
           override val customerInfoCallExpected: Boolean = false
           override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
           private val result = target.changeClientAction()(fakeRequest)
-          contentType(result) shouldBe Some("text/html")
+
+          redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
         }
       }
     }

--- a/test/controllers/VatDetailsControllerSpec.scala
+++ b/test/controllers/VatDetailsControllerSpec.scala
@@ -228,10 +228,12 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
     "user is an Agent" should {
 
-      "return 403 (Forbidden)" in new DetailsTest {
+      "redirect to Agent Action page" in new DetailsTest {
         override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = agentAuthResult
         val result: Future[Result] = target().details()(fakeRequest)
-        status(result) shouldBe Status.FORBIDDEN
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.agentClientLookupActionUrl)
       }
     }
 

--- a/test/controllers/VatDetailsControllerSpec.scala
+++ b/test/controllers/VatDetailsControllerSpec.scala
@@ -199,10 +199,12 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
     "the user is not logged in" should {
 
-      "return 401 (Unauthorised)" in new DetailsTest {
+      "return SEE_OTHER" in new DetailsTest {
         override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
         val result: Future[Result] = target().details()(fakeRequest)
-        status(result) shouldBe Status.UNAUTHORIZED
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
       }
     }
 


### PR DESCRIPTION
Also, when user is an agent but access is not allowed on the page, they are redirected to VACLUF agent action page