### PR TITLE
Reintroduced 'overdue' flag to VAT summary and open payments page

### DIFF
--- a/app/controllers/OpenPaymentsController.scala
+++ b/app/controllers/OpenPaymentsController.scala
@@ -73,7 +73,10 @@ extends FrontendController with I18nSupport {
   private[controllers] def getModel(payments: Seq[Payment], hasActiveDirectDebit: Option[Boolean]): OpenPaymentsViewModel = {
     OpenPaymentsViewModel(
       payments.map { payment =>
-        OpenPaymentsModel(payment)
+        OpenPaymentsModel(
+          payment,
+          isOverdue = appConfig.features.ddCollectionInProgressEnabled() && payment.due.isBefore(dateService.now()) && !payment.ddCollectionInProgress
+        )
       },
       hasActiveDirectDebit
     )

--- a/app/models/payments/OpenPaymentsModel.scala
+++ b/app/models/payments/OpenPaymentsModel.scala
@@ -27,6 +27,7 @@ sealed trait OpenPaymentsModel {
   val amount: BigDecimal
   val due: LocalDate
   val periodKey: String
+  val isOverdue: Boolean
   def makePaymentRedirect: String
 }
 
@@ -37,28 +38,46 @@ object OpenPaymentsModel {
             due: LocalDate,
             periodFrom: LocalDate,
             periodTo: LocalDate,
-            periodKey: String): OpenPaymentsModel = OpenPaymentsModelWithPeriod(chargeType, amount, due, periodFrom, periodTo, periodKey)
+            periodKey: String,
+            isOverdue: Boolean): OpenPaymentsModel = OpenPaymentsModelWithPeriod(
+    chargeType,
+    amount,
+    due,
+    periodFrom,
+    periodTo,
+    periodKey,
+    isOverdue
+  )
 
   def apply(chargeType: ChargeType,
             amount: BigDecimal,
             due: LocalDate,
-            periodKey: String): OpenPaymentsModel = OpenPaymentsModelNoPeriod(chargeType, amount, due, periodKey)
+            periodKey: String,
+            isOverdue: Boolean): OpenPaymentsModel = OpenPaymentsModelNoPeriod(
+    chargeType,
+    amount,
+    due,
+    periodKey,
+    isOverdue
+  )
 
-  def apply(payment: Payment)(implicit messages: Messages): OpenPaymentsModel = payment match {
+  def apply(payment: Payment,
+            isOverdue: Boolean)(implicit messages: Messages): OpenPaymentsModel = payment match {
     case payment: PaymentWithPeriod => OpenPaymentsModelWithPeriod(
       payment.chargeType,
       payment.outstandingAmount,
       payment.due,
       payment.periodFrom,
       payment.periodTo,
-      payment.periodKey
-
+      payment.periodKey,
+      isOverdue
     )
     case payment: PaymentNoPeriod => OpenPaymentsModelNoPeriod(
       payment.chargeType,
       payment.outstandingAmount,
       payment.due,
-      payment.periodKey
+      payment.periodKey,
+      isOverdue
     )
   }
 
@@ -73,7 +92,8 @@ case class OpenPaymentsModelWithPeriod(chargeType: ChargeType,
                                        due: LocalDate,
                                        periodFrom: LocalDate,
                                        periodTo: LocalDate,
-                                       periodKey: String) extends OpenPaymentsModel {
+                                       periodKey: String,
+                                       isOverdue: Boolean) extends OpenPaymentsModel {
 
   override def makePaymentRedirect: String = controllers.routes.MakePaymentController.makePayment(
     amountInPence = (amount * 100).toLong,
@@ -100,7 +120,8 @@ object OpenPaymentsModelWithPeriod {
 case class OpenPaymentsModelNoPeriod(chargeType: ChargeType,
                                      amount: BigDecimal,
                                      due: LocalDate,
-                                     periodKey: String) extends OpenPaymentsModel {
+                                     periodKey: String,
+                                     isOverdue: Boolean) extends OpenPaymentsModel {
 
   override def makePaymentRedirect: String = controllers.routes.MakePaymentController.makePaymentNoPeriod(
     amountInPence = (amount * 100).toLong,

--- a/app/views/templates/nextPaymentSection.scala.html
+++ b/app/views/templates/nextPaymentSection.scala.html
@@ -19,8 +19,11 @@
 @import config.AppConfig
 @import views.templates.formatters.dates.DisplayDateRangeHelper.displayDate
 
-@(paymentsData: Option[String], hasMultiple: Boolean, isError: Boolean, isHybridUser: Boolean)(implicit messages: Messages, appConfig: AppConfig, user: User, lang: Lang)
-
+@(paymentsData: Option[String],
+  hasMultiple: Boolean,
+  isError: Boolean,
+  isHybridUser: Boolean,
+  isOverdue: Boolean)(implicit messages: Messages, appConfig: AppConfig, user: User, lang: Lang)
 
 <div class ="tile tile-no-border">
   <div id="payments" class="tile-body">
@@ -35,6 +38,11 @@
         case (Some(numOfPayments), true, _) => { @messages("vatDetails.paymentsDue", numOfPayments)}
         case _ => {
           @paymentsData.map(date => displayDate(LocalDate.parse(date))).getOrElse(messages("payment.noPayment"))
+          @if(isOverdue){
+            <span>
+                <strong class="task-overdue">@messages("common.overdue")</strong>
+            </span>
+          }
         }
       }
       </p>

--- a/app/views/templates/payments/whatYouOweChargeRow.scala.html
+++ b/app/views/templates/payments/whatYouOweChargeRow.scala.html
@@ -32,6 +32,9 @@
             <h2 class="bold heading-small what-you-owe-heading">@chargeDetails.title @chargeDescription.map { description => <div class="what-you-owe-subheading">@description</div> }</h2>
             <div data-due="@(payment.due.toString)" class="form-hint">
                 @messages("openPayments.dueBy") @displayDate(payment.due,useShortDayFormat = true)
+                @if(payment.isOverdue) {
+                    <span class="inline"><strong class="task-overdue">@messages("common.overdue")</strong></span>
+                }
             </div>
         </dt>
         <dd class="cya-answer what-you-owe-amount">

--- a/app/views/vatDetails/details.scala.html
+++ b/app/views/vatDetails/details.scala.html
@@ -45,7 +45,8 @@
           detailsViewModel.paymentsData,
           detailsViewModel.hasMultiplePayments,
           detailsViewModel.paymentError,
-          detailsViewModel.isHybridUser
+          detailsViewModel.isHybridUser,
+          detailsViewModel.paymentOverdue
       )
 
       @views.html.templates.nextReturnSection(

--- a/it/connectors/FinancialDataConnectorISpec.scala
+++ b/it/connectors/FinancialDataConnectorISpec.scala
@@ -50,7 +50,8 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           periodTo = LocalDate.parse("2015-03-31"),
           due = LocalDate.parse("2019-01-15"),
           outstandingAmount = 10000,
-          periodKey = "15AC"
+          periodKey = "15AC",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           chargeType = ReturnDebitCharge,
@@ -58,7 +59,8 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           periodTo = LocalDate.parse("2015-03-31"),
           due = LocalDate.parse("2019-01-16"),
           outstandingAmount = 10000,
-          periodKey = "15AC"
+          periodKey = "15AC",
+          ddCollectionInProgress = false
         )
       )))
 

--- a/test/audit/ViewNextOutstandingVatPaymentAuditModelSpec.scala
+++ b/test/audit/ViewNextOutstandingVatPaymentAuditModelSpec.scala
@@ -33,7 +33,8 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends UnitSpec {
         LocalDate.parse("2017-03-01"),
         LocalDate.parse("2017-03-08"),
         9999,
-        Some("#001")
+        Some("#001"),
+        ddCollectionInProgress = false
       )
     )
   )
