### PR TITLE
[BTAT-8241] Added CSS to hide menu toggle properly on small screens

### DIFF
--- a/public/stylesheets/vat-v1.8.css
+++ b/public/stylesheets/vat-v1.8.css
@@ -184,3 +184,11 @@ html[data-useragent*='MSIE 10.0'] .flex-container {
     padding-top: 19px;
     width: 90%
 }
+
+#global-header .header-proposition a.menu {
+    display: none;
+}
+
+.js-enabled #global-header .header-proposition #proposition-links {
+    display: block;
+}


### PR DESCRIPTION
To see the change, you might have to close the tab and log in again after switching to/merging the branch (I did anyway, which is why the fix seemed inconsistent).
The change is only for small screens so you need to emulate a smartphone screen in the browser