### PR TITLE
BTAT-9592 Added elements to Payment History screen for agents

### DIFF
--- a/app/models/viewModels/PaymentsHistoryViewModel.scala
+++ b/app/models/viewModels/PaymentsHistoryViewModel.scala
@@ -21,4 +21,5 @@ case class PaymentsHistoryViewModel(tabOne: Int,
                                     tabThree: Option[Int],
                                     previousPaymentsTab: Boolean,
                                     transactions: Seq[PaymentsHistoryModel],
-                                    showInsolvencyContent: Boolean)
+                                    showInsolvencyContent: Boolean,
+                                    clientName: Option[String])

--- a/app/views/payments/PaymentHistory.scala.html
+++ b/app/views/payments/PaymentHistory.scala.html
@@ -15,37 +15,41 @@
  *@
 
 @import models.viewModels.PaymentsHistoryViewModel
-@import play.twirl.api.HtmlFormat
 @import views.html.templates.payments._
 
 @this(mainTemplate: MainTemplate,
       paymentsHistoryTabs: PaymentsHistoryTabs,
       paymentsHistoryTabsContent: PaymentsHistoryTabsContent,
       govukBreadcrumbs: GovukBreadcrumbs,
-      govukTabs: GovukTabs)
+      govukTabs: GovukTabs,
+      govukBackLink: GovukBackLink)
 
-@(model: PaymentsHistoryViewModel,
-  serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_],
-                                                        messages: Messages,
-                                                        appConfig: config.AppConfig,
-                                                        user: User)
+@(model: PaymentsHistoryViewModel, serviceInfoContent: Html)(
+  implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, user: User)
 
 @breadcrumbs = {
-    @govukBreadcrumbs(Breadcrumbs(
-        items = Seq(
-            BreadcrumbsItem(
-                content = Text(messages("breadcrumbs.bta")),
-                href = Some(appConfig.btaHomeUrl)
-            ),
-            BreadcrumbsItem(
-                content = Text(messages("vatDetails.title")),
-                href = Some(controllers.routes.VatDetailsController.details().url)
-            ),
-            BreadcrumbsItem(
-                content = Text(messages("paymentsHistory.title"))
-            )
-        )
-    ))
+  @govukBreadcrumbs(Breadcrumbs(
+    items = Seq(
+      BreadcrumbsItem(
+        content = Text(messages("breadcrumbs.bta")),
+        href = Some(appConfig.btaHomeUrl)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("vatDetails.title")),
+        href = Some(controllers.routes.VatDetailsController.details().url)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("paymentsHistory.title"))
+      )
+    )
+  ))
+}
+
+@backLink = {
+  @govukBackLink(BackLink(
+    href = appConfig.agentClientLookupHubUrl,
+    content = Text(messages("base.back"))
+  ))
 }
 
 @additionalYears = @{
@@ -57,11 +61,14 @@
   appConfig = appConfig,
   serviceInfoContent = serviceInfoContent,
   user = Some(user),
-  navLinkContent = Some(breadcrumbs)) {
-
+  navLinkContent = if(user.isAgent) Some(backLink) else Some(breadcrumbs)
+) {
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      @model.clientName.map { name =>
+        <span class="govuk-caption-xl">@name</span>
+      }
       <h1 id="top" class="govuk-heading-xl">@messages("paymentsHistory.title")</h1>
       <p class="govuk-body govuk-!-margin-bottom-8">
         <a class="govuk-link" href="@controllers.routes.OpenPaymentsController.openPayments().url">
@@ -74,11 +81,14 @@
       }
 
       <div class="govuk-tabs" data-module="govuk-tabs">
-        @paymentsHistoryTabs(Seq(model.tabOne) ++ additionalYears, model.previousPaymentsTab)
+        @paymentsHistoryTabs(
+          Seq(model.tabOne) ++ additionalYears,
+          model.previousPaymentsTab && !user.isAgent
+        )
         @paymentsHistoryTabsContent(
           Seq(model.tabOne) ++ additionalYears,
           model.transactions,
-          model.previousPaymentsTab
+          model.previousPaymentsTab && !user.isAgent
         )
       </div>
     </div>

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import play.core.PlayVersion
 import play.sbt.routes.RoutesKeys
 import sbt.Tests.{Group, SubProcess}
 import uk.gov.hmrc.DefaultBuildSettings._
@@ -32,21 +31,14 @@ lazy val coverageSettings: Seq[Setting[_]] = {
   val excludedPackages = Seq(
     "<empty>",
     ".*Reverse.*",
-    ".*standardError*.*",
-    ".*main_template*.*",
-    "uk.gov.hmrc.BuildInfo",
-    "app.*",
-    "prod.*",
+    ".*Routes.*",
     "config.*",
-    "testOnly.*",
-    "testOnlyDoNotUseInAppConf.*",
-    ".*feedback*.*",
-    "partials.*"
+    "testOnly.*"
   )
 
   Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
-    ScoverageKeys.coverageMinimum := 95,
+    ScoverageKeys.coverageMinimumStmtTotal := 95,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )

--- a/test/controllers/PaymentHistoryControllerSpec.scala
+++ b/test/controllers/PaymentHistoryControllerSpec.scala
@@ -42,7 +42,6 @@ import views.html.errors.StandardError
 import views.html.payments.PaymentHistory
 import play.api.test.Helpers.defaultAwaitTimeout
 
-
 import scala.concurrent.{ExecutionContext, Future}
 
 class PaymentHistoryControllerSpec extends ControllerBaseSpec {
@@ -192,11 +191,9 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
         authorisedController,
         mockDateService,
         mockServiceInfoService,
-        enrolmentsAuthService,
         mockAccountDetailsService,
         mockServiceErrorHandler,
         mcc,
-        ec,
         paymentHistory,
         ddInterruptPredicate
       )
@@ -500,14 +497,16 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
             emptyResult,
             showPreviousPaymentsTab = false,
             Some(LocalDate.parse("2018-01-01")),
-            showInsolvencyContent = false
+            showInsolvencyContent = false,
+            None
           ) shouldBe Some(PaymentsHistoryViewModel(
             currentYear,
             None,
             None,
             previousPaymentsTab = false,
             (serviceResultYearOne.right.get ++ serviceResultYearTwo.right.get).distinct,
-            showInsolvencyContent = false
+            showInsolvencyContent = false,
+            None
           ))
         }
       }
@@ -521,14 +520,16 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
             emptyResult,
             showPreviousPaymentsTab = false,
             Some(LocalDate.parse("2017-01-01")),
-            showInsolvencyContent = false
+            showInsolvencyContent = false,
+            None
           ) shouldBe Some(PaymentsHistoryViewModel(
             currentYear,
             Some(currentYear - 1),
             None,
             previousPaymentsTab = false,
             (serviceResultYearOne.right.get ++ serviceResultYearTwo.right.get).distinct,
-            showInsolvencyContent = false
+            showInsolvencyContent = false,
+            None
           ))
         }
       }
@@ -542,14 +543,16 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
             serviceResultYearThree,
             showPreviousPaymentsTab = false,
             Some(LocalDate.parse("2016-12-12")),
-            showInsolvencyContent = false
+            showInsolvencyContent = false,
+            None
           ) shouldBe Some(PaymentsHistoryViewModel(
             currentYear,
             Some(currentYear - 1),
             Some(currentYear - 2),
             previousPaymentsTab = false,
             (serviceResultYearOne.right.get ++ serviceResultYearTwo.right.get ++ serviceResultYearThree.right.get.drop(1)).distinct,
-            showInsolvencyContent = false
+            showInsolvencyContent = false,
+            None
           ))
         }
       }
@@ -565,7 +568,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
           serviceResultYearThree,
           showPreviousPaymentsTab = false,
           None,
-          showInsolvencyContent = false
+          showInsolvencyContent = false,
+          None
         ) shouldBe None
       }
     }


### PR DESCRIPTION
The agent-specific elements are:
- Client name caption above h1
- Disabling of 'Previous payments' tab and content
- Back link instead of breadcrumbs