### PR TITLE
BTAT-9137 Added support for Debit & Credit VAT Default Surcharges

### DIFF
--- a/app/config/filters/ServiceFilters.scala
+++ b/app/config/filters/ServiceFilters.scala
@@ -17,11 +17,10 @@
 package config.filters
 
 import javax.inject.Inject
-import play.api.http.DefaultHttpFilters
+import play.api.http.{DefaultHttpFilters, EnabledFilters}
 import play.filters.csrf.CSRFFilter
-import uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters
 
-class ServiceFilters @Inject()(defaultFilters: FrontendFilters, excludingCSRFFilter: ExcludingCSRFFilter)
+class ServiceFilters @Inject()(defaultFilters: EnabledFilters, excludingCSRFFilter: ExcludingCSRFFilter)
   extends DefaultHttpFilters({
     defaultFilters.filters.filterNot(f => f.isInstanceOf[CSRFFilter]) :+ excludingCSRFFilter
   }:_*)

--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -24,7 +24,7 @@ import services.EnrolmentsAuthService
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.{AffinityGroup, AuthorisationException}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +37,7 @@ class SignOutController @Inject()(enrolmentsAuthService: EnrolmentsAuthService,
 
   def signOut(authorised: Boolean): Action[AnyContent] = Action.async { implicit request =>
     implicit val hc: HeaderCarrier =
-      HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+      HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
     if(authorised) {
       enrolmentsAuthService.authorised.retrieve(Retrievals.affinityGroup) {

--- a/app/models/payments/ChargeType.scala
+++ b/app/models/payments/ChargeType.scala
@@ -60,8 +60,11 @@ case object OADefaultInterestCharge extends ChargeType {
 case object OAFurtherInterestCharge extends ChargeType {
   override val value: String = "VAT OA Further Interest"
 }
-case object DefaultSurcharge extends ChargeType {
-  override val value: String = "VAT Default Surcharge"
+case object DebitDefaultSurcharge extends ChargeType {
+  override val value: String = "VAT Debit Default Surcharge"
+}
+case object CreditDefaultSurcharge extends ChargeType {
+  override val value: String = "VAT Credit Default Surcharge"
 }
 case object CentralAssessmentCharge extends ChargeType {
   override val value: String = "VAT Central Assessment"
@@ -208,7 +211,8 @@ object ChargeType {
     ReturnCreditCharge,
     OACreditCharge,
     OADebitCharge,
-    DefaultSurcharge,
+    DebitDefaultSurcharge,
+    CreditDefaultSurcharge,
     CentralAssessmentCharge,
     ErrorCorrectionCreditCharge,
     ErrorCorrectionDebitCharge,

--- a/app/testOnly/connectors/BtaStubConnector.scala
+++ b/app/testOnly/connectors/BtaStubConnector.scala
@@ -17,6 +17,7 @@
 package testOnly.connectors
 
 import config.VatHeaderCarrierForPartialsConverter
+
 import javax.inject.Inject
 import play.api.http.Status._
 import play.api.mvc.{AnyContent, Request}

--- a/app/views/templates/payments/PaymentMessageHelper.scala
+++ b/app/views/templates/payments/PaymentMessageHelper.scala
@@ -79,10 +79,17 @@ object PaymentMessageHelper {
     "chargeType.vatCentralAssessmentTitle",
     Some("chargeType.vatCentralAssessmentDescription"))
 
-  object VatDefaultSurcharge extends PaymentMessageHelper(
-    DefaultSurcharge.value,
+  object VatDebitDefaultSurcharge extends PaymentMessageHelper(
+    DebitDefaultSurcharge.value,
     "chargeType.vatDefaultSurchargeTitle",
     Some("chargeType.vatDefaultSurchargeDescription"))
+
+  object VatCreditDefaultSurcharge extends PaymentMessageHelper(
+    CreditDefaultSurcharge.value,
+    "chargeType.vatDefaultSurchargeTitle",
+    Some("chargeType.vatDefaultSurchargeDescription"),
+    "repayment"
+  )
 
   object VatErrorCorrectionDebitCharge extends PaymentMessageHelper(
     ErrorCorrectionDebitCharge.value,
@@ -360,7 +367,8 @@ object PaymentMessageHelper {
     VatOfficerAssessmentCreditCharge,
     VatOfficerAssessmentDebitCharge,
     VatCentralAssessment,
-    VatDefaultSurcharge,
+    VatDebitDefaultSurcharge,
+    VatCreditDefaultSurcharge,
     VatErrorCorrectionDebitCharge,
     VatErrorCorrectionCreditCharge,
     VatRepaymentSupplement,

--- a/build.sbt
+++ b/build.sbt
@@ -57,11 +57,11 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile: Seq[ModuleID] = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-frontend-play-26" % "3.4.0",
-  "uk.gov.hmrc" %% "govuk-template" % "5.61.0-play-26",
-  "uk.gov.hmrc" %% "play-ui" % "8.21.0-play-26",
+  "uk.gov.hmrc" %% "bootstrap-frontend-play-26" % "4.2.0",
+  "uk.gov.hmrc" %% "govuk-template" % "5.65.0-play-26",
+  "uk.gov.hmrc" %% "play-ui" % "9.1.0-play-26",
   "uk.gov.hmrc" %% "play-partials" % "7.1.0-play-26",
-  "uk.gov.hmrc" %% "play-language" % "4.10.0-play-26",
+  "uk.gov.hmrc" %% "play-language" % "4.12.0-play-26",
   "com.typesafe.play" %% "play-json-joda" % "2.6.14"
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.12")
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.14.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 

--- a/test/common/MessageLookup.scala
+++ b/test/common/MessageLookup.scala
@@ -50,7 +50,7 @@ object MessageLookup {
         case VatOfficerAssessmentCreditCharge.name => ("VAT officer’s assessment", "for overpaying by this amount")
         case VatOfficerAssessmentDebitCharge.name => ("VAT officer’s assessment", "for underpaying by this amount")
         case VatCentralAssessment.name => ("Estimate", s"for your $datePeriod return")
-        case VatDefaultSurcharge.name => ("Surcharge", s"for late payment of your $datePeriod return")
+        case VatDebitDefaultSurcharge.name | VatCreditDefaultSurcharge.name => ("Surcharge", s"for late payment of your $datePeriod return")
         case VatErrorCorrectionDebitCharge.name => ("Error correction payment", s"for correcting your $datePeriod return")
         case VatErrorCorrectionCreditCharge.name => ("Error correction repayment from HMRC", s"for correcting your $datePeriod return")
         case VatRepaymentSupplement.name => ("Late repayment compensation from HMRC", s"we took too long to repay your $datePeriod return")

--- a/test/connectors/ServiceInfoPartialConnectorSpec.scala
+++ b/test/connectors/ServiceInfoPartialConnectorSpec.scala
@@ -38,8 +38,9 @@ class ServiceInfoPartialConnectorSpec extends ControllerBaseSpec {
     val httpClient: HttpClient = mock[HttpClient]
     lazy val connector: ServiceInfoPartialConnector = {
 
-      (httpClient.GET[HtmlPartial](_: String)(_: HttpReads[HtmlPartial],_: HeaderCarrier,_: ExecutionContext))
-        .stubs(*,*,*,*)
+      (httpClient.GET[HtmlPartial](_: String, _: Seq[(String, String)], _: Seq[(String, String)])
+                                  (_: HttpReads[HtmlPartial],_: HeaderCarrier,_: ExecutionContext))
+        .stubs(*,*,*,*,*,*)
         .returns(result)
       new ServiceInfoPartialConnector(httpClient, header, btanl)(messagesApi, mockAppConfig)
     }

--- a/test/connectors/httpParsers/PaymentsHistoryHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHistoryHttpParserSpec.scala
@@ -146,8 +146,8 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |        ]
        |      },
        |      {
-       |        "chargeType" : "$DefaultSurcharge",
-       |        "mainType" : "$DefaultSurcharge",
+       |        "chargeType" : "$DebitDefaultSurcharge",
+       |        "mainType" : "VAT Default Surcharge",
        |        "periodKey" : "17AA",
        |        "periodKeyDescription" : "ABCD",
        |        "taxPeriodFrom" : "2018-06-10",
@@ -169,6 +169,33 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
        |            "clearingDate" : "2018-11-10",
        |            "dueDate" : "2018-09-07",
        |            "paymentAmount" : 150
+       |          }
+       |        ]
+       |      },
+       |      {
+       |        "chargeType" : "$CreditDefaultSurcharge",
+       |        "mainType" : "VAT Default Surcharge",
+       |        "periodKey" : "17AA",
+       |        "periodKeyDescription" : "ABCD",
+       |        "taxPeriodFrom" : "2018-06-10",
+       |        "taxPeriodTo" : "2018-10-31",
+       |        "businessPartner" : "0",
+       |        "contractAccountCategory" : "99",
+       |        "contractAccount" : "X",
+       |        "contractObjectType" : "ABCD",
+       |        "contractObject" : "0",
+       |        "sapDocumentNumber" : "0",
+       |        "sapDocumentNumberItem" : "0",
+       |        "chargeReference" : "XD002750002155",
+       |        "mainTransaction" : "1234",
+       |        "subTransaction" : "5678",
+       |        "originalAmount" : -150,
+       |        "items" : [
+       |          {
+       |            "subItem" : "000",
+       |            "clearingDate" : "2018-11-10",
+       |            "dueDate" : "2018-09-07",
+       |            "paymentAmount" : -150
        |          }
        |        ]
        |      },
@@ -422,10 +449,17 @@ class PaymentsHistoryHttpParserSpec extends UnitSpec {
       clearedDate = Some(LocalDate.of(2018, 6, 28))
     ),
     PaymentsHistoryModel(
-      chargeType = DefaultSurcharge,
+      chargeType = DebitDefaultSurcharge,
       taxPeriodFrom = Some(LocalDate.of(2018, 6, 10)),
       taxPeriodTo = Some(LocalDate.of(2018, 10, 31)),
       amount = 150,
+      clearedDate = Some(LocalDate.of(2018, 11, 10))
+    ),
+    PaymentsHistoryModel(
+      chargeType = CreditDefaultSurcharge,
+      taxPeriodFrom = Some(LocalDate.of(2018, 6, 10)),
+      taxPeriodTo = Some(LocalDate.of(2018, 10, 31)),
+      amount = -150,
       clearedDate = Some(LocalDate.of(2018, 11, 10))
     ),
     PaymentsHistoryModel(

--- a/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
@@ -99,14 +99,26 @@ class PaymentsHttpParserSpec extends UnitSpec {
               "chargeReference" -> "XD002750002155"
             ),
             Json.obj(
-              "mainType" -> DefaultSurcharge,
-              "chargeType" -> DefaultSurcharge,
-              "taxPeriodFrom" -> "2015-12-01",
-              "taxPeriodTo" -> "2014-01-01",
+              "mainType" -> DebitDefaultSurcharge,
+              "chargeType" -> DebitDefaultSurcharge,
+              "taxPeriodFrom" -> "2014-12-01",
+              "taxPeriodTo" -> "2015-01-01",
               "items" -> Json.arr(
                 Json.obj("dueDate" -> "2015-10-25")
               ),
               "outstandingAmount" -> 1000.27,
+              "periodKey" -> "#006",
+              "chargeReference" -> "XD002750002155"
+            ),
+            Json.obj(
+              "mainType" -> CreditDefaultSurcharge,
+              "chargeType" -> CreditDefaultSurcharge,
+              "taxPeriodFrom" -> "2014-12-01",
+              "taxPeriodTo" -> "2015-01-01",
+              "items" -> Json.arr(
+                Json.obj("dueDate" -> "2015-10-25")
+              ),
+              "outstandingAmount" -> -1000.27,
               "periodKey" -> "#006",
               "chargeReference" -> "XD002750002155"
             ),
@@ -586,11 +598,21 @@ class PaymentsHttpParserSpec extends UnitSpec {
           ddCollectionInProgress = false
         ),
         PaymentWithPeriod(
-          DefaultSurcharge,
-          periodFrom = LocalDate.parse("2015-12-01"),
-          periodTo = LocalDate.parse("2014-01-01"),
+          DebitDefaultSurcharge,
+          periodFrom = LocalDate.parse("2014-12-01"),
+          periodTo = LocalDate.parse("2015-01-01"),
           due = LocalDate.parse("2015-10-25"),
           outstandingAmount = BigDecimal(1000.27),
+          periodKey = "#006",
+          chargeReference = Some("XD002750002155"),
+          ddCollectionInProgress = false
+        ),
+        PaymentWithPeriod(
+          CreditDefaultSurcharge,
+          periodFrom = LocalDate.parse("2014-12-01"),
+          periodTo = LocalDate.parse("2015-01-01"),
+          due = LocalDate.parse("2015-10-25"),
+          outstandingAmount = BigDecimal(-1000.27),
           periodKey = "#006",
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false

--- a/test/models/PaymentsHistoryModelSpec.scala
+++ b/test/models/PaymentsHistoryModelSpec.scala
@@ -64,7 +64,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |            "paymentAmount" : 150,
            |            "dueDate" : "2018-12-07",
            |            "clearingDate" : "2018-01-10"
-         |            }
+           |          }
            |        ]
            |      },
            |      {
@@ -91,7 +91,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |            "paymentAmount" : -600,
            |            "dueDate" : "2018-09-07",
            |            "clearingDate" : "2018-03-10"
-         |            }
+           |          }
            |        ]
            |      }
            |    ]
@@ -157,8 +157,8 @@ class PaymentsHistoryModelSpec extends UnitSpec {
            |        ]
            |      },
            |      {
-           |        "chargeType" : "$DefaultSurcharge",
-           |        "mainType" : "$DefaultSurcharge",
+           |        "chargeType" : "$DebitDefaultSurcharge",
+           |        "mainType" : "VAT Default Surcharge",
            |        "periodKey" : "17AA",
            |        "periodKeyDescription" : "ABCD",
            |        "taxPeriodFrom" : "2018-08-01",
@@ -304,7 +304,7 @@ class PaymentsHistoryModelSpec extends UnitSpec {
           clearedDate = Some(LocalDate.of(2018, 1, 10))
         ),
         PaymentsHistoryModel(
-          chargeType = DefaultSurcharge,
+          chargeType = DebitDefaultSurcharge,
           taxPeriodFrom = Some(LocalDate.of(2018, 8, 1)),
           taxPeriodTo = Some(LocalDate.of(2018, 10, 31)),
           amount = 150,

--- a/test/testOnly/connectors/BtaStubConnectorSpec.scala
+++ b/test/testOnly/connectors/BtaStubConnectorSpec.scala
@@ -52,8 +52,9 @@ class BtaStubConnectorSpec extends ControllerBaseSpec {
       }
     }
 
-    (mockHttp.GET[HttpResponse](_: String)(_: HttpReads[HttpResponse], _: HeaderCarrier, _: ExecutionContext))
-      .expects(*, *, *, *)
+    (mockHttp.GET[HttpResponse](_: String, _: Seq[(String, String)], _: Seq[(String, String)])
+                               (_: HttpReads[HttpResponse], _: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *, *, *)
       .returns(generateResponse(response))
 
     new BtaStubConnector(mockHttp, hc, ec)

--- a/test/views/templates/payments/PaymentsHistoryChargeTemplateSpec.scala
+++ b/test/views/templates/payments/PaymentsHistoryChargeTemplateSpec.scala
@@ -205,10 +205,38 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
       }
     }
 
-    "there is a vat default surcharge charge" should {
+    "there is a VAT Debit Default Surcharge charge" should {
 
       val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        DefaultSurcharge,
+        DebitDefaultSurcharge,
+        Some(LocalDate.parse("2018-01-12")),
+        Some(LocalDate.parse("2018-03-23")),
+        123456,
+        Some(LocalDate.parse("2018-02-14"))
+      )
+
+      lazy val template = paymentsHistoryCharge(model)
+      lazy implicit val document: Document = Jsoup.parse(
+        s"<table>${template.body}</table>"
+      )
+
+      "display the correct table row class" in {
+        element(Selectors.tableRow).attr("class") shouldBe ""
+      }
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Surcharge"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for late payment of your 12 Jan to 23 Mar 2018 return"
+      }
+    }
+
+    "there is a VAT Credit Default Surcharge charge" should {
+
+      val model: PaymentsHistoryModel = PaymentsHistoryModel(
+        CreditDefaultSurcharge,
         Some(LocalDate.parse("2018-01-12")),
         Some(LocalDate.parse("2018-03-23")),
         -123456,
@@ -221,7 +249,7 @@ class PaymentsHistoryChargeTemplateSpec extends ViewBaseSpec {
       )
 
       "display the correct table row class" in {
-        element(Selectors.tableRow).attr("class") shouldBe ""
+        element(Selectors.tableRow).attr("class") shouldBe "repayment"
       }
 
       "display the correct charge title" in {


### PR DESCRIPTION
After discussion with Jack, Hana and Martin there is no need for new content and we can simply display the existing content but with the appropriate debit or credit styling for the payment history page.