@@ -46,7 +47,8 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends UnitSpec {
         LocalDate.parse("2017-03-01"),
         LocalDate.parse("2017-03-08"),
         9999,
-        Some("#001")
+        Some("#001"),
+        ddCollectionInProgress = false
       ),
       Payment(
         ReturnDebitCharge,
@@ -54,7 +56,8 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends UnitSpec {
         LocalDate.parse("2017-04-01"),
         LocalDate.parse("2017-05-08"),
         7777,
-        Some("#002")
+        Some("#002"),
+        ddCollectionInProgress = false
       )
     )
   )

--- a/test/common/TestModels.scala
+++ b/test/common/TestModels.scala
@@ -38,7 +38,8 @@ object TestModels {
     LocalDate.parse("2019-02-02"),
     LocalDate.parse("2019-03-03"),
     1,
-    Some("#001")
+    Some("#001"),
+    ddCollectionInProgress = false
   )))
 
   val obligations: VatReturnObligations = VatReturnObligations(Seq(VatReturnObligation(

--- a/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
@@ -506,7 +506,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2017-01-01"),
           due = LocalDate.parse("2017-10-25"),
           outstandingAmount = BigDecimal(1000.50),
-          periodKey = "#001"
+          periodKey = "#001",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           ReturnCreditCharge,
@@ -514,7 +515,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2018-01-01"),
           due = LocalDate.parse("2018-10-25"),
           outstandingAmount = BigDecimal(1000.51),
-          periodKey = "#002"
+          periodKey = "#002",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           OACreditCharge,
@@ -522,7 +524,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2018-01-01"),
           due = LocalDate.parse("2017-10-25"),
           outstandingAmount = BigDecimal(1000.52),
-          periodKey = "#003"
+          periodKey = "#003",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           OADebitCharge,
@@ -530,7 +533,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2018-01-01"),
           due = LocalDate.parse("2017-10-25"),
           outstandingAmount = BigDecimal(1000.53),
-          periodKey = "#004"
+          periodKey = "#004",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           CentralAssessmentCharge,
@@ -538,7 +542,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2017-01-01"),
           due = LocalDate.parse("2016-10-25"),
           outstandingAmount = BigDecimal(1000.25),
-          periodKey = "#005"
+          periodKey = "#005",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           DefaultSurcharge,
@@ -546,7 +551,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.27),
-          periodKey = "#006"
+          periodKey = "#006",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           ErrorCorrectionCreditCharge,
@@ -554,7 +560,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.29),
-          periodKey = "#007"
+          periodKey = "#007",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           ErrorCorrectionDebitCharge,
@@ -562,7 +569,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.30),
-          periodKey = "#007"
+          periodKey = "#007",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           AAInterestCharge,
@@ -570,7 +578,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.30),
-          periodKey = "#008"
+          periodKey = "#008",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           AAReturnDebitCharge,
@@ -578,7 +587,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.30),
-          periodKey = "#009"
+          periodKey = "#009",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           AAReturnCreditCharge,
@@ -586,7 +596,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.30),
-          periodKey = "#010"
+          periodKey = "#010",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           AAMonthlyInstalment,
@@ -594,7 +605,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.30),
-          periodKey = "#011"
+          periodKey = "#011",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           AAQuarterlyInstalments,
@@ -602,7 +614,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.30),
-          periodKey = "#012"
+          periodKey = "#012",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           OADefaultInterestCharge,
@@ -610,7 +623,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.30),
-          periodKey = "#018"
+          periodKey = "#018",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           AACharge,
@@ -618,7 +632,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2016-06-21"),
           due = LocalDate.parse("2016-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#009"
+          periodKey = "#009",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           OAFurtherInterestCharge,
@@ -626,7 +641,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2016-06-21"),
           due = LocalDate.parse("2016-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#010"
+          periodKey = "#010",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           BnpRegPre2010Charge,
@@ -634,7 +650,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2015-06-21"),
           due = LocalDate.parse("2015-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#019"
+          periodKey = "#019",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           BnpRegPost2010Charge,
@@ -642,7 +659,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2015-06-21"),
           due = LocalDate.parse("2015-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#011"
+          periodKey = "#011",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           FtnMatPre2010Charge,
@@ -650,7 +668,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2014-06-21"),
           due = LocalDate.parse("2014-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#012"
+          periodKey = "#012",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           FtnMatPost2010Charge,
@@ -658,7 +677,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2013-06-21"),
           due = LocalDate.parse("2013-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#013"
+          periodKey = "#013",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           MiscPenaltyCharge,
@@ -666,7 +686,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2012-06-21"),
           due = LocalDate.parse("2012-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#014"
+          periodKey = "#014",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           FtnEachPartnerCharge,
@@ -674,7 +695,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2011-06-21"),
           due = LocalDate.parse("2011-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#015"
+          periodKey = "#015",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           MpPre2009Charge,
@@ -682,7 +704,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2010-06-21"),
           due = LocalDate.parse("2010-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#016"
+          periodKey = "#016",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           MpRepeatedPre2009Charge,
@@ -690,7 +713,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2009-06-21"),
           due = LocalDate.parse("2009-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#017"
+          periodKey = "#017",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           CivilEvasionPenaltyCharge,
@@ -698,7 +722,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2008-06-21"),
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = "#018"
+          periodKey = "#018",
+          ddCollectionInProgress = false
         ),
         Payment(
           VatOAInaccuraciesFrom2009,
@@ -706,7 +731,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2017-06-21"),
           due = LocalDate.parse("2017-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#020")
+          periodKey = Some("#020"),
+          ddCollectionInProgress = false
         ),
         Payment(
           InaccuraciesAssessmentsPenCharge,
@@ -714,7 +740,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2008-06-21"),
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         ),
         Payment(
           InaccuraciesReturnReplacedCharge,
@@ -722,7 +749,8 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2008-06-21"),
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         ),
         Payment(
           CarterPenaltyCharge,
@@ -730,43 +758,50 @@ class PaymentsHttpParserSpec extends UnitSpec {
           periodTo = LocalDate.parse("2008-06-21"),
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         ),
         Payment(
           WrongDoingPenaltyCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         ),
         Payment(
           FailureToSubmitRCSLCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         ),
         Payment(
           FailureToNotifyRCSLCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         ),
         Payment(
           PaymentOnAccountInstalments,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         ),
         Payment(
           PaymentOnAccountReturnDebitCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         ),
         Payment(
           PaymentOnAccountReturnCreditCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
-          periodKey = Some("#018")
+          periodKey = Some("#018"),
+          ddCollectionInProgress = false
         )
       )))
 

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -70,10 +70,12 @@ class ControllerBaseSpec extends UnitSpec with MockFactory with GuiceOneAppPerSu
   override def beforeEach(): Unit = {
     super.beforeEach()
     mockAppConfig.features.agentAccess(true)
+    mockAppConfig.features.ddCollectionInProgressEnabled(true)
   }
 
   override def afterEach(): Unit = {
     super.afterEach()
     mockAppConfig.features.agentAccess(true)
+    mockAppConfig.features.ddCollectionInProgressEnabled(true)
   }
 }

--- a/test/controllers/OpenPaymentsControllerSpec.scala
+++ b/test/controllers/OpenPaymentsControllerSpec.scala
@@ -74,14 +74,16 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
       LocalDate.parse("2017-01-01"),
       LocalDate.parse("2017-01-01"),
       BigDecimal("10000"),
-      Some("ABCD")
+      Some("ABCD"),
+      ddCollectionInProgress = false
     )
 
     val paymentOnAccount = Payment(
       PaymentOnAccount,
       LocalDate.parse("2017-01-01"),
       BigDecimal("0"),
-      None
+      None,
+      ddCollectionInProgress = false
     )
 
     val mockAuthConnector: AuthConnector = mock[AuthConnector]

--- a/test/controllers/OpenPaymentsControllerSpec.scala
+++ b/test/controllers/OpenPaymentsControllerSpec.scala
@@ -390,27 +390,161 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
       }
     }
 
-    "Calling the .getModel function" should {
+    "Calling the .getModel function" when {
 
-      "return a sequence of OpenPaymentsModel" in new Test {
-        override def setupMocks(): Unit = (
-          mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01")
-        )
+      "ddCollectionInProgressEnabled feature switch is on" when {
 
-        val expected = OpenPaymentsViewModel(
-          Seq(OpenPaymentsModel(
-            ReturnDebitCharge,
-            payment.outstandingAmount,
-            payment.due,
-            payment.periodFrom,
-            payment.periodTo,
-            payment.periodKey
-          )),
-          Some(true)
-        )
-        val result: OpenPaymentsViewModel = target.getModel(Seq(payment), Some(true))
+        "due date of payments is in the past" when {
 
-        result shouldBe expected
+          "user has direct debit collections in progress" should {
+
+            "return payments that are not overdue" in new Test {
+
+              override def setupMocks(): Unit = (
+                mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01")
+              )
+
+              val testPayment: PaymentWithPeriod = Payment(
+                ReturnDebitCharge,
+                LocalDate.parse("2017-01-01"),
+                LocalDate.parse("2017-01-01"),
+                due = LocalDate.parse("2017-01-01"),
+                BigDecimal("10000"),
+                Some("ABCD"),
+                ddCollectionInProgress = true
+              )
+
+              val expected = OpenPaymentsViewModel(
+                Seq(OpenPaymentsModel(
+                  testPayment.chargeType,
+                  testPayment.outstandingAmount,
+                  testPayment.due,
+                  testPayment.periodFrom,
+                  testPayment.periodTo,
+                  testPayment.periodKey,
+                  isOverdue = false
+                )),
+                Some(true)
+              )
+              val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment), Some(true))
+
+              result shouldBe expected
+            }
+          }
+
+          "user has no direct debit collections in progress" should {
+
+            "return payments that are overdue" in new Test {
+
+              override def setupMocks(): Unit = (
+                mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01")
+              )
+
+              val testPayment: PaymentWithPeriod = Payment(
+                ReturnDebitCharge,
+                LocalDate.parse("2017-01-01"),
+                LocalDate.parse("2017-01-01"),
+                due = LocalDate.parse("2017-01-01"),
+                BigDecimal("10000"),
+                Some("ABCD"),
+                ddCollectionInProgress = false
+              )
+
+              val expected = OpenPaymentsViewModel(
+                Seq(OpenPaymentsModel(
+                  testPayment.chargeType,
+                  testPayment.outstandingAmount,
+                  testPayment.due,
+                  testPayment.periodFrom,
+                  testPayment.periodTo,
+                  testPayment.periodKey,
+                  isOverdue = true
+                )),
+                Some(true)
+              )
+              val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment), Some(true))
+
+              result shouldBe expected
+            }
+          }
+        }
+
+        "due date of payments is in the future" should {
+
+          "return payments that are not overdue" in new Test {
+
+            override def setupMocks(): Unit = (
+              mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01")
+            )
+
+            val testPayment: PaymentWithPeriod = Payment(
+              ReturnDebitCharge,
+              LocalDate.parse("2017-01-01"),
+              LocalDate.parse("2017-01-01"),
+              due = LocalDate.parse("2020-01-01"),
+              BigDecimal("10000"),
+              Some("ABCD"),
+              ddCollectionInProgress = false
+            )
+
+            val expected = OpenPaymentsViewModel(
+              Seq(OpenPaymentsModel(
+                testPayment.chargeType,
+                testPayment.outstandingAmount,
+                testPayment.due,
+                testPayment.periodFrom,
+                testPayment.periodTo,
+                testPayment.periodKey,
+                isOverdue = false
+              )),
+              Some(true)
+            )
+            val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment), Some(true))
+
+            result shouldBe expected
+          }
+        }
+      }
+
+      "ddCollectionInProgressEnabled feature switch is off" when {
+
+        "due date of payments are in the past and have no direct debit" should {
+
+          "return payments that are not overdue" in new Test {
+
+            mockAppConfig.features.ddCollectionInProgressEnabled(false)
+
+            override def setupMocks(): Unit = (
+              mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01")
+            )
+
+            val testPayment: PaymentWithPeriod = Payment(
+              ReturnDebitCharge,
+              LocalDate.parse("2017-01-01"),
+              LocalDate.parse("2017-01-01"),
+              due = LocalDate.parse("2017-01-01"),
+              BigDecimal("10000"),
+              Some("ABCD"),
+              ddCollectionInProgress = false
+            )
+
+            val expected = OpenPaymentsViewModel(
+              Seq(OpenPaymentsModel(
+                testPayment.chargeType,
+                testPayment.outstandingAmount,
+                testPayment.due,
+                testPayment.periodFrom,
+                testPayment.periodTo,
+                testPayment.periodKey,
+                isOverdue = false
+              )),
+              Some(true)
+            )
+            val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment), Some(true))
+
+            result shouldBe expected
+          }
+        }
       }
     }
   }

--- a/test/controllers/VatDetailsControllerSpec.scala
+++ b/test/controllers/VatDetailsControllerSpec.scala
@@ -27,7 +27,7 @@ import controllers.predicates.{AgentPredicate, HybridUserPredicate}
 import models._
 import models.errors.{BadRequestError, NextPaymentError, ObligationsError}
 import models.obligations.{VatReturnObligation, VatReturnObligations}
-import models.payments.{Payment, PaymentNoPeriod, PaymentWithPeriod, Payments, ReturnDebitCharge}
+import models.payments.{Payment, PaymentNoPeriod, Payments, ReturnDebitCharge}
 import models.viewModels.VatDetailsViewModel
 import play.api.http.Status
 import play.api.mvc.{AnyContentAsEmpty, Request, Result}

--- a/test/controllers/VatDetailsControllerSpec.scala
+++ b/test/controllers/VatDetailsControllerSpec.scala
@@ -27,7 +27,7 @@ import controllers.predicates.{AgentPredicate, HybridUserPredicate}
 import models._
 import models.errors.{BadRequestError, NextPaymentError, ObligationsError}
 import models.obligations.{VatReturnObligation, VatReturnObligations}
-import models.payments.Payments
+import models.payments.{Payment, PaymentNoPeriod, PaymentWithPeriod, Payments, ReturnDebitCharge}
 import models.viewModels.VatDetailsViewModel
 import play.api.http.Status
 import play.api.mvc.{AnyContentAsEmpty, Request, Result}
@@ -283,7 +283,7 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
       }
     }
 
-    "the feature switch is turned off" should {
+    "the submit return feature switch is turned off" should {
       "the View Returns link should be displayed" in new DetailsTest {
         mockAppConfig.features.submitReturnFeatures(false)
         lazy val result: Future[Result] = target().details()(fakeRequest)
@@ -292,7 +292,7 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
       }
     }
 
-    "the feature switch is turned on" should {
+    "the submit return feature switch is turned on" should {
       "return a VatDetailsViewModel as a non MTDfB user" in new DetailsTest {
         (mockMandationService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
           .expects(*, *, *)
@@ -499,9 +499,9 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
     }
   }
 
-  "Calling .getObligationFlags" when {
+  "Calling .getObligationDetails" when {
 
-    "there is a single due obligation" should {
+    "there is a single obligation" should {
 
       "return a VatDetailsDataModel with the correct data" in new DetailsTest {
 
@@ -512,23 +512,7 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
           hasError = false
         )
 
-        val result: VatDetailsDataModel = target().getObligationFlags(obligations.obligations)
-        result shouldBe expected
-      }
-    }
-
-    "there is a single overdue obligation" should {
-
-      "return a VatDetailsDataModel with the overdue flag set" in new DetailsTest {
-
-        val expected = VatDetailsDataModel(
-          Some("2017-06-06"),
-          hasMultiple = false,
-          isOverdue = true,
-          hasError = false
-        )
-
-        val result: VatDetailsDataModel = target().getObligationFlags(overdueObligations.obligations)
+        val result: VatDetailsDataModel = target().getObligationDetails(obligations.obligations, isOverdue = false)
         result shouldBe expected
       }
     }
@@ -563,14 +547,149 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
           hasError = false
         )
 
-        val result: VatDetailsDataModel = target().getObligationFlags(multipleObligations)
+        val result: VatDetailsDataModel = target().getObligationDetails(multipleObligations, isOverdue = false)
         result shouldBe expected
       }
     }
   }
 
+  "Calling .getPaymentObligationDetails" when {
+
+    "there is at least one obligation" when {
+
+      "ddCollectionInProgressEnabled feature switch is on" when {
+
+        "due date of payment is in the past" when {
+
+          "user has direct debit collection in progress" should {
+
+            "return payment that is not overdue" in new DetailsTest {
+
+              mockAppConfig.features.ddCollectionInProgressEnabled(true)
+
+              val testPayment: PaymentNoPeriod = Payment(
+                ReturnDebitCharge,
+                due = LocalDate.parse("2017-01-01"),
+                BigDecimal("10000"),
+                Some("ABCD"),
+                ddCollectionInProgress = true
+              )
+
+              val result: VatDetailsDataModel = target().getPaymentObligationDetails(Seq(testPayment))
+
+              result.isOverdue shouldBe false
+            }
+          }
+
+          "user has no direct debit collection in progress" should {
+
+            "return payment that is overdue" in new DetailsTest {
+
+              mockAppConfig.features.ddCollectionInProgressEnabled(true)
+
+              val testPayment: PaymentNoPeriod = Payment(
+                ReturnDebitCharge,
+                due = LocalDate.parse("2017-01-01"),
+                BigDecimal("10000"),
+                Some("ABCD"),
+                ddCollectionInProgress = false
+              )
+
+              val result: VatDetailsDataModel = target().getPaymentObligationDetails(Seq(testPayment))
+
+              result.isOverdue shouldBe true
+            }
+          }
+        }
+
+        "due date of payment is in the future" should {
+
+          "return payment that is not overdue" in new DetailsTest {
+
+            mockAppConfig.features.ddCollectionInProgressEnabled(true)
+
+            val testPayment: PaymentNoPeriod = Payment(
+              ReturnDebitCharge,
+              due = LocalDate.parse("2020-01-01"),
+              BigDecimal("10000"),
+              Some("ABCD"),
+              ddCollectionInProgress = false
+            )
+
+            val result: VatDetailsDataModel = target().getPaymentObligationDetails(Seq(testPayment))
+
+            result.isOverdue shouldBe false
+          }
+        }
+      }
+
+      "ddCollectionInProgressEnabled feature switch is off" when {
+
+        "due date of payment is in the past and has no direct debit" should {
+
+          "return payment that isn't not overdue" in new DetailsTest {
+
+            mockAppConfig.features.ddCollectionInProgressEnabled(false)
+
+            val testPayment: PaymentNoPeriod = Payment(
+              ReturnDebitCharge,
+              due = LocalDate.parse("2017-01-01"),
+              BigDecimal("10000"),
+              Some("ABCD"),
+              ddCollectionInProgress = false
+            )
+
+            val result: VatDetailsDataModel = target().getPaymentObligationDetails(Seq(testPayment))
+
+            result.isOverdue shouldBe false
+          }
+        }
+      }
+    }
+  }
+
+  "Calling .getReturnObligationDetails" when {
+
+    "there is at least one obligation" when {
+
+      "obligation is overdue" should {
+
+        "return VatDetailsDataModel with overdue flag set to true" in new DetailsTest {
+
+          val expected = VatDetailsDataModel(
+            displayData = Some("2017-06-06"),
+            hasMultiple = false,
+            isOverdue = true,
+            hasError = false
+          )
+
+          val result: VatDetailsDataModel = target().getReturnObligationDetails(overdueObligations.obligations)
+          result shouldBe expected
+        }
+      }
+
+      "obligation is not overdue" should {
+
+        "return VatDetailsDataModel with overdue flag set to false" in new DetailsTest {
+
+          val expected = VatDetailsDataModel(
+            displayData = Some("2019-06-06"),
+            hasMultiple = false,
+            isOverdue = false,
+            hasError = false
+          )
+
+          val result: VatDetailsDataModel = target().getReturnObligationDetails(obligations.obligations)
+          result shouldBe expected
+        }
+      }
+    }
+  }
+
   "Calling .retrieveMandationStatus" should {
+
     "return a mandation status" when {
+
       "it is available in session" in new DetailsTest {
         implicit val fakeRequestWithSession: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession(
           "mtdVatMandationStatus" -> "Non MTDfB"
@@ -580,6 +699,7 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
         await(result) shouldBe Right(MandationStatus("Non MTDfB"))
       }
+
       "it is needs to be collected from the mandation service" in new DetailsTest {
         implicit val fakeRequestWithEmptySession: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession()
 
@@ -594,7 +714,9 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
         await(result) shouldBe Right(MandationStatus("Non MTDfB"))
       }
     }
+
     "return a HTTP error" when {
+
       "one is received from the mandation service layer" in new DetailsTest {
         (mockMandationService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
           .expects(*, *, *)

--- a/test/models/payments/OpenPaymentsModelSpec.scala
+++ b/test/models/payments/OpenPaymentsModelSpec.scala
@@ -29,7 +29,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
       periodTo = LocalDate.parse("2001-03-31"),
       due = LocalDate.parse("2003-04-05"),
       outstandingAmount = 300.00,
-      periodKey = Some("#003")
+      periodKey = Some("#003"),
+      ddCollectionInProgress = false
     )
   )
 
@@ -38,7 +39,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
       chargeType = OADebitCharge,
       due = LocalDate.parse("2003-04-05"),
       outstandingAmount = 300.00,
-      periodKey = Some("#003")
+      periodKey = Some("#003"),
+      ddCollectionInProgress = false
     )
   )
 

--- a/test/models/payments/OpenPaymentsModelSpec.scala
+++ b/test/models/payments/OpenPaymentsModelSpec.scala
@@ -31,7 +31,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
       outstandingAmount = 300.00,
       periodKey = Some("#003"),
       ddCollectionInProgress = false
-    )
+    ),
+    isOverdue = false
   )
 
   val openPaymentsModelNoPeriod: OpenPaymentsModel = OpenPaymentsModel(
@@ -41,7 +42,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
       outstandingAmount = 300.00,
       periodKey = Some("#003"),
       ddCollectionInProgress = false
-    )
+    ),
+    isOverdue = false
   )
 
   "OpenPaymentsModel" when {
@@ -58,7 +60,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
             due = LocalDate.parse("2003-04-05"),
             periodFrom = LocalDate.parse("2001-01-01"),
             periodTo = LocalDate.parse("2001-03-31"),
-            periodKey = "#003"
+            periodKey = "#003",
+            isOverdue = false
           )
 
           openPaymentsModelWithPeriod shouldBe regularApply
@@ -73,7 +76,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
             chargeType = OADebitCharge,
             amount = 300.00,
             due = LocalDate.parse("2003-04-05"),
-            periodKey = "#003"
+            periodKey = "#003",
+            isOverdue = false
           )
 
           openPaymentsModelNoPeriod shouldBe regularApply
@@ -140,7 +144,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
         chargeType = OADebitCharge,
         due = LocalDate.parse("2003-04-05"),
         amount = 300.00,
-        periodKey = "#003"
+        periodKey = "#003",
+        isOverdue = false
       )
 
       val expectedJson = Json.parse(
@@ -182,7 +187,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
         periodFrom = LocalDate.parse("2001-01-01"),
         periodTo = LocalDate.parse("2001-03-31"),
         amount = 300.00,
-        periodKey = "#003"
+        periodKey = "#003",
+        isOverdue = false
       )
 
       val expectedJson = Json.parse(

--- a/test/models/payments/PaymentSpec.scala
+++ b/test/models/payments/PaymentSpec.scala
@@ -29,7 +29,7 @@ class PaymentSpec extends UnitSpec {
     val endDate = "2017-03-01"
     val dueDate = "2017-03-08"
 
-    "given a start and end date" should {
+    "given a start and end date and no direct debit collection flag" should {
 
       "write to Json correctly" in {
         val paymentJson = Json.obj(
@@ -51,15 +51,16 @@ class PaymentSpec extends UnitSpec {
           periodTo = LocalDate.parse(endDate),
           due = LocalDate.parse(dueDate),
           outstandingAmount = 9999,
-          periodKey = "#001"
+          periodKey = "#001",
+          ddCollectionInProgress = false
         )
         paymentJson.as[Payment] shouldBe paymentWithPeriodModel
       }
     }
 
-    "not given a start and end date" should {
+    "not given a start and end date and no direct debit collection flag" should {
 
-      "write to Json correctly" in {
+      "read from Json correctly" in {
         val paymentJson = Json.obj(
           "chargeType" -> ReturnDebitCharge.value,
           "items" -> Json.arr(
@@ -75,7 +76,8 @@ class PaymentSpec extends UnitSpec {
           chargeType = ReturnDebitCharge,
           due = LocalDate.parse(dueDate),
           outstandingAmount = -9999,
-          periodKey = "#001"
+          periodKey = "#001",
+          ddCollectionInProgress = false
         )
         paymentJson.as[Payment] shouldBe paymentNoPeriodModel
       }
@@ -83,7 +85,7 @@ class PaymentSpec extends UnitSpec {
 
     "not given only a start or an end date" should {
 
-      "write to Json correctly" in {
+      "read from Json correctly" in {
         val paymentJson = Json.obj(
           "chargeType" -> ReturnDebitCharge.value,
           "taxPeriodFrom" -> startDate,
@@ -103,6 +105,35 @@ class PaymentSpec extends UnitSpec {
       }
     }
 
-  }
+    "given a direct debit collection flag" should {
 
+      val paymentJson = Json.obj(
+        "chargeType" -> ReturnDebitCharge.value,
+        "taxPeriodFrom" -> startDate,
+        "taxPeriodTo" -> endDate,
+        "items" -> Json.arr(
+          Json.obj(
+            "dueDate" -> dueDate,
+            "DDCollectionInProgress" -> true
+          )
+        ),
+        "outstandingAmount" -> 0,
+        "periodKey" -> "#001"
+      )
+
+      val model = PaymentWithPeriod(
+        chargeType = ReturnDebitCharge,
+        periodFrom = LocalDate.parse(startDate),
+        periodTo = LocalDate.parse(endDate),
+        due = LocalDate.parse(dueDate),
+        outstandingAmount = 0,
+        periodKey = "#001",
+        ddCollectionInProgress = true
+      )
+
+      "read from json correctly" in {
+        paymentJson.as[Payment] shouldBe model
+      }
+    }
+  }
 }

--- a/test/models/payments/PaymentsSpec.scala
+++ b/test/models/payments/PaymentsSpec.scala
@@ -31,7 +31,8 @@ class PaymentsSpec extends UnitSpec {
       LocalDate.parse("2017-03-01"),
       LocalDate.parse("2017-03-08"),
       9999,
-      "#001"
+      "#001",
+      ddCollectionInProgress = false
     )
 
     val exampleInputString =
@@ -62,7 +63,8 @@ class PaymentsSpec extends UnitSpec {
           LocalDate.parse("2017-03-01"),
           LocalDate.parse("2017-03-08"),
           9999,
-          "#001"
+          "#001",
+          ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
           ReturnCreditCharge,
@@ -70,7 +72,8 @@ class PaymentsSpec extends UnitSpec {
           LocalDate.parse("2017-04-01"),
           LocalDate.parse("2017-05-08"),
           7777,
-          "#002"
+          "#002",
+          ddCollectionInProgress = false
         )
       )
     )

--- a/test/services/PaymentsServiceSpec.scala
+++ b/test/services/PaymentsServiceSpec.scala
@@ -65,7 +65,8 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
           LocalDate.parse("2009-01-01"),
           LocalDate.parse("2008-11-29"),
           BigDecimal("21.22"),
-          ""
+          "",
+          ddCollectionInProgress = false
         )
         val payment2 = PaymentWithPeriod(
           ReturnDebitCharge,
@@ -73,7 +74,8 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
           LocalDate.parse("2009-01-01"),
           LocalDate.parse("2008-12-01"),
           BigDecimal("21.22"),
-          ""
+          "",
+          ddCollectionInProgress = false
         )
         val payment3 = PaymentWithPeriod(
           ReturnDebitCharge,
@@ -81,7 +83,8 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
           LocalDate.parse("2009-01-01"),
           LocalDate.parse("2009-01-01"),
           BigDecimal("21.22"),
-          ""
+          "",
+          ddCollectionInProgress = false
         )
         val payment4 = PaymentWithPeriod(
           ReturnDebitCharge,
@@ -89,7 +92,8 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
           LocalDate.parse("2009-01-01"),
           LocalDate.parse("2008-11-30"),
           BigDecimal("21.22"),
-          ""
+          "",
+          ddCollectionInProgress = false
         )
 
         val payments = Payments(Seq(payment1, payment2, payment3, payment4))
@@ -110,7 +114,8 @@ class PaymentsServiceSpec extends UnitSpec with MockFactory with Matchers {
           LocalDate.parse("2009-01-04"),
           LocalDate.parse("2008-12-06"),
           BigDecimal("-1000"),
-          ""
+          "",
+          ddCollectionInProgress = false
         )))
         override val responseFromFinancialDataConnector = Right(payments)
         val paymentsResponse: ServiceResponse[Option[Payments]] = await(target.getOpenPayments("123456789"))

--- a/test/services/VatDetailsServiceSpec.scala
+++ b/test/services/VatDetailsServiceSpec.scala
@@ -51,7 +51,8 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
         periodTo = LocalDate.parse("2017-12-22"),
         due = LocalDate.parse("2017-12-26"),
         outstandingAmount = BigDecimal(1000.00),
-        periodKey = "#003"
+        periodKey = "#003",
+        ddCollectionInProgress = false
       ),
       PaymentWithPeriod(
         ReturnDebitCharge,
@@ -59,7 +60,8 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
         periodTo = LocalDate.parse("2016-12-22"),
         due = LocalDate.parse("2016-12-26"),
         outstandingAmount = BigDecimal(1000.00),
-        periodKey = "#003"
+        periodKey = "#003",
+        ddCollectionInProgress = false
       ),
       PaymentWithPeriod(
         ReturnDebitCharge,
@@ -67,7 +69,8 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
         periodTo = LocalDate.parse("2015-12-22"),
         due = LocalDate.parse("2015-12-26"),
         outstandingAmount = BigDecimal(1000.00),
-        periodKey = "#003"
+        periodKey = "#003",
+        ddCollectionInProgress = false
       ),
       PaymentWithPeriod(
         ReturnDebitCharge,
@@ -75,7 +78,8 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
         periodTo = LocalDate.parse("2011-12-22"),
         due = LocalDate.parse("2011-12-26"),
         outstandingAmount = BigDecimal(1000.00),
-        periodKey = "#003"
+        periodKey = "#003",
+        ddCollectionInProgress = false
       ),
       PaymentWithPeriod(
         ReturnDebitCharge,
@@ -83,7 +87,8 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
         periodTo = LocalDate.parse("2013-12-22"),
         due = LocalDate.parse("2013-12-26"),
         outstandingAmount = BigDecimal(1000.00),
-        periodKey = "#003"
+        periodKey = "#003",
+        ddCollectionInProgress = false
       )))
     lazy val paymentsResult: HttpGetResult[Payments] = Right(payments)
     val paymentsCall: Boolean = false

--- a/test/views/payments/OpenPaymentsViewSpec.scala
+++ b/test/views/payments/OpenPaymentsViewSpec.scala
@@ -74,7 +74,8 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
       due = LocalDate.parse("2001-04-08"),
       periodFrom = LocalDate.parse("2001-01-01"),
       periodTo = LocalDate.parse("2001-03-31"),
-      periodKey = "#001"
+      periodKey = "#001",
+      isOverdue = false
     ),
     OpenPaymentsModelWithPeriod(
       AAInterestCharge,
@@ -82,7 +83,8 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
       LocalDate.parse("2003-04-05"),
       LocalDate.parse("2003-01-01"),
       LocalDate.parse("2003-03-31"),
-      "#003"
+      "#003",
+      isOverdue = false
     )
   )
 
@@ -289,7 +291,8 @@ class OpenPaymentsViewSpec extends ViewBaseSpec {
             due = LocalDate.parse("2008-04-08"),
             periodFrom = LocalDate.parse("2018-01-01"),
             periodTo = LocalDate.parse("2018-02-01"),
-            periodKey = "#001"
+            periodKey = "#001",
+            isOverdue = false
           )),
           hasDirectDebit = Some(false)
         ),

--- a/test/views/templates/NextPaymentSectionTemplateSpec.scala
+++ b/test/views/templates/NextPaymentSectionTemplateSpec.scala
@@ -34,24 +34,50 @@ class NextPaymentSectionTemplateSpec extends ViewBaseSpec {
       val portalLink = "a"
     }
 
-    "there is a payment to display" should {
+    "there is a payment to display" when {
 
-      lazy val view = views.html.templates.nextPaymentSection(Some("2017-03-08"),
-        hasMultiple = false,
-        isError = false,
-        isHybridUser = false)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
+      "payment is not overdue" should {
 
-      "display the 'Next payment due' heading" in {
-        elementText(Selectors.nextPaymentDueHeading) shouldBe "Next payment due"
+        lazy val view = views.html.templates.nextPaymentSection(
+          Some("2017-03-08"),
+          hasMultiple = false,
+          isError = false,
+          isHybridUser = false,
+          isOverdue = false
+        )
+        lazy implicit val document: Document = Jsoup.parse(view.body)
+
+        "display the 'Next payment due' heading" in {
+          elementText(Selectors.nextPaymentDueHeading) shouldBe "Next payment due"
+        }
+
+        "display the due date of the payment" in {
+          elementText(Selectors.nextPaymentDate) shouldBe "8 March 2017"
+        }
+
+        "display the 'View payment details' button" in {
+          elementText(Selectors.viewPaymentButton) shouldBe "Check what you owe"
+        }
+
+        "not display overdue flag" in {
+          elementExtinct(".task-overdue")
+        }
       }
 
-      "display the due date of the payment" in {
-        elementText(Selectors.nextPaymentDate) shouldBe "8 March 2017"
-      }
+      "payment is overdue" should {
 
-      "display the 'View payment details' button" in {
-        elementText(Selectors.viewPaymentButton) shouldBe "Check what you owe"
+        lazy val view = views.html.templates.nextPaymentSection(
+          Some("2017-03-08"),
+          hasMultiple = false,
+          isError = false,
+          isHybridUser = false,
+          isOverdue = true
+        )
+        lazy implicit val document: Document = Jsoup.parse(view.body)
+
+        "display overdue flag" in {
+          elementText(".task-overdue")shouldBe "overdue"
+        }
       }
     }
 
@@ -60,7 +86,9 @@ class NextPaymentSectionTemplateSpec extends ViewBaseSpec {
       lazy val view = views.html.templates.nextPaymentSection(None,
         hasMultiple = false,
         isError = false,
-        isHybridUser = false)
+        isHybridUser = false,
+        isOverdue = false
+      )
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "display the 'Next payment due' heading" in {
@@ -81,7 +109,9 @@ class NextPaymentSectionTemplateSpec extends ViewBaseSpec {
       lazy val view = views.html.templates.nextPaymentSection(None,
         hasMultiple = false,
         isError = true,
-        isHybridUser = false)
+        isHybridUser = false,
+        isOverdue = false
+      )
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "display the 'Next payment due' heading" in {
@@ -103,7 +133,9 @@ class NextPaymentSectionTemplateSpec extends ViewBaseSpec {
       lazy val view = views.html.templates.nextPaymentSection(Some("2"),
         hasMultiple = true,
         isError = false,
-        isHybridUser = false)
+        isHybridUser = false,
+        isOverdue = false
+      )
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "display the 'Next payment due' heading" in {
@@ -125,7 +157,9 @@ class NextPaymentSectionTemplateSpec extends ViewBaseSpec {
       lazy val view = views.html.templates.nextPaymentSection(None,
         hasMultiple = false,
         isError = false,
-        isHybridUser = true)
+        isHybridUser = true,
+        isOverdue = false
+      )
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "display the 'Next payment due' heading" in {

--- a/test/views/templates/payments/WhatYouOweChargeHelperSpec.scala
+++ b/test/views/templates/payments/WhatYouOweChargeHelperSpec.scala
@@ -29,14 +29,16 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
     LocalDate.parse("2018-03-03"),
     LocalDate.parse("2018-01-01"),
     LocalDate.parse("2018-02-02"),
-    "18AA"
+    "18AA",
+    isOverdue = false
   )
 
   def paymentModelNoPeriod(chargeType: ChargeType): OpenPaymentsModel = OpenPaymentsModelNoPeriod(
     chargeType,
     BigDecimal(100.00),
     LocalDate.parse("2018-03-03"),
-    "18AA"
+    "18AA",
+    isOverdue = false
   )
 
   "WhatYouOweChargeHelper .description" when {

--- a/test/views/templates/payments/WhatYouOweChargeRowTemplateSpec.scala
+++ b/test/views/templates/payments/WhatYouOweChargeRowTemplateSpec.scala
@@ -88,6 +88,10 @@ class WhatYouOweChargeRowTemplateSpec extends ViewBaseSpec {
           elementText(Selectors.payText) shouldBe "Pay now"
         }
 
+        "not display overdue flag" in {
+          elementExtinct(".task-overdue")
+        }
+
         "have the correct pay link destination" in {
           element(Selectors.payLink).attr("href") shouldBe
             "/vat-through-software/make-payment/10000/2/2018/VAT%20Return%20Debit%20Charge/2018-03-03"
@@ -130,6 +134,29 @@ class WhatYouOweChargeRowTemplateSpec extends ViewBaseSpec {
         "not show a link to View Return" in {
           document.select(Selectors.viewReturnLink) shouldBe empty
         }
+      }
+    }
+
+    "payment is overdue" should {
+
+      val model: OpenPaymentsModelWithPeriod = {
+        OpenPaymentsModelWithPeriod(
+          ReturnDebitCharge,
+          BigDecimal(100.00),
+          LocalDate.parse("2018-03-03"),
+          LocalDate.parse("2018-01-01"),
+          LocalDate.parse("2018-02-02"),
+          "18AA",
+          isOverdue = true
+        )
+      }
+      lazy val view = views.html.templates.payments.whatYouOweChargeRow(model, 0)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${view.body}</table>"
+      )
+
+      "display overdue flag" in {
+        elementText(".task-overdue")shouldBe "overdue"
       }
     }
   }

--- a/test/views/templates/payments/WhatYouOweChargeRowTemplateSpec.scala
+++ b/test/views/templates/payments/WhatYouOweChargeRowTemplateSpec.scala
@@ -53,7 +53,8 @@ class WhatYouOweChargeRowTemplateSpec extends ViewBaseSpec {
         LocalDate.parse("2018-03-03"),
         LocalDate.parse("2018-01-01"),
         LocalDate.parse("2018-02-02"),
-        "18AA"
+        "18AA",
+        isOverdue = false
       )
     }
 
@@ -117,7 +118,8 @@ class WhatYouOweChargeRowTemplateSpec extends ViewBaseSpec {
           LocalDate.parse("2018-03-03"),
           LocalDate.parse("2018-01-01"),
           LocalDate.parse("2018-02-02"),
-          "18AA"
+          "18AA",
+          isOverdue = false
         )
 
         lazy val view = views.html.templates.payments.whatYouOweChargeRow(model, 0)


### PR DESCRIPTION
Test VRNs:
- Overdue payment (no DD flag set): 444444444
- Overdue payments but DD flag is set for one payment due 7 Sep 2017: 555555555