### PR TITLE
Added DD session key to stub agent client VRN entry

### DIFF
--- a/app/testOnly/controllers/AgentClientLookupStubController.scala
+++ b/app/testOnly/controllers/AgentClientLookupStubController.scala
@@ -50,6 +50,7 @@ class AgentClientLookupStubController @Inject()(implicit val appConfig: AppConfi
       error => InternalServerError(s"Failed to bind model. Error: $error"),
       success => Redirect(success.redirectUrl)
         .addingToSession(SessionKeys.agentSessionVrn -> success.vrn)
+        .addingToSession(SessionKeys.viewedDDInterrupt -> "true")
     )
   }
 }


### PR DESCRIPTION
The DD interrupt controller does not allow agents through the logic so currently when trying to use the test only page to bypass VACLF, you get denied access to where you were trying to go. I've added the session value here to bypass the DD check, which is consistent with what agents going through VACLF would have at this point.