### PR TITLE
BTAT-8877 Added insolvency content to the Payment History page

### DIFF
--- a/app/models/CustomerDetails.scala
+++ b/app/models/CustomerDetails.scala
@@ -44,9 +44,11 @@ case class CustomerDetails(
     case _ => false
   }
 
+  val exemptInsolvencyTypes = Seq("07", "12", "13", "14")
+
   def insolvencyDateFutureUserBlocked(today: LocalDate): Boolean =
     (isInsolvent, insolvencyType, insolvencyDate, continueToTrade) match {
-      case (_, Some(inType), _, _) if Seq("07", "12", "13", "14").contains(inType) => false
+      case (_, Some(inType), _, _) if exemptInsolvencyTypes.contains(inType) => false
       case (true, Some(_), Some(date), Some(true)) if LocalDate.parse(date).isAfter(today) => true
       case _ => false
     }

--- a/app/models/viewModels/PaymentsHistoryViewModel.scala
+++ b/app/models/viewModels/PaymentsHistoryViewModel.scala
@@ -20,4 +20,5 @@ case class PaymentsHistoryViewModel(tabOne: Int,
                                     tabTwo: Option[Int],
                                     tabThree: Option[Int],
                                     previousPaymentsTab: Boolean,
-                                    transactions: Seq[PaymentsHistoryModel])
+                                    transactions: Seq[PaymentsHistoryModel],
+                                    showInsolvencyContent: Boolean)

--- a/app/views/payments/PaymentHistory.scala.html
+++ b/app/views/payments/PaymentHistory.scala.html
@@ -24,7 +24,8 @@
       paymentsHistoryTabs: PaymentsHistoryTabs,
       paymentsHistoryTabsContent: PaymentsHistoryTabsContent)
 
-@(model: PaymentsHistoryViewModel, serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, user: User)
+@(model: PaymentsHistoryViewModel,
+  serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, user: User)
 
 @additionalYears = @{
     (model.tabTwo.fold(Seq[Int]())(year=>Seq(year)) ++ model.tabThree.fold(Seq[Int]())(year=>Seq(year+1, year))).distinct
@@ -46,6 +47,10 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 id="top" class="heading-xlarge">@messages("paymentsHistory.title")</h1>
+
+      @if(model.showInsolvencyContent) {
+        <div class="panel panel-border-wide form-group">@messages("paymentsHistory.insolvencyNotice")</div>
+      }
 
       <div class="tabbed">
         @paymentsHistoryTabs(Seq(model.tabOne) ++ additionalYears, model.previousPaymentsTab)

--- a/build.sbt
+++ b/build.sbt
@@ -57,11 +57,11 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile: Seq[ModuleID] = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-frontend-play-26" % "3.1.0",
-  "uk.gov.hmrc" %% "govuk-template" % "5.60.0-play-26",
-  "uk.gov.hmrc" %% "play-ui" % "8.18.0-play-26",
-  "uk.gov.hmrc" %% "play-partials" % "7.0.0-play-26",
-  "uk.gov.hmrc" %% "play-language" % "4.5.0-play-26",
+  "uk.gov.hmrc" %% "bootstrap-frontend-play-26" % "3.4.0",
+  "uk.gov.hmrc" %% "govuk-template" % "5.61.0-play-26",
+  "uk.gov.hmrc" %% "play-ui" % "8.21.0-play-26",
+  "uk.gov.hmrc" %% "play-partials" % "7.1.0-play-26",
+  "uk.gov.hmrc" %% "play-language" % "4.10.0-play-26",
   "com.typesafe.play" %% "play-json-joda" % "2.6.14"
 )
 

--- a/conf/messages
+++ b/conf/messages
@@ -123,6 +123,7 @@ paymentsHistory.previousPayments.youCan = You can
 paymentsHistory.previousPayments.viewPreviousPayments = view your previous payments (opens in new tab)
 paymentsHistory.previousPayments.beforeMtd = if you made payments before joining Making Tax Digital.
 paymentsHistory.backToTop = Back to top
+paymentsHistory.insolvencyNotice = You cannot view payments made before the insolvency date.
 
 #VAT certificate
 vatCertificate.title = Your VAT Certificate

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -149,6 +149,7 @@ paymentsHistory.previousPayments.youCan = Gallwch
 paymentsHistory.previousPayments.viewPreviousPayments = fwrw golwg dros eich taliadau blaenorol (yn agor tab newydd)
 paymentsHistory.previousPayments.beforeMtd = os gwnaethoch daliadau cyn ymuno â’r cynllun Troi Treth yn Ddigidol.
 paymentsHistory.backToTop = Nôl i’r brig
+paymentsHistory.insolvencyNotice = Ni allwch fwrw golwg dros daliadau a wnaed cyn dyddiad yr ansolfedd.
 
 #VAT certificate
 vatCertificate.title = Eich tystysgrif TAW

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,9 +4,9 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.12")
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 

--- a/test/common/TestModels.scala
+++ b/test/common/TestModels.scala
@@ -88,6 +88,9 @@ object TestModels {
   )
 
   val customerDetailsInsolvent: CustomerDetails = customerDetailsMax.copy(isInsolvent = true, continueToTrade = Some(false))
+  val customerDetailsInsolventTrading: CustomerDetails = customerDetailsMax.copy(isInsolvent = true)
+  val customerDetailsInsolventTradingExempt: CustomerDetails =
+    customerDetailsMax.copy(isInsolvent = true, insolvencyType = Some("07"))
   val customerDetailsInsolventFuture: CustomerDetails = customerDetailsMax.copy(
     isInsolvent = true, insolvencyDate = Some("2019-01-01")
   )
@@ -117,6 +120,10 @@ object TestModels {
   )
 
   val customerInformationInsolvent: CustomerInformation = customerInformationMax.copy(details = customerDetailsInsolvent)
+  val customerInformationInsolventTrading: CustomerInformation =
+    customerInformationMax.copy(details = customerDetailsInsolventTrading)
+  val customerInformationInsolventTradingExempt: CustomerInformation =
+    customerInformationMax.copy(details = customerDetailsInsolventTradingExempt)
   val customerInformationInsolventFuture: CustomerInformation =
     customerInformationMax.copy(details = customerDetailsInsolventFuture)
 

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -79,7 +79,8 @@ class ControllerBaseSpec extends UnitSpec with MockFactory with GuiceOneAppPerSu
   lazy val fakeRequestWithSession: FakeRequest[AnyContentAsEmpty.type] = fakeRequest.withSession(
     GovUKSessionKeys.lastRequestTimestamp -> "1498236506662",
     GovUKSessionKeys.authToken -> "Bearer Token",
-    SessionKeys.migrationToETMP -> "2018-01-01"
+    SessionKeys.migrationToETMP -> "2018-01-01",
+    SessionKeys.financialAccess -> "true"
   )
 
   lazy val insolventRequest: FakeRequest[AnyContentAsEmpty.type] =

--- a/test/views/payments/PaymentHistoryViewSpec.scala
+++ b/test/views/payments/PaymentHistoryViewSpec.scala
@@ -52,6 +52,7 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
     val descriptionTableChargeType = "tr td:nth-of-type(2) span.bold"
     val descriptionTableContent = "tr td:nth-of-type(2) span:nth-of-type(2)"
     val amountPaidTableContent = "tr td:nth-of-type(3)"
+    val insolvencyBanner = ".panel"
   }
 
   val currentYear = 2018
@@ -68,114 +69,133 @@ class PaymentHistoryViewSpec extends ViewBaseSpec {
       taxPeriodTo = Some(LocalDate.parse(s"2018-02-01")),
       amount = exampleAmount,
       clearedDate = Some(LocalDate.parse(s"2018-03-01"))
-    ))
+    )),
+    showInsolvencyContent = false
   )
 
-  "The payments history page" should {
+  "The payments history page" when {
 
-    lazy val view: Html = paymentHistoryView(model)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
+    "the user is not insolvent" should {
 
-    "have the correct document title" in {
-      document.title shouldBe "Payment history - Business tax account - GOV.UK"
-    }
+      lazy val view: Html = paymentHistoryView(model)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct page heading" in {
-      elementText(Selectors.pageHeading) shouldBe "Payment history"
-    }
-
-    "render breadcrumbs" which {
-
-      "have the text 'Business tax account'" in {
-        elementText(Selectors.btaBreadcrumb) shouldBe "Business tax account"
+      "have the correct document title" in {
+        document.title shouldBe "Payment history - Business tax account - GOV.UK"
       }
 
-      "link to bta" in {
-        element(Selectors.btaBreadcrumbLink).attr("href") shouldBe "bta-url"
+      "have the correct page heading" in {
+        elementText(Selectors.pageHeading) shouldBe "Payment history"
       }
 
-      "have the text 'Your VAT account'" in {
-        elementText(Selectors.vatBreadcrumb) shouldBe "Your VAT account"
-      }
+      "render breadcrumbs" which {
 
-      s"link to ${controllers.routes.VatDetailsController.details().url}" in {
-        element(Selectors.vatBreadcrumbLink).attr("href") shouldBe controllers.routes.VatDetailsController.details().url
-      }
-
-      "have the text 'Payment history'" in {
-        elementText(Selectors.paymentHistoryBreadcrumb) shouldBe "Payment history"
-      }
-    }
-
-    "display a current year tab" in {
-      elementText(Selectors.tabOne) shouldBe currentYear.toString
-    }
-
-    "display a previous year tab" in {
-      elementText(Selectors.tabTwo) shouldBe (currentYear - 1).toString
-    }
-
-    "display a tab for 2 years ago" in {
-      elementText(Selectors.tabThree) shouldBe (currentYear - 2).toString
-    }
-
-    "display a previous payments tab" in {
-      elementText(Selectors.tabFour) shouldBe "Previous payments"
-    }
-
-    "have the current year subheading" in {
-      elementText(Selectors.currentYearSubheading) shouldBe currentYear.toString
-    }
-
-    "have the previous year subheading" in {
-      elementText(Selectors.previousYearSubheading) shouldBe (currentYear - 1).toString
-    }
-
-    "have the previous payments subheading" in {
-      elementText(Selectors.prevPaymentsSubheading) shouldBe "Previous payments"
-    }
-
-    "have the correct current year tab content" which {
-
-      "has the correct amount in the charge row" in {
-        elementText(Selectors.amountPaidTableContent) shouldBe "- £100"
-      }
-
-      "has the correct title in the charge row" in {
-        elementText(Selectors.descriptionTableChargeType) shouldBe "Return"
-      }
-
-      "has the correct description in the charge row" in {
-        elementText(Selectors.descriptionTableContent) shouldBe "for the period 1 Jan to 1 Feb 2018"
-      }
-
-      "has the correct date in the charge row" in {
-        elementText(Selectors.paymentDateTableContent) shouldBe "1 Mar 2018"
-      }
-    }
-
-    "have the correct previous year tab content" in {
-      elementText(Selectors.previousYearNoPayments) shouldBe
-        "You have not made or received any payments using the new VAT service this year."
-    }
-
-    "have the correct previous payments tab content" which {
-
-      "has the correct message" in {
-        elementText(Selectors.prevPaymentsParagraph) shouldBe "You can view your previous payments " +
-          "(opens in new tab) if you made payments before joining Making Tax Digital."
-      }
-
-      "has a link to the old VAT portal" which {
-
-        "has the correct link text" in {
-          elementText(Selectors.prevPaymentsLink) shouldBe "view your previous payments (opens in new tab)"
+        "have the text 'Business tax account'" in {
+          elementText(Selectors.btaBreadcrumb) shouldBe "Business tax account"
         }
 
-        "has the correct link href" in {
-          element(Selectors.prevPaymentsLink).attr("href") shouldBe
-            mockConfig.portalNonHybridPreviousPaymentsUrl(user.vrn)
+        "link to bta" in {
+          element(Selectors.btaBreadcrumbLink).attr("href") shouldBe "bta-url"
         }
+
+        "have the text 'Your VAT account'" in {
+          elementText(Selectors.vatBreadcrumb) shouldBe "Your VAT account"
+        }
+
+        s"link to ${controllers.routes.VatDetailsController.details().url}" in {
+          element(Selectors.vatBreadcrumbLink).attr("href") shouldBe controllers.routes.VatDetailsController.details().url
+        }
+
+        "have the text 'Payment history'" in {
+          elementText(Selectors.paymentHistoryBreadcrumb) shouldBe "Payment history"
+        }
+      }
+
+      "display a current year tab" in {
+        elementText(Selectors.tabOne) shouldBe currentYear.toString
+      }
+
+      "display a previous year tab" in {
+        elementText(Selectors.tabTwo) shouldBe (currentYear - 1).toString
+      }
+
+      "display a tab for 2 years ago" in {
+        elementText(Selectors.tabThree) shouldBe (currentYear - 2).toString
+      }
+
+      "display a previous payments tab" in {
+        elementText(Selectors.tabFour) shouldBe "Previous payments"
+      }
+
+      "have the current year subheading" in {
+        elementText(Selectors.currentYearSubheading) shouldBe currentYear.toString
+      }
+
+      "have the previous year subheading" in {
+        elementText(Selectors.previousYearSubheading) shouldBe (currentYear - 1).toString
+      }
+
+      "have the previous payments subheading" in {
+        elementText(Selectors.prevPaymentsSubheading) shouldBe "Previous payments"
+      }
+
+      "have the correct current year tab content" which {
+
+        "has the correct amount in the charge row" in {
+          elementText(Selectors.amountPaidTableContent) shouldBe "- £100"
+        }
+
+        "has the correct title in the charge row" in {
+          elementText(Selectors.descriptionTableChargeType) shouldBe "Return"
+        }
+
+        "has the correct description in the charge row" in {
+          elementText(Selectors.descriptionTableContent) shouldBe "for the period 1 Jan to 1 Feb 2018"
+        }
+
+        "has the correct date in the charge row" in {
+          elementText(Selectors.paymentDateTableContent) shouldBe "1 Mar 2018"
+        }
+      }
+
+      "have the correct previous year tab content" in {
+        elementText(Selectors.previousYearNoPayments) shouldBe
+          "You have not made or received any payments using the new VAT service this year."
+      }
+
+      "have the correct previous payments tab content" which {
+
+        "has the correct message" in {
+          elementText(Selectors.prevPaymentsParagraph) shouldBe "You can view your previous payments " +
+            "(opens in new tab) if you made payments before joining Making Tax Digital."
+        }
+
+        "has a link to the old VAT portal" which {
+
+          "has the correct link text" in {
+            elementText(Selectors.prevPaymentsLink) shouldBe "view your previous payments (opens in new tab)"
+          }
+
+          "has the correct link href" in {
+            element(Selectors.prevPaymentsLink).attr("href") shouldBe
+              mockConfig.portalNonHybridPreviousPaymentsUrl(user.vrn)
+          }
+        }
+      }
+
+      "not display the insolvency banner" in {
+        elementExtinct(Selectors.insolvencyBanner)
+      }
+    }
+
+    "the user is insolvent" should {
+
+      val insolventViewModel = model.copy(showInsolvencyContent = true)
+      lazy val view: Html = paymentHistoryView(insolventViewModel)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "display the insolvency banner" in {
+        elementText(Selectors.insolvencyBanner) shouldBe "You cannot view payments made before the insolvency date."
       }
     }
   }


### PR DESCRIPTION
I removed the session logic around retrieving the migrationToETMPDate because the customer info API call is needed for this additional work anyway.