### PR TITLE
BTAT-6857 Corrected bug with hidden tab alongside previous payments

### DIFF
--- a/app/controllers/PaymentHistoryController.scala
+++ b/app/controllers/PaymentHistoryController.scala
@@ -145,7 +145,7 @@ class PaymentHistoryController @Inject()(val messagesApi: MessagesApi,
       case (Right(yearOneTrans), Right(yearTwoTrans)) =>
         val (tabOne, tabTwo) = generateTabs(yearOneTrans.isEmpty, yearTwoTrans.isEmpty, showPreviousPaymentsTab)
         val transactions = if(selectedYear == currentYear) yearOneTrans else yearTwoTrans
-        if (yearTwoTrans.isEmpty && selectedYear == previousYear) {
+        if (yearTwoTrans.isEmpty && selectedYear == previousYear && !showPreviousPaymentsTab) {
           None
         } else {
           Some(PaymentsHistoryViewModel(
@@ -162,7 +162,7 @@ class PaymentHistoryController @Inject()(val messagesApi: MessagesApi,
 
   def generateTabs(yearOneEmpty: Boolean, yearTwoEmpty: Boolean, showPreviousPaymentsTab: Boolean): (Option[Int], Option[Int]) =
     (yearOneEmpty, yearTwoEmpty) match {
-      case (true, true) if showPreviousPaymentsTab => (Some(currentYear), None)
+      case (true, true) if showPreviousPaymentsTab => (Some(currentYear), Some(previousYear))
       case (true, true) => (None, None)
       case (false, true) => (Some(currentYear), None)
       case _ => (Some(currentYear), Some(previousYear))

--- a/app/views/payments/paymentHistory.scala.html
+++ b/app/views/payments/paymentHistory.scala.html
@@ -98,7 +98,7 @@
           </table>
         }
         case (false, Some(year)) => {
-          <p class="lede">@messages("paymentsHistory.noCurrentYearHistory")</p>
+          <p>@messages("paymentsHistory.noCurrentYearHistory")</p>
         }
         case (false, None) => {
           <p>

--- a/test/controllers/PaymentHistoryControllerSpec.scala
+++ b/test/controllers/PaymentHistoryControllerSpec.scala
@@ -461,7 +461,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
         "return a PaymentsHistoryViewModel with the transactions from the current year" in new Test {
           target.generateViewModel(
-            serviceResultYearOne, serviceResultYearTwo, showPreviousPaymentsTab = false, currentYear
+            serviceResultYearOne, serviceResultYearTwo, showPreviousPaymentsTab = false, currentYear, None
           ) shouldBe Some(PaymentsHistoryViewModel(
             Some(currentYear),
             Some(currentYear - 1),
@@ -477,7 +477,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
         "return a PaymentsHistoryViewModel with the transactions from the previous year" in new Test {
           target.generateViewModel(
-            serviceResultYearOne, serviceResultYearTwo, showPreviousPaymentsTab = false, currentYear - 1
+            serviceResultYearOne, serviceResultYearTwo, showPreviousPaymentsTab = false, currentYear - 1, None
           ) shouldBe Some(PaymentsHistoryViewModel(
             Some(currentYear),
             Some(currentYear - 1),
@@ -494,7 +494,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
         "return None" in new Test {
           override val serviceResultYearTwo = Right(Seq.empty)
           target.generateViewModel(
-            serviceResultYearOne, serviceResultYearTwo, showPreviousPaymentsTab = false, currentYear - 1
+            serviceResultYearOne, serviceResultYearTwo, showPreviousPaymentsTab = false, currentYear - 1, None
           ) shouldBe None
         }
       }
@@ -505,7 +505,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
       "return None" in new Test {
         override val serviceResultYearOne = Left(VatLiabilitiesError)
         target.generateViewModel(
-          serviceResultYearOne, serviceResultYearTwo, showPreviousPaymentsTab = false, currentYear
+          serviceResultYearOne, serviceResultYearTwo, showPreviousPaymentsTab = false, currentYear, None
         ) shouldBe None
       }
     }
@@ -513,11 +513,21 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
   "Calling .generateTabs" when {
 
-    "both years are empty and the previous payments tab is enabled" should {
+    "the previous payments tab is enabled and user was migrated to ETMP in the current year" should {
 
-      "generate no tabs (None, None)" in new Test {
+      "generate only the first tab (Some, None)" in new Test {
         target.generateTabs(
-          yearOneEmpty = true, yearTwoEmpty = true, showPreviousPaymentsTab = false) shouldBe (None, None)
+          yearOneEmpty = true, yearTwoEmpty = true, showPreviousPaymentsTab = true, migratedThisYear = true
+        ) shouldBe (Some(currentYear), None)
+      }
+    }
+
+    "the previous payments tab is enabled and user was migrated to ETMP before the current year" should {
+
+      "generate both tabs (Some, Some)" in new Test {
+        target.generateTabs(
+          yearOneEmpty = true, yearTwoEmpty = true, showPreviousPaymentsTab = true, migratedThisYear = false
+        ) shouldBe (Some(currentYear), Some(currentYear - 1))
       }
     }
 
@@ -525,7 +535,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "generate no tabs (None, None)" in new Test {
         target.generateTabs(
-          yearOneEmpty = true, yearTwoEmpty = true, showPreviousPaymentsTab = false) shouldBe (None, None)
+          yearOneEmpty = true, yearTwoEmpty = true, showPreviousPaymentsTab = false, migratedThisYear = true
+        ) shouldBe (None, None)
       }
     }
 
@@ -533,7 +544,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "generate only the first tab (Some, None)" in new Test {
         target.generateTabs(
-          yearOneEmpty = false, yearTwoEmpty = true, showPreviousPaymentsTab = false) shouldBe (Some(currentYear), None)
+          yearOneEmpty = false, yearTwoEmpty = true, showPreviousPaymentsTab = false, migratedThisYear = true
+        ) shouldBe (Some(currentYear), None)
       }
     }
 
@@ -541,7 +553,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "generate both tabs (Some, Some)" in new Test {
         target.generateTabs(
-          yearOneEmpty = false, yearTwoEmpty = false, showPreviousPaymentsTab = false
+          yearOneEmpty = false, yearTwoEmpty = false, showPreviousPaymentsTab = false, migratedThisYear = true
         ) shouldBe (Some(currentYear), Some(currentYear - 1))
       }
     }
@@ -550,7 +562,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
 
       "generate both tabs (Some, Some)" in new Test {
         target.generateTabs(
-          yearOneEmpty = false, yearTwoEmpty = false, showPreviousPaymentsTab = false
+          yearOneEmpty = false, yearTwoEmpty = false, showPreviousPaymentsTab = false, migratedThisYear = true
         ) shouldBe (Some(currentYear), Some(currentYear - 1))
       }
     }


### PR DESCRIPTION
When the previous payments tab was clicked, because it does not call the financial data API, it has no scope of whether there are empty payments in a certain year. It only knows about the ETMP migration date. Therefore it needs to show the relevant year tabs (in all circumstances, i.e. when they click one of the years), even if they are empty.