### PR TITLE
BTAT-9193 Tweak to accounting view to align numeric columns to the right

### DIFF
--- a/app/views/templates/payments/PaymentsHistoryTabsContent.scala.html
+++ b/app/views/templates/payments/PaymentsHistoryTabsContent.scala.html
@@ -36,8 +36,8 @@
         head = Some(Seq(
           HeadCell(content = Text(messages("paymentsHistory.date"))),
           HeadCell(content = Text(messages("paymentsHistory.description"))),
-          HeadCell(content = Text(messages("paymentsHistory.youPaid"))),
-          HeadCell(content = Text(messages("paymentsHistory.paidYou")))
+          HeadCell(content = Text(messages("paymentsHistory.youPaid")), format = Some("numeric")),
+          HeadCell(content = Text(messages("paymentsHistory.paidYou")), format = Some("numeric"))
         )),
         rows = transactions
                 .filter(_.clearedDate.getOrElse("").toString.contains(year.toString))
@@ -47,8 +47,14 @@
               Seq(
                 TableRow(content = Text(displayDate(date, useShortDayFormat = true, showYear = false))),
                 TableRow(content = HtmlContent(paymentsHistoryChargeDescription(transaction))),
-                TableRow(content = HtmlContent(displayMoney(if(transaction.amount > 0) transaction.amount else 0))),
-                TableRow(content = HtmlContent(displayMoney(if(transaction.amount < 0) transaction.amount.abs else 0)))
+                TableRow(
+                  content = HtmlContent(displayMoney(if(transaction.amount > 0) transaction.amount else 0)),
+                  format = Some("numeric")
+                ),
+                TableRow(
+                  content = HtmlContent(displayMoney(if(transaction.amount < 0) transaction.amount.abs else 0)),
+                  format = Some("numeric")
+                )
               )
             case None => Seq()
           }

--- a/test/views/templates/payments/PaymentHistoryTabsContentTemplateSpec.scala
+++ b/test/views/templates/payments/PaymentHistoryTabsContentTemplateSpec.scala
@@ -58,8 +58,8 @@ class PaymentHistoryTabsContentTemplateSpec extends TemplateBaseSpec {
       |      <tr class="govuk-table__row">
       |        <th scope="col" class="govuk-table__header">Date</th>
       |        <th scope="col" class="govuk-table__header">Payment description</th>
-      |        <th scope="col" class="govuk-table__header">You paid HMRC</th>
-      |        <th scope="col" class="govuk-table__header">HMRC paid you</th>
+      |        <th scope="col" class="govuk-table__header govuk-table__header--numeric">You paid HMRC</th>
+      |        <th scope="col" class="govuk-table__header govuk-table__header--numeric">HMRC paid you</th>
       |      </tr>
       |    </thead>
       |    <tbody class="govuk-table__body">
@@ -68,8 +68,12 @@ class PaymentHistoryTabsContentTemplateSpec extends TemplateBaseSpec {
       |        <td class="govuk-table__cell">
       |          ${paymentsHistoryChargeDescription(if(repayment) repaymentTransaction else paymentTransaction)}
       |        </td>
-      |        <td class="govuk-table__cell"> £${if(repayment) "0" else examplePaymentAmount} </td>
-      |        <td class="govuk-table__cell"> £${if(repayment) exampleRepaymentAmount.abs else "0"} </td>
+      |        <td class="govuk-table__cell govuk-table__cell--numeric">
+      |          £${if(repayment) "0" else examplePaymentAmount}
+      |        </td>
+      |        <td class="govuk-table__cell govuk-table__cell--numeric">
+      |          £${if(repayment) exampleRepaymentAmount.abs else "0"}
+      |        </td>
       |      </tr>
       |    </tbody>
       |  </table>


### PR DESCRIPTION
This is in line with the guidance here: https://design-system.service.gov.uk/components/table/#numbers-in-a-table