### PR TITLE
BTAT-9591 Added agent variants of What You Owe screens

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,19 +13,14 @@ $hmrc-assets-path: "/vat-through-software/assets/lib/hmrc-frontend/hmrc/assets/"
   padding-top: 0;
 }
 
-.govuk-back-link {
-  margin-bottom: 40px;
+.govuk-back-link, .govuk-breadcrumbs {
+  margin-bottom: 30px;
 }
 
 .govuk-header__link--service-name:hover {
   text-decoration: none;
   pointer-events: none;
   cursor: default;
-}
-
-.govuk-heading-xl {
-  margin-top: 30px;
-  margin-bottom: 30px
 }
 
 .govuk-summary-list {

--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -20,6 +20,7 @@ object SessionKeys {
   val migrationToETMP = "customerMigratedToETMPDate"
   val mandationStatus = "mtdVatMandationStatus"
   val agentSessionVrn = "CLIENT_VRN"
+  val clientName: String = "mtdVatAgentClientName"
 
   val prepopulationEmailKey: String = "vatCorrespondencePrepopulationEmail"
   val inFlightContactKey: String = "inFlightContactDetailsChange"

--- a/app/controllers/OpenPaymentsController.scala
+++ b/app/controllers/OpenPaymentsController.scala
@@ -18,8 +18,10 @@ package controllers
 
 import audit.AuditingService
 import audit.models.ViewOutstandingVatPaymentsAuditModel
+import common.SessionKeys
 import config.AppConfig
 import controllers.predicates.DDInterruptPredicate
+
 import javax.inject.{Inject, Singleton}
 import models.User
 import models.payments.{OpenPaymentsModel, Payment, PaymentOnAccount}
@@ -27,7 +29,7 @@ import models.viewModels.OpenPaymentsViewModel
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import play.twirl.api.Html
-import services.{DateService, EnrolmentsAuthService, PaymentsService, ServiceInfoService}
+import services.{DateService, PaymentsService, ServiceInfoService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.LoggerUtil
@@ -37,59 +39,56 @@ import views.html.payments.{NoPayments, OpenPayments}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class OpenPaymentsController @Inject()(val enrolmentsAuthService: EnrolmentsAuthService,
-                                       authorisedController: AuthorisedController,
+class OpenPaymentsController @Inject()(authorisedController: AuthorisedController,
                                        serviceInfoService: ServiceInfoService,
-                                       val paymentsService: PaymentsService,
-                                       val dateService: DateService,
-                                       implicit val appConfig: AppConfig,
+                                       paymentsService: PaymentsService,
+                                       dateService: DateService,
                                        auditingService: AuditingService,
                                        mcc: MessagesControllerComponents,
-                                       implicit val ec: ExecutionContext,
                                        noPayments: NoPayments,
                                        paymentsError: PaymentsError,
                                        openPaymentsPage: OpenPayments,
                                        DDInterrupt: DDInterruptPredicate)
-extends FrontendController(mcc) with I18nSupport with LoggerUtil {
+                                      (implicit appConfig: AppConfig,
+                                       ec: ExecutionContext)
+  extends FrontendController(mcc) with I18nSupport with LoggerUtil {
 
   def openPayments(): Action[AnyContent] = authorisedController.financialAction { implicit request =>
     implicit user =>
       DDInterrupt.interruptCheck { _ =>
         for {
           serviceInfoContent <- serviceInfoService.getPartial
-          paymentsView <- renderView(None, serviceInfoContent)
+          paymentsView <- renderView(serviceInfoContent)
         } yield paymentsView
       }
   }
 
-  private[controllers] def renderView(hasActiveDirectDebit: Option[Boolean], serviceInfoContent: Html)
+  private[controllers] def renderView(serviceInfoContent: Html)
                                      (implicit request: Request[_], user: User, hc: HeaderCarrier): Future[Result] = {
+    val clientName = request.session.get(SessionKeys.clientName)
     paymentsService.getOpenPayments(user.vrn).map {
       case Right(Some(payments)) =>
-        val model = getModel(payments.financialTransactions.filterNot(_.chargeType equals PaymentOnAccount), hasActiveDirectDebit)
+        val model = getModel(payments.financialTransactions.filterNot(_.chargeType equals PaymentOnAccount))
         auditEvent(user, model.payments)
-        Ok(openPaymentsPage(user, model, serviceInfoContent))
+        Ok(openPaymentsPage(user, model, serviceInfoContent, clientName))
       case Right(_) =>
         auditEvent(user, Seq.empty)
-        Ok(noPayments(user, hasActiveDirectDebit, serviceInfoContent))
+        Ok(noPayments(user, serviceInfoContent, clientName))
       case Left(error) =>
         logger.warn("[OpenPaymentsController][openPayments] error: " + error.toString)
         InternalServerError(paymentsError())
     }
   }
 
-  private[controllers] def getModel(payments: Seq[Payment], hasActiveDirectDebit: Option[Boolean]):
-  OpenPaymentsViewModel = {
+  private[controllers] def getModel(payments: Seq[Payment]): OpenPaymentsViewModel =
     OpenPaymentsViewModel(
       payments.map { payment =>
         OpenPaymentsModel(
           payment,
           isOverdue = payment.due.isBefore(dateService.now()) && !payment.ddCollectionInProgress
         )
-      },
-      hasActiveDirectDebit
+      }
     )
-  }
 
   private[controllers] def auditEvent(user: User, payments: Seq[OpenPaymentsModel])(implicit hc: HeaderCarrier): Unit = {
     auditingService.extendedAudit(ViewOutstandingVatPaymentsAuditModel(user, payments), routes.OpenPaymentsController.openPayments().url)

--- a/app/models/viewModels/OpenPaymentsViewModel.scala
+++ b/app/models/viewModels/OpenPaymentsViewModel.scala
@@ -18,5 +18,4 @@ package models.viewModels
 
 import models.payments.OpenPaymentsModel
 
-case class OpenPaymentsViewModel(payments: Seq[OpenPaymentsModel],
-                                 hasDirectDebit: Option[Boolean])
+case class OpenPaymentsViewModel(payments: Seq[OpenPaymentsModel])

--- a/app/views/errors/PaymentsError.scala.html
+++ b/app/views/errors/PaymentsError.scala.html
@@ -14,15 +14,47 @@
  * limitations under the License.
  *@
 
-@this(mainTemplate: MainTemplate)
+@this(mainTemplate: MainTemplate, govukBreadcrumbs: GovukBreadcrumbs, govukBackLink: GovukBackLink)
 
 @()(implicit appConfig: config.AppConfig, request: Request[_], messages: Messages, user: User)
 
-@mainTemplate(title = messages("paymentsError.title"), appConfig = appConfig, user = Some(user)) {
-  <h1 class="govuk-heading-l">@messages("paymentsError.heading")</h1>
+@breadcrumbs = {
+  @govukBreadcrumbs(Breadcrumbs(
+    items = Seq(
+      BreadcrumbsItem(
+        content = Text(messages("breadcrumbs.bta")),
+        href = Some(appConfig.btaHomeUrl)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("vatDetails.title")),
+        href = Some(controllers.routes.VatDetailsController.details().url)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("openPayments.title"))
+      )
+    )
+  ))
+}
+
+@backLink = {
+  @govukBackLink(BackLink(
+    href = appConfig.agentClientLookupHubUrl,
+    content = Text(messages("base.back"))
+  ))
+}
+
+@mainTemplate(
+  title = messages("paymentsError.title"),
+  appConfig = appConfig,
+  user = Some(user),
+  navLinkContent = if(user.isAgent) Some(backLink) else Some(breadcrumbs)
+) {
+  <h1 class="govuk-heading-xl">@messages("paymentsError.heading")</h1>
   <p class="govuk-body-l">@messages("paymentsError.message")</p>
-  <p class="govuk-body" id="pay-now-content">
-    @messages("paymentsError.payNowOne")
-    <a class="govuk-link" href="@appConfig.unauthenticatedPaymentsUrl">@messages("paymentsError.payNowTwo")</a>.
-  </p>
+  @if(!user.isAgent) {
+    <p class="govuk-body" id="pay-now-content">
+      @messages("paymentsError.payNowOne")
+      <a class="govuk-link" href="@appConfig.unauthenticatedPaymentsUrl">@messages("paymentsError.payNowTwo")</a>.
+    </p>
+  }
 }

--- a/app/views/partials/covid/CovidMessage.scala.html
+++ b/app/views/partials/covid/CovidMessage.scala.html
@@ -32,8 +32,6 @@
   <p class="govuk-body">@messages("covid.line2")</p>
 }
 
-<div class="govuk-grid-row govuk-form-group flex-container">
-  @govukInsetText(InsetText(
-    content = HtmlContent(insetTextContent)
-  ))
-</div>
+@govukInsetText(InsetText(
+  content = HtmlContent(insetTextContent)
+))

--- a/app/views/payments/NoPayments.scala.html
+++ b/app/views/payments/NoPayments.scala.html
@@ -14,34 +14,39 @@
  * limitations under the License.
  *@
 
-@import play.twirl.api.HtmlFormat
 @import views.html.partials.covid.CovidMessage
 
 @this(mainTemplate: MainTemplate,
       covidMessage: CovidMessage,
-      govukBreadcrumbs: GovukBreadcrumbs)
+      govukBreadcrumbs: GovukBreadcrumbs,
+      govukBackLink: GovukBackLink)
 
-@(user: models.User,
-  hasDirectDebit: Option[Boolean],
-  serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_],
-                                                        messages: Messages,
-                                                        appConfig: config.AppConfig)
+@(user: models.User, serviceInfoContent: Html, clientName: Option[String])(
+  implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+
 @breadcrumbs = {
-    @govukBreadcrumbs(Breadcrumbs(
-        items = Seq(
-            BreadcrumbsItem(
-                content = Text(messages("breadcrumbs.bta")),
-                href = Some(appConfig.btaHomeUrl)
-            ),
-            BreadcrumbsItem(
-                content = Text(messages("vatDetails.title")),
-                href = Some(controllers.routes.VatDetailsController.details().url)
-            ),
-            BreadcrumbsItem(
-                content = Text(messages("openPayments.title"))
-            )
-        )
-    ))
+  @govukBreadcrumbs(Breadcrumbs(
+    items = Seq(
+      BreadcrumbsItem(
+        content = Text(messages("breadcrumbs.bta")),
+        href = Some(appConfig.btaHomeUrl)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("vatDetails.title")),
+        href = Some(controllers.routes.VatDetailsController.details().url)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("openPayments.title"))
+      )
+    )
+  ))
+}
+
+@backLink = {
+  @govukBackLink(BackLink(
+    href = appConfig.agentClientLookupHubUrl,
+    content = Text(messages("base.back"))
+  ))
 }
 
 @mainTemplate(
@@ -49,10 +54,13 @@
   appConfig = appConfig,
   serviceInfoContent = serviceInfoContent,
   user = Some(user),
-  navLinkContent = Some(breadcrumbs)) {
+  navLinkContent = if(user.isAgent) Some(backLink) else Some(breadcrumbs)) {
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      @clientName.map { name =>
+        <span class="govuk-caption-xl">@name</span>
+      }
       <h1 class="govuk-heading-xl">@messages("noPayments.heading")</h1>
 
       @if(appConfig.features.displayCovidMessage()) { @covidMessage() }
@@ -61,9 +69,11 @@
         <h2 class="govuk-body-l">@messages("noPayments.oweNothing")</h2>
         <p class="govuk-body">
           @messages("noPayments.twentyFourHours")
-          @messages("payment.stillMake")
-          <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="@appConfig.unauthenticatedPaymentsUrl">
+          @if(!user.isAgent) {
+            @messages("payment.stillMake")
+            <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="@appConfig.unauthenticatedPaymentsUrl">
             @messages("payment.stillMakeLink")</a>.
+          }
         </p>
       </div>
     </div>

--- a/app/views/payments/OpenPayments.scala.html
+++ b/app/views/payments/OpenPayments.scala.html
@@ -16,48 +16,56 @@
 
 @import models.User
 @import models.viewModels.OpenPaymentsViewModel
-@import play.twirl.api.HtmlFormat
 @import views.html.partials.covid.CovidMessage
 @import views.html.templates.payments.WhatYouOweChargeRow
 
 @this(mainTemplate: MainTemplate,
       covidMessage: CovidMessage,
       whatYouOweChargeRow: WhatYouOweChargeRow,
-      govukBreadcrumbs: GovukBreadcrumbs)
+      govukBreadcrumbs: GovukBreadcrumbs,
+      govukBackLink: GovukBackLink)
 
-@(user: User,
-  model: OpenPaymentsViewModel,
-  serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_],
-                                                        messages: Messages,
-                                                        appConfig: config.AppConfig)
+@(user: User, model: OpenPaymentsViewModel, serviceInfoContent: Html, clientName: Option[String])(
+  implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @breadcrumbs = {
-    @govukBreadcrumbs(Breadcrumbs(
-        items = Seq(
-            BreadcrumbsItem(
-                content = Text(messages("breadcrumbs.bta")),
-                href = Some(appConfig.btaHomeUrl)
-            ),
-            BreadcrumbsItem(
-                content = Text(messages("vatDetails.title")),
-                href = Some(controllers.routes.VatDetailsController.details().url)
-            ),
-            BreadcrumbsItem(
-                content = Text(messages("openPayments.title"))
-            )
-        )
-    ))
+  @govukBreadcrumbs(Breadcrumbs(
+    items = Seq(
+      BreadcrumbsItem(
+        content = Text(messages("breadcrumbs.bta")),
+        href = Some(appConfig.btaHomeUrl)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("vatDetails.title")),
+        href = Some(controllers.routes.VatDetailsController.details().url)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("openPayments.title"))
+      )
+    )
+  ))
+}
+
+@backLink = {
+  @govukBackLink(BackLink(
+    href = appConfig.agentClientLookupHubUrl,
+    content = Text(messages("base.back"))
+  ))
 }
 
 @mainTemplate(
-    title = messages("openPayments.title"),
-    appConfig = appConfig,
-    serviceInfoContent = serviceInfoContent,
-    user = Some(user),
-    navLinkContent = Some(breadcrumbs)) {
+  title = messages("openPayments.title"),
+  appConfig = appConfig,
+  serviceInfoContent = serviceInfoContent,
+  user = Some(user),
+  navLinkContent = if(user.isAgent) Some(backLink) else Some(breadcrumbs)
+) {
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      @clientName.map { name =>
+        <span class="govuk-caption-xl">@name</span>
+      }
       <h1 class="govuk-heading-xl">@messages("openPayments.heading")</h1>
 
       @if(appConfig.features.displayCovidMessage()) { @covidMessage() }
@@ -65,7 +73,7 @@
       <div class="payments">
         <div class="section">
           @model.payments.zipWithIndex.map { case(payment, count) =>
-            @whatYouOweChargeRow(payment, count)
+            @whatYouOweChargeRow(payment, count, user.isAgent)
           }
         </div>
 
@@ -78,12 +86,16 @@
           <a class="govuk-link" href="https://www.gov.uk/vat-corrections" rel="noreferrer noopener" target="_blank">
             @messages("openPayments.correctErrors")</a>.
         </p>
-        <p class="govuk-body">@messages("payment.afterSubmitted") @Messages("payment.stillMake")
-          <a class="govuk-link" href="@appConfig.unauthenticatedPaymentsUrl" id="vatPaymentsLink" rel="noreferrer noopener" target="_blank">
-            @messages("payment.stillMakeLink")
-            <span class="govuk-visually-hidden"> @messages("payment.evenIfNotShown")</span></a>.
+        <p class="govuk-body">
+          @messages("payment.afterSubmitted")
+          @if(!user.isAgent) {
+            @messages("payment.stillMake")
+            <a class="govuk-link" href="@appConfig.unauthenticatedPaymentsUrl"
+               id="vatPaymentsLink" rel="noreferrer noopener" target="_blank">
+              @messages("payment.stillMakeLink")
+              <span class="govuk-visually-hidden">@messages("payment.evenIfNotShown")</span></a>.
+          }
         </p>
-
       </div>
     </div>
   </div>

--- a/app/views/templates/payments/WhatYouOweChargeRow.scala.html
+++ b/app/views/templates/payments/WhatYouOweChargeRow.scala.html
@@ -21,7 +21,7 @@
 
 @this(displayMoney: DisplayMoney)
 
-@(payment: OpenPaymentsModel, count: Int)(implicit messages: Messages, appConfig: config.AppConfig)
+@(payment: OpenPaymentsModel, count: Int, userIsAgent: Boolean)(implicit messages: Messages, appConfig: config.AppConfig)
 
 @chargeDetails = @{new WhatYouOweChargeHelper(payment, messages)}
 @defining(chargeDetails.description()) { chargeDescription =>
@@ -46,12 +46,14 @@
         <span data-amount="@(payment.amount)">@displayMoney(payment.amount)</span>
       </dd>
       <dd class="govuk-summary-list__actions what-you-owe-links nowrap">
-        <a class="govuk-link" href="@payment.makePaymentRedirect">
-          <span>@chargeDetails.payLinkText</span>
-          <span class="govuk-visually-hidden">
+        @if(!userIsAgent) {
+          <a class="govuk-link" href="@payment.makePaymentRedirect">
+            <span>@chargeDetails.payLinkText</span>
+            <span class="govuk-visually-hidden">
             @displayMoney(payment.amount)
-          </span>
-        </a>
+            </span>
+          </a>
+        }
 
         @if(chargeDetails.viewReturnEnabled) {
           <p class="govuk-body">

--- a/app/views/vatDetails/Details.scala.html
+++ b/app/views/vatDetails/Details.scala.html
@@ -75,13 +75,12 @@
 ) {
 
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">@messages("vatDetails.title")</h1>
-  <span class="govuk-caption-m">@messages("vatDetails.vrn", user.vrn)
-  </span>
+  <span class="govuk-caption-m">@messages("vatDetails.vrn", user.vrn)</span>
   @detailsViewModel.entityName.map { entityName =>
-    <span class="govuk-caption-m govuk-!-margin-bottom-6">@entityName</span>
+    <span class="govuk-caption-m">@entityName</span>
   }
 
-  <div class="flex-container govuk-grid-row">
+  <div class="flex-container govuk-grid-row govuk-!-margin-top-6">
     @nextPaymentSection(
       detailsViewModel.paymentsData,
       detailsViewModel.hasMultiplePayments,

--- a/test/controllers/OpenPaymentsControllerSpec.scala
+++ b/test/controllers/OpenPaymentsControllerSpec.scala
@@ -98,15 +98,12 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
     def target: OpenPaymentsController = {
       setupMocks()
       new OpenPaymentsController(
-        enrolmentsAuthService,
         authorisedController,
         mockServiceInfoService,
         mockPaymentsService,
         mockDateService,
-        mockAppConfig,
         mockAuditService,
         mcc,
-        ec,
         NoPayments,
         mockPaymentsError,
         openPayments,
@@ -393,10 +390,9 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
                   testPayment.periodTo,
                   testPayment.periodKey,
                   isOverdue = false
-                )),
-                Some(true)
+                ))
               )
-              val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment), Some(true))
+              val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment))
 
               result shouldBe expected
             }
@@ -428,10 +424,9 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
                   testPayment.periodTo,
                   testPayment.periodKey,
                   isOverdue = true
-                )),
-                Some(true)
+                ))
               )
-              val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment), Some(true))
+              val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment))
 
               result shouldBe expected
             }
@@ -464,10 +459,9 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
                 testPayment.periodTo,
                 testPayment.periodKey,
                 isOverdue = false
-              )),
-              Some(true)
+              ))
             )
-            val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment), Some(true))
+            val result: OpenPaymentsViewModel = target.getModel(Seq(testPayment))
 
             result shouldBe expected
           }


### PR DESCRIPTION
As part of this work I found that there were still "has direct debit" elements in the controller, views and view model. The API call to retrieve this status was removed a while ago and so this checking of DD status was pointless, so I have removed it and the related test cases.

Also removed the custom margin that was applied to XL headings, in favour of margin below the breadcrumbs to match the back link.