### PR TITLE
BTAT-9213 Added DD interrupt logic

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -25,4 +25,5 @@ object SessionKeys {
   val inFlightContactKey: String = "inFlightContactDetailsChange"
   val insolventWithoutAccessKey: String = "insolventWithoutAccess"
   val financialAccess: String = "vatSummaryFinancialAccess"
+  val viewedDDInterrupt: String = "vatSummaryHasViewedDDInterrupt"
 }

--- a/app/connectors/FinancialDataConnector.scala
+++ b/app/connectors/FinancialDataConnector.scala
@@ -17,9 +17,10 @@
 package connectors
 
 import java.time.LocalDate
-
 import config.AppConfig
 import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
+import models.DirectDebitStatus
+
 import javax.inject.{Inject, Singleton}
 import models.payments.Payments
 import models.viewModels.PaymentsHistoryModel
@@ -82,7 +83,8 @@ class FinancialDataConnector @Inject()(http: HttpClient,
       }
   }
 
-  def getDirectDebitStatus(vrn: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[Boolean]] = {
+  def getDirectDebitStatus(vrn: String)
+                          (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[DirectDebitStatus]] = {
 
     import connectors.httpParsers.DirectDebitStatusHttpParser.DirectDebitStatusReads
 

--- a/app/connectors/httpParsers/DirectDebitStatusHttpParser.scala
+++ b/app/connectors/httpParsers/DirectDebitStatusHttpParser.scala
@@ -17,16 +17,17 @@
 package connectors.httpParsers
 
 import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
+import models.DirectDebitStatus
 import models.errors.{ServerSideError, UnexpectedStatusError}
 import play.api.http.Status.{BAD_REQUEST, OK}
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 
 object DirectDebitStatusHttpParser extends ResponseHttpParsers {
 
-  implicit object DirectDebitStatusReads extends HttpReads[HttpGetResult[Boolean]] {
-    override def read(method: String, url: String, response: HttpResponse): HttpGetResult[Boolean] = {
+  implicit object DirectDebitStatusReads extends HttpReads[HttpGetResult[DirectDebitStatus]] {
+    override def read(method: String, url: String, response: HttpResponse): HttpGetResult[DirectDebitStatus] = {
       response.status match {
-        case OK => Right(response.json.as[Boolean])
+        case OK => Right(response.json.as[DirectDebitStatus])
         case BAD_REQUEST => handleBadRequest(response.json)
         case status if status >= 500 && status < 600 => Left(ServerSideError(response.status.toString, response.body))
         case _ => Left(UnexpectedStatusError(response.status.toString, response.body))

--- a/app/models/DDInterruptResult.scala
+++ b/app/models/DDInterruptResult.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+sealed trait DDInterruptResult
+
+case object InterruptNoDD extends DDInterruptResult
+case object InterruptExistingDD extends DDInterruptResult
+case object BypassInterrupt extends DDInterruptResult

--- a/app/models/DirectDebitStatus.scala
+++ b/app/models/DirectDebitStatus.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Format, Json}
+
+case class DDIDetails(dateCreated: String)
+
+object DDIDetails {
+  implicit val format: Format[DDIDetails] = Json.format[DDIDetails]
+}
+
+case class DirectDebitStatus(directDebitMandateFound: Boolean, directDebitDetails: Option[Seq[DDIDetails]])
+
+object DirectDebitStatus {
+  implicit val format: Format[DirectDebitStatus] = Json.format[DirectDebitStatus]
+}

--- a/app/services/PaymentsService.scala
+++ b/app/services/PaymentsService.scala
@@ -17,13 +17,13 @@
 package services
 
 import java.time.LocalDate
-
 import connectors.{DirectDebitConnector, FinancialDataConnector, PaymentsConnector}
+
 import javax.inject.{Inject, Singleton}
 import models.errors._
 import models.payments.{PaymentDetailsModel, Payments}
 import models.viewModels.PaymentsHistoryModel
-import models.{DirectDebitDetailsModel, ServiceResponse}
+import models.{DirectDebitDetailsModel, DirectDebitStatus, ServiceResponse}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -56,7 +56,8 @@ class PaymentsService @Inject()(financialDataConnector: FinancialDataConnector,
     }
   }
 
-  def setupPaymentsJourney(journeyDetails: PaymentDetailsModel)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[String]] = {
+  def setupPaymentsJourney(journeyDetails: PaymentDetailsModel)
+                          (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[String]] = {
     paymentsConnector.setupJourney(journeyDetails).map {
       case Right(url) => Right(url)
       case Left(_) => Left(PaymentSetupError)
@@ -70,7 +71,8 @@ class PaymentsService @Inject()(financialDataConnector: FinancialDataConnector,
       case Left(_) => Left(DirectDebitSetupError)
     }
 
-  def getDirectDebitStatus(vrn: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[Boolean]] =
+  def getDirectDebitStatus(vrn: String)
+                          (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[DirectDebitStatus]] =
     financialDataConnector.getDirectDebitStatus(vrn) map {
       case Right(directDebitStatus) => Right(directDebitStatus)
       case Left(_) => Left(DirectDebitStatusError)

--- a/it/connectors/FinancialDataConnectorISpec.scala
+++ b/it/connectors/FinancialDataConnectorISpec.scala
@@ -17,9 +17,9 @@
 package connectors
 
 import java.time.LocalDate
-
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import helpers.IntegrationBaseSpec
+import models.{DDIDetails, DirectDebitStatus}
 import models.errors.BadRequestError
 import models.payments.{PaymentWithPeriod, Payments, ReturnCreditCharge, ReturnDebitCharge}
 import models.viewModels.PaymentsHistoryModel
@@ -133,10 +133,10 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
   }
 
   "calling getDirectDebitStatus with a valid VRN" should {
-    "return a Boolean" in new Test {
+    "return a DirectDebitStatus" in new Test {
       override def setupStubs(): StubMapping = FinancialDataStub.stubSuccessfulDirectDebit
 
-      val expected = Right(true)
+      val expected = Right(DirectDebitStatus(directDebitMandateFound = true, Some(Seq(DDIDetails("2018-01-01")))))
 
       setupStubs()
       private val result = await(connector.getDirectDebitStatus("111111111"))

--- a/it/stubs/FinancialDataStub.scala
+++ b/it/stubs/FinancialDataStub.scala
@@ -56,13 +56,20 @@ object FinancialDataStub extends WireMockMethods {
 
   def stubSuccessfulDirectDebit: StubMapping = {
     when(method = GET, uri = financialDataDirectDebitUri)
-      .thenReturn(status = OK, body = true)
+      .thenReturn(status = OK, body = DDStatusJson)
   }
 
   def stubInvalidVrnDirectDebit: StubMapping = {
     when(method = GET, uri = financialDataDirectDebitUri)
       .thenReturn(BAD_REQUEST, body = invalidVrn)
   }
+
+  private val DDStatusJson: JsValue = Json.obj(
+    "directDebitMandateFound" -> true,
+    "directDebitDetails" -> Json.arr(
+      Json.obj("dateCreated" -> "2018-01-01")
+    )
+  )
 
   private val paidTransactions: JsValue = Json.parse(
     s"""{

--- a/test/connectors/httpParsers/DirectDebitStatusHttpParserSpec.scala
+++ b/test/connectors/httpParsers/DirectDebitStatusHttpParserSpec.scala
@@ -16,8 +16,8 @@
 
 package connectors.httpParsers
 
-
 import connectors.httpParsers.DirectDebitStatusHttpParser.DirectDebitStatusReads
+import models.DirectDebitStatus
 import models.errors._
 import play.api.http.Status
 import play.api.libs.json.{JsObject, Json}
@@ -30,10 +30,9 @@ class DirectDebitStatusHttpParserSpec extends UnitSpec {
 
     "the http response status is 200 OK" should {
 
-      val httpResponse = HttpResponse(Status.OK, Json.parse("true").toString())
-
-      val expected = Right(true)
-
+      val jsonResponse = Json.obj("directDebitMandateFound" -> false)
+      val httpResponse = HttpResponse(Status.OK, jsonResponse.toString())
+      val expected = Right(DirectDebitStatus(directDebitMandateFound = false, None))
       val result = DirectDebitStatusReads.read("", "", httpResponse)
 
       "return a DirectDebitStatus instance" in {
@@ -44,9 +43,7 @@ class DirectDebitStatusHttpParserSpec extends UnitSpec {
     "the http response status is 404 NOT_FOUND" should {
 
       val httpResponse = HttpResponse(Status.NOT_FOUND, "")
-
       val expected = Left(UnexpectedStatusError("404", ""))
-
       val result = DirectDebitStatusReads.read("", "", httpResponse)
 
       "return a 404 error" in {

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -94,6 +94,7 @@ class ControllerBaseSpec extends UnitSpec with MockFactory with GuiceOneAppPerSu
     super.beforeEach()
     mockAppConfig.features.agentAccess(true)
     mockAppConfig.features.ddCollectionInProgressEnabled(true)
+    mockAppConfig.features.directDebitInterrupt(true)
   }
 
   override def afterEach(): Unit = {

--- a/test/controllers/VatDetailsControllerSpec.scala
+++ b/test/controllers/VatDetailsControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import java.time.LocalDate
-
 import audit.AuditingService
 import audit.models.AuditModel
 import common.FinancialTransactionsConstants._
@@ -30,8 +29,7 @@ import models.obligations.{VatReturnObligation, VatReturnObligations}
 import models.payments.{Payment, PaymentNoPeriod, Payments, ReturnDebitCharge}
 import models.viewModels.VatDetailsViewModel
 import play.api.http.Status
-import play.api.mvc.{AnyContentAsEmpty, Request, Result}
-import play.api.test.FakeRequest
+import play.api.mvc.{Request, Result}
 import play.api.test.Helpers._
 import play.twirl.api.Html
 import services._
@@ -39,6 +37,7 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
+import views.html.interrupt.{DDInterruptExistingDD, DDInterruptNoDD}
 import views.html.vatDetails.Details
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -51,16 +50,20 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
     val payments: Payments = TestModels.payments
 
     val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = successfulAuthResult
-    val vatServiceReturnsResult: Future[ServiceResponse[Option[VatReturnObligations]]] = Future.successful(Right(Some(obligations)))
-    val vatServicePaymentsResult: Future[ServiceResponse[Option[Payments]]] = Future.successful(Right(Some(payments)))
-    val accountDetailsServiceResult: Future[HttpGetResult[CustomerInformation]] = Future.successful(Right(customerInformationMax))
+    val vatServiceReturnsResult: Future[ServiceResponse[Option[VatReturnObligations]]] =
+      Future.successful(Right(Some(obligations)))
+    val vatServicePaymentsResult: Future[ServiceResponse[Option[Payments]]] =
+      Future.successful(Right(Some(payments)))
+    val accountDetailsServiceResult: Future[HttpGetResult[CustomerInformation]] =
+      Future.successful(Right(customerInformationMax))
     val serviceInfoServiceResult: Future[Html] = Future.successful(Html(""))
+    val ddResult: Future[ServiceResponse[DirectDebitStatus]] =
+      Future.successful(Right(DirectDebitStatus(directDebitMandateFound = false, None)))
 
     val mockServiceInfoService: ServiceInfoService = mock[ServiceInfoService]
     val mockVatDetailsService: VatDetailsService = mock[VatDetailsService]
     val mockAuditService: AuditingService = mock[AuditingService]
-
-    val detailsView: Details = injector.instanceOf[Details]
+    val mockPaymentsService: PaymentsService = mock[PaymentsService]
 
     def setup(): Any = {
       (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
@@ -88,6 +91,10 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
       (mockServiceInfoService.getPartial(_: Request[_], _: User, _: ExecutionContext))
         .stubs(*,*,*)
         .returns(serviceInfoServiceResult)
+
+      (mockPaymentsService.getDirectDebitStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
+        .stubs(*, *, *)
+        .returns(ddResult)
     }
 
     mockAppConfig.features.submitReturnFeatures(true)
@@ -99,13 +106,16 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
         mockAppConfig,
         mockVatDetailsService,
         mockServiceInfoService,
+        mockPaymentsService,
         authorisedController,
         mockAccountDetailsService,
         mockDateService,
         mockAuditService,
         mcc,
         ec,
-        detailsView,
+        injector.instanceOf[Details],
+        injector.instanceOf[DDInterruptNoDD],
+        injector.instanceOf[DDInterruptExistingDD],
         mockServiceErrorHandler
       )
     }
@@ -113,62 +123,32 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
   "Calling the details action" when {
 
-    "the user is logged in and does not have a customerMigratedToETMPDate in session" should {
+    "the user is logged in and does not meet the criteria to see an interrupt screen" should {
 
-      "return 200" in new DetailsTest {
-        private val result = target().details()(fakeRequest)
-        status(result) shouldBe Status.OK
+      object Test extends DetailsTest { lazy val result: Future[Result] = target().details()(fakeRequest) }
+
+      "return 200" in {
+        status(Test.result) shouldBe Status.OK
       }
 
-      "return HTML" in new DetailsTest {
-        private val result = target().details()(fakeRequest)
-        contentType(result) shouldBe Some("text/html")
+      "return HTML" in {
+        contentType(Test.result) shouldBe Some("text/html")
       }
 
-      "return charset utf-8" in new DetailsTest {
-        private val result = target().details()(fakeRequest)
-        charset(result) shouldBe Some("utf-8")
+      "return charset utf-8" in {
+        charset(Test.result) shouldBe Some("utf-8")
       }
 
-      "put a customerMigratedToETMPDate key into the session" in new DetailsTest {
-        private val result = target().details()(fakeRequest)
-        session(result).get(SessionKeys.migrationToETMP) shouldBe Some("2017-05-06")
+      "return the VAT overview view" in {
+        await(bodyOf(Test.result)).contains("Your VAT account") shouldBe true
       }
 
-      "put a mandation status in the session" in new DetailsTest {
-        private val result = target().details()(fakeRequest)
-        session(result).get(SessionKeys.mandationStatus) shouldBe Some("MTDfB")
+      "put a customerMigratedToETMPDate key into the session" in {
+        session(Test.result).get(SessionKeys.migrationToETMP) shouldBe Some("2017-05-05")
       }
 
-      "not overwrite the mandation status in the session" in new DetailsTest {
-        val fakeRequestWithSession: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession(
-          SessionKeys.mandationStatus -> "Non MTDfB")
-
-        private val result = target().details()(fakeRequestWithSession)
-        session(result).get(SessionKeys.mandationStatus) shouldBe Some("Non MTDfB")
-      }
-    }
-
-    "the user is logged in and has a customerMigratedToETMPDate in session" should {
-
-      "return 200" in new DetailsTest {
-        private val result = target().details()(fakeRequestWithSession)
-        status(result) shouldBe Status.OK
-      }
-
-      "return HTML" in new DetailsTest {
-        private val result = target().details()(fakeRequestWithSession)
-        contentType(result) shouldBe Some("text/html")
-      }
-
-      "return charset utf-8" in new DetailsTest {
-        private val result = target().details()(fakeRequestWithSession)
-        charset(result) shouldBe Some("utf-8")
-      }
-
-      "not overwrite the customerMigratedToETMPDate value in the session" in new DetailsTest {
-        private val result = target().details()(fakeRequestWithSession)
-        session(result).get(SessionKeys.migrationToETMP) shouldBe Some("2018-01-01")
+      "put a mandation status in the session" in {
+        session(Test.result).get(SessionKeys.mandationStatus) shouldBe Some("MTDfB")
       }
     }
 
@@ -247,6 +227,10 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
           (mockAuditService.audit(_: AuditModel, _: String)(_: HeaderCarrier, _: ExecutionContext))
             .stubs(*, *, *, *)
             .returns({})
+
+          (mockPaymentsService.getDirectDebitStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
+            .stubs(*, *, *)
+            .returns(ddResult)
         }
 
         val result: Future[Result] = target().details()(fakeRequest)
@@ -265,9 +249,8 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
     "the submit return feature switch is turned on" should {
       "return a VatDetailsViewModel as a non MTDfB user" in new DetailsTest {
-        (mockAccountDetailsService.getAccountDetails(_: String)(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, *, *)
-          .returns(Future.successful(Right(customerInformationNonMTDfB)))
+        override val accountDetailsServiceResult: Future[HttpGetResult[CustomerInformation]] =
+          Future.successful(Right(customerInformationNonMTDfB))
 
         mockAppConfig.features.submitReturnFeatures(true)
         lazy val result: Future[Result] = target().details()(fakeRequest)
@@ -276,7 +259,7 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
       }
     }
 
-    "user is a missing trader" should {
+    "the user is a missing trader" should {
 
       "redirect to the manage-vat-subscription-frontend missing trader URL" in new DetailsTest {
         override val accountDetailsServiceResult: Future[HttpGetResult[CustomerInformation]] = Future.successful(Right(
@@ -286,6 +269,60 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
         lazy val result: Future[Result] = target().details()(fakeRequest)
         status(result) shouldBe SEE_OTHER
         redirectLocation(result) shouldBe Some("/missing-trader")
+      }
+    }
+
+    "the user meets the criteria for the DD interrupt screen (no current DD)" should {
+
+      object Test extends DetailsTest {
+        lazy val result: Future[Result] = target().details()(fakeRequest)
+        override val accountDetailsServiceResult: Future[HttpGetResult[CustomerInformation]] =
+          Future.successful(Right(customerInformationMax.copy(customerMigratedToETMPDate = Some("2018-04-01"))))
+      }
+
+      "return 200" in {
+        status(Test.result) shouldBe Status.OK
+      }
+
+      "return HTML" in {
+        contentType(Test.result) shouldBe Some("text/html")
+      }
+
+      "return charset utf-8" in {
+        charset(Test.result) shouldBe Some("utf-8")
+      }
+
+      "return the no DD interrupt view" in {
+        await(bodyOf(Test.result))
+          .contains("Direct debit interrupt screen for migrated users with no existing DD") shouldBe true
+      }
+    }
+
+    "the user meets the criteria for the DD interrupt screen (existing DD)" should {
+
+      object Test extends DetailsTest {
+        lazy val result: Future[Result] = target().details()(fakeRequest)
+        override val accountDetailsServiceResult: Future[HttpGetResult[CustomerInformation]] =
+          Future.successful(Right(customerInformationMax.copy(customerMigratedToETMPDate = Some("2018-04-01"))))
+        override val ddResult: Future[ServiceResponse[DirectDebitStatus]] =
+          Future.successful(Right(DirectDebitStatus(directDebitMandateFound = true, Some(Seq(DDIDetails("2018-03-01"))))))
+      }
+
+      "return 200" in {
+        status(Test.result) shouldBe Status.OK
+      }
+
+      "return HTML" in {
+        contentType(Test.result) shouldBe Some("text/html")
+      }
+
+      "return charset utf-8" in {
+        charset(Test.result) shouldBe Some("utf-8")
+      }
+
+      "return the existing DD interrupt view" in {
+        await(bodyOf(Test.result))
+          .contains("Direct debit interrupt screen for migrated users with an existing DD") shouldBe true
       }
     }
   }
@@ -834,6 +871,119 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
       "return false" in new DetailsTest {
         target().redirectForMissingTrader(Right(customerInformationMax)) shouldBe false
+      }
+    }
+  }
+
+  "Calling .ddInterrupt" when {
+
+    val ddStatusFalse = DirectDebitStatus(directDebitMandateFound = false, Some(Seq(DDIDetails("2018-01-01"))))
+    val ddStatusTrue = DirectDebitStatus(directDebitMandateFound = true, Some(Seq(DDIDetails("2018-01-01"))))
+    val customerMigratedWithin4M = customerInformationMax.copy(customerMigratedToETMPDate = Some("2018-04-01"))
+
+    "the migration date is over 4 months in the past" should {
+
+      "return BypassInterrupt" in new DetailsTest {
+        target().ddInterrupt(Right(customerInformationMax), Right(ddStatusFalse)) shouldBe BypassInterrupt
+      }
+    }
+
+    "the migration date is within 4 months and DD mandate is set to false" should {
+
+      "return InterruptNoDD" in new DetailsTest {
+        target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddStatusFalse)) shouldBe InterruptNoDD
+      }
+    }
+
+    "the migration date is within 4 months and DD mandate is set to true" when {
+
+      "there are no DD details" should {
+
+        "return BypassInterrupt" in new DetailsTest {
+          val ddNoDates: DirectDebitStatus = ddStatusTrue.copy(directDebitDetails = None)
+          target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddNoDates)) shouldBe BypassInterrupt
+        }
+      }
+
+      "there is one set of DD details" when {
+
+        "the DD creation date is before the migration date" should {
+
+          "return InterruptExistingDD" in new DetailsTest {
+            target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddStatusTrue)) shouldBe InterruptExistingDD
+          }
+        }
+
+        "the DD creation date is after the migration date" should {
+
+          "return BypassInterrupt" in new DetailsTest {
+            val ddAfterMig: DirectDebitStatus = ddStatusTrue.copy(directDebitDetails = Some(Seq(DDIDetails("2018-06-01"))))
+            target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddAfterMig)) shouldBe BypassInterrupt
+          }
+        }
+
+        "the DD creation date is the same day as the migration date" should {
+
+          "return InterruptExistingDD" in new DetailsTest {
+            val ddSameDay: DirectDebitStatus = ddStatusTrue.copy(directDebitDetails = Some(Seq(DDIDetails("2018-04-01"))))
+            target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddSameDay)) shouldBe InterruptExistingDD
+          }
+        }
+      }
+
+      "there are multiple sets of DD Details" when {
+
+        "at least one of the DD creation dates is before the migration date" should {
+
+          "return InterruptExistingDD" in new DetailsTest {
+            val ddBeforeMig: DirectDebitStatus =
+              ddStatusTrue.copy(directDebitDetails = Some(Seq(DDIDetails("2018-01-01"), DDIDetails("2018-07-01"))))
+            target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddBeforeMig)) shouldBe InterruptExistingDD
+          }
+        }
+
+        "all of the DD creation dates are after the migration date" should {
+
+          "return BypassInterrupt" in new DetailsTest {
+            val ddAfterMig: DirectDebitStatus =
+              ddStatusTrue.copy(directDebitDetails = Some(Seq(DDIDetails("2018-06-01"), DDIDetails("2018-07-01"))))
+            target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddAfterMig)) shouldBe BypassInterrupt
+          }
+        }
+      }
+    }
+
+    "no migration date was returned" should {
+
+      "return BypassInterrupt, regardless of the DD response" in new DetailsTest {
+        target().ddInterrupt(Right(customerInformationMin), Right(ddStatusFalse)) shouldBe BypassInterrupt
+        target().ddInterrupt(Right(customerInformationMin), Right(ddStatusTrue)) shouldBe BypassInterrupt
+      }
+    }
+
+    "the customer info API response was an error" should {
+
+      "return BypassInterrupt, regardless of the DD response" in new DetailsTest {
+        target().ddInterrupt(Left(UnknownError), Right(ddStatusFalse)) shouldBe BypassInterrupt
+        target().ddInterrupt(Left(UnknownError), Right(ddStatusTrue)) shouldBe BypassInterrupt
+      }
+    }
+
+    "the DD API response was an error" should {
+
+      "return BypassInterrupt, regardless of the customer info response" in new DetailsTest {
+        target().ddInterrupt(Right(customerInformationMax), Left(DirectDebitStatusError)) shouldBe BypassInterrupt
+        target().ddInterrupt(Right(customerMigratedWithin4M), Left(DirectDebitStatusError)) shouldBe BypassInterrupt
+      }
+    }
+
+    "the DD interrupt feature switch is off" should {
+
+      "return BypassInterrupt, regardless of the two API responses" in new DetailsTest {
+        mockAppConfig.features.directDebitInterrupt(false)
+        target().ddInterrupt(Right(customerInformationMax), Right(ddStatusFalse)) shouldBe BypassInterrupt
+        target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddStatusFalse)) shouldBe BypassInterrupt
+        target().ddInterrupt(Right(customerMigratedWithin4M), Right(ddStatusTrue)) shouldBe BypassInterrupt
       }
     }
   }

--- a/test/models/DirectDebitStatusSpec.scala
+++ b/test/models/DirectDebitStatusSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.test.UnitSpec
+
+class DirectDebitStatusSpec extends UnitSpec {
+
+  "Direct debit JSON should parse to a DirectDebitStatus model correctly" when {
+
+    "all expected JSON fields are present and there is one item in the DDI details array" in {
+      val json = Json.obj(
+        "directDebitMandateFound" -> true,
+        "directDebitDetails" -> Json.arr(
+          Json.obj("dateCreated" -> "2018-01-01")
+        )
+      )
+      json.as[DirectDebitStatus] shouldBe
+        DirectDebitStatus(directDebitMandateFound = true, Some(Seq(DDIDetails("2018-01-01"))))
+    }
+
+    "all expected JSON fields are present and there are multiple items in the DDI details array" in {
+      val json = Json.obj(
+        "directDebitMandateFound" -> true,
+        "directDebitDetails" -> Json.arr(
+          Json.obj("dateCreated" -> "2018-01-01"),
+          Json.obj("dateCreated" -> "2018-02-02"),
+          Json.obj("dateCreated" -> "2018-03-03")
+        )
+      )
+      json.as[DirectDebitStatus] shouldBe
+        DirectDebitStatus(
+          directDebitMandateFound = true,
+          Some(Seq(DDIDetails("2018-01-01"), DDIDetails("2018-02-02"), DDIDetails("2018-03-03")))
+        )
+    }
+
+    "the optional DDI details field is not present" in {
+      val json = Json.obj("directDebitMandateFound" -> false)
+      json.as[DirectDebitStatus] shouldBe DirectDebitStatus(directDebitMandateFound = false, None)
+    }
+  }
+}


### PR DESCRIPTION
As part of these changes I removed a small bit of logic in the VAT details controller regarding _reading_ mandation status and migration date from the session. This was to reduce cyclomatic complexity. It's not clear to me why this logic existed as the customer info call is made every time this page loads anyway, so there's no value in branches of logic attempting to read these values from the session. The _writing_ to the session is unaffected.

I was not able to manually test these changes yet as the backend and stub data PRs are not ready. The unit tests should prove the work but we should hold off on the merge until those tasks are ready.