### PR TITLE
BTAT-9726 Refactor to VatCertificateControllerSpec

### DIFF
--- a/test/controllers/AuthorisedControllerSpec.scala
+++ b/test/controllers/AuthorisedControllerSpec.scala
@@ -90,7 +90,7 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
 
           lazy val result = {
             mockAuth(successfulAuthResponse)
-            mockCustomerInfo(Future.successful(Right(customerInformationInsolvent)))
+            mockCustomerInfo(Right(customerInformationInsolvent))
             target(FakeRequest())
           }
 
@@ -107,7 +107,7 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
 
           lazy val result = {
             mockAuth(successfulAuthResponse)
-            mockCustomerInfo(Future.successful(Right(customerInformationMax)))
+            mockCustomerInfo(Right(customerInformationMax))
             target(FakeRequest())
           }
 
@@ -124,7 +124,7 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
 
           lazy val result = {
             mockAuth(successfulAuthResponse)
-            mockCustomerInfo(Future.successful(Left(UnknownError)))
+            mockCustomerInfo(Left(UnknownError))
             target(FakeRequest())
           }
 

--- a/test/controllers/PaymentHistoryControllerSpec.scala
+++ b/test/controllers/PaymentHistoryControllerSpec.scala
@@ -52,7 +52,6 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
   val paymentHistory: PaymentHistory = injector.instanceOf[PaymentHistory]
 
   val mockPaymentsService: PaymentsService = mock[PaymentsService]
-  val mockServiceInfoService: ServiceInfoService = mock[ServiceInfoService]
   implicit val mockAuditService: AuditingService = mock[AuditingService]
 
   lazy val fakeRequestWithEmptyDate: FakeRequest[AnyContentAsEmpty.type] =
@@ -166,7 +165,7 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
       }
 
       if (accountDetailsCall) {
-        mockCustomerInfo(Future.successful(accountDetailsResponse))
+        mockCustomerInfo(accountDetailsResponse)
       }
 
       if (paymentsServiceCall) {
@@ -333,8 +332,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
         (mockPaymentsService.getPaymentsHistory(_: String, _: Int)(_: HeaderCarrier, _: ExecutionContext))
           .expects(*, *, *, *).noMoreThanOnce()
           .returns(Future.successful(emptyResult))
-        mockCustomerInfo(Future.successful(accountDetailsResponseNoMigratedDate))
-        mockCustomerInfo(Future.successful(accountDetailsResponseNoMigratedDate))
+        mockCustomerInfo(accountDetailsResponseNoMigratedDate)
+        mockCustomerInfo(accountDetailsResponseNoMigratedDate)
         val result: Future[Result] = target.paymentHistory()(fakeRequest)
         status(result) shouldBe OK
       }
@@ -344,8 +343,8 @@ class PaymentHistoryControllerSpec extends ControllerBaseSpec {
         (mockPaymentsService.getPaymentsHistory(_: String, _: Int)(_: HeaderCarrier, _: ExecutionContext))
           .expects(*, *, *, *).noMoreThanOnce()
           .returns(Future.successful(emptyResult))
-        mockCustomerInfo(Future.successful(accountDetailsResponseNoMigratedDate))
-        mockCustomerInfo(Future.successful(accountDetailsResponseNoMigratedDate))
+        mockCustomerInfo(accountDetailsResponseNoMigratedDate)
+        mockCustomerInfo(accountDetailsResponseNoMigratedDate)
         val result: Future[Result] = target.paymentHistory()(fakeRequest)
         val document: Document = Jsoup.parse(contentAsString(result))
         document.select("li.govuk-tabs__list-item:nth-child(4)").text() shouldBe "Previous payments"

--- a/test/controllers/VatCertificateControllerSpec.scala
+++ b/test/controllers/VatCertificateControllerSpec.scala
@@ -18,199 +18,89 @@ package controllers
 
 import common.SessionKeys
 import common.TestModels._
-import models.User
 import org.jsoup.Jsoup
 import play.api.http.Status
-import play.api.mvc.Request
 import play.api.test.Helpers._
-import play.twirl.api.Html
-import services.ServiceInfoService
-import uk.gov.hmrc.auth.core.AffinityGroup.Agent
-import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
-import uk.gov.hmrc.http.HeaderCarrier
 import views.html.certificate.VatCertificate
-
-import scala.concurrent.{ExecutionContext, Future}
 
 class VatCertificateControllerSpec extends ControllerBaseSpec {
 
-  private trait Test {
-    val mockServiceInfoService: ServiceInfoService = mock[ServiceInfoService]
-    val vatCertificate: VatCertificate = injector.instanceOf[VatCertificate]
-
-    val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = successfulAuthResult
-    val serviceInfoServiceResult: Future[Html] = Future.successful(Html(""))
-
-    val customerInfoCallExpected: Boolean = true
-
-    def setup(): Any = {
-      (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
-        .expects(*, *, *, *)
-        .returns(authResult)
-
-      if (customerInfoCallExpected) {
-        (mockAccountDetailsService.getAccountDetails(_: String)(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, *, *)
-          .returns(Future.successful(Right(customerInformationMax)))
-      }
-
-      (mockServiceInfoService.getPartial(_: Request[_], _: User, _: ExecutionContext))
-        .stubs(*, *, *)
-        .returns(serviceInfoServiceResult)
-
-    }
-
-    def target: VatCertificateController = {
-      setup()
-      new VatCertificateController(
-        mockServiceInfoService,
-        authorisedController,
-        mockAccountDetailsService,
-        mcc,
-        vatCertificate,
-        mockServiceErrorHandler
-      )
-    }
-  }
+  val vatCertificate: VatCertificate = injector.instanceOf[VatCertificate]
+  val controller = new VatCertificateController(
+    mockServiceInfoService,
+    authorisedController,
+    mockAccountDetailsService,
+    mcc,
+    vatCertificate,
+    mockServiceErrorHandler
+  )
 
   "The show() action" when {
 
-    "the user is non-agent" when {
+    "the user is a principal entity" when {
 
-      "authorised" should {
+      lazy val result = {
+        mockPrincipalAuth()
+        mockServiceInfoCall()
+        mockCustomerInfo(Right(customerInformationMax))
+        controller.show()(fakeRequest)
+      }
 
-        "return OK (200)" in new Test {
-          private val result = target.show()(fakeRequest)
-          status(result) shouldBe Status.OK
-        }
+      "return OK (200)" in {
+        status(result) shouldBe Status.OK
+      }
 
-        "return HTML" in new Test {
-          private val result = target.show()(fakeRequest)
-          contentType(result) shouldBe Some("text/html")
-        }
+      "return HTML" in {
+        contentType(result) shouldBe Some("text/html")
       }
     }
 
     "the user is an agent" when {
 
-      "user is authorised" should {
-
-        "return OK (200)" in new Test {
-          override def setup(): Unit = {
-            (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
-              .expects(*, *, *, *)
-              .returns(agentAuthResult)
-              .noMoreThanOnce()
-
-            (mockAuthConnector.authorise(_: Predicate, _: Retrieval[Enrolments])(_: HeaderCarrier, _: ExecutionContext))
-              .expects(*, *, *, *)
-              .returns(Future.successful(agentEnrolments))
-              .noMoreThanOnce()
-
-            (mockAccountDetailsService.getAccountDetails(_: String)(_: HeaderCarrier, _: ExecutionContext))
-              .expects(*, *, *)
-              .returns(Future.successful(Right(customerInformationMax)))
-            (mockServiceInfoService.getPartial(_: Request[_], _: User, _: ExecutionContext))
-              .stubs(*, *, *)
-              .returns(serviceInfoServiceResult)
-          }
-
-          private val result = target.show()(fakeRequest.withSession("CLIENT_VRN" -> "123456789"))
-
-          status(result) shouldBe Status.OK
-          contentType(result) shouldBe Some("text/html")
-        }
+      lazy val result = {
+        mockAgentAuth()
+        mockServiceInfoCall()
+        mockCustomerInfo(Right(customerInformationMax))
+        controller.show()(fakeRequest.withSession(SessionKeys.agentSessionVrn -> "123456789"))
       }
 
-      "user is unauthorised" should {
+      "return OK (200)" in {
+        status(result) shouldBe Status.OK
+      }
 
-        "return FORBIDDEN and agent unauthorised page" in new Test {
-
-          override def setup(): Unit = {
-            (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
-              .expects(*, *, *, *)
-              .returns(Future.successful(new ~(otherEnrolment, Some(Agent))))
-              .noMoreThanOnce()
-
-            (mockAuthConnector.authorise(_: Predicate, _: Retrieval[Enrolments])(_: HeaderCarrier, _: ExecutionContext))
-              .expects(*, *, *, *)
-              .returns(Future.successful(otherEnrolment))
-              .noMoreThanOnce()
-          }
-
-          private val result = target.show()(fakeRequest.withSession("CLIENT_VRN" -> "123456789"))
-
-          status(result) shouldBe Status.FORBIDDEN
-          Jsoup.parse(contentAsString(result)).title() shouldBe "You can’t use this service yet - VAT - GOV.UK"
-        }
+      "return HTML" in {
+        contentType(result) shouldBe Some("text/html")
       }
     }
 
     "the user is logged in with invalid credentials" should {
 
-      "return Forbidden (403)" in new Test {
-        override def setup(): Unit = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, *, *, *)
-            .returns(Future.successful(new ~(otherEnrolment, Some(Agent))))
-            .noMoreThanOnce()
+      lazy val result = {
+        mockInsufficientEnrolments()
+        controller.show()(fakeRequest)
+      }
 
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[Enrolments])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, *, *, *)
-            .returns(Future.successful(otherEnrolment))
-            .noMoreThanOnce()
-        }
-
-        override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(InsufficientEnrolments())
-        private val result = target.show()(fakeRequest.withSession(SessionKeys.agentSessionVrn -> "1112223331"))
+      "return Forbidden (403)" in {
         status(result) shouldBe Status.FORBIDDEN
       }
 
-      "return HTML" in new Test {
-        override def setup(): Unit = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, *, *, *)
-            .returns(Future.successful(new ~(otherEnrolment, Some(Agent))))
-            .noMoreThanOnce()
-
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[Enrolments])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, *, *, *)
-            .returns(Future.successful(otherEnrolment))
-            .noMoreThanOnce()
-        }
-
-        override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(InsufficientEnrolments())
-        private val result = target.show()(fakeRequest.withSession(SessionKeys.agentSessionVrn -> "1112223331"))
-        contentType(result) shouldBe Some("text/html")
+      "return the unauthorised page" in {
+        Jsoup.parse(contentAsString(result)).title() shouldBe "You are not authorised to use this service - VAT - GOV.UK"
       }
     }
 
     "the user is not logged in" should {
 
-      "return SEE_OTHER" in new Test {
-        override def setup(): Unit = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, *, *, *)
-            .returns(Future.failed(MissingBearerToken()))
-            .noMoreThanOnce()
-        }
+      lazy val result = {
+        mockMissingBearerToken()
+        controller.show()(fakeRequest)
+      }
 
-        override val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.failed(MissingBearerToken())
-        private val result = target.show()(fakeRequest)
+      "return SEE_OTHER" in {
         status(result) shouldBe Status.SEE_OTHER
       }
 
-      "redirect to sign in" in new Test {
-        override def setup(): Unit = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, *, *, *)
-            .returns(Future.failed(MissingBearerToken()))
-            .noMoreThanOnce()
-        }
-
-        private val result = target.show()(fakeRequest)
+      "redirect to sign in" in {
         redirectLocation(result) shouldBe Some(mockAppConfig.signInUrl)
       }
     }

--- a/test/controllers/predicates/AgentPredicateSpec.scala
+++ b/test/controllers/predicates/AgentPredicateSpec.scala
@@ -65,7 +65,7 @@ class AgentPredicateSpec extends ControllerBaseSpec {
                 .expects(*, *, *, *)
                 .returns(Future.successful(authResponse))
 
-              mockCustomerInfo(Future.successful(Right(customerInformationMax)))
+              mockCustomerInfo(Right(customerInformationMax))
               mockDateServiceCall()
               target(requestWithVRN, financialRequest = true)
             }

--- a/test/controllers/predicates/FinancialPredicateSpec.scala
+++ b/test/controllers/predicates/FinancialPredicateSpec.scala
@@ -49,7 +49,7 @@ class FinancialPredicateSpec extends ControllerBaseSpec {
       "they are hybrid" should {
 
         lazy val result = {
-          mockCustomerInfo(Future.successful(Right(customerInformationHybrid)))
+          mockCustomerInfo(Right(customerInformationHybrid))
           target(fakeRequest)
         }
 
@@ -68,7 +68,7 @@ class FinancialPredicateSpec extends ControllerBaseSpec {
 
         val result = {
           mockDateServiceCall()
-          mockCustomerInfo(Future.successful(Right(customerInformationInsolventFuture)))
+          mockCustomerInfo(Right(customerInformationInsolventFuture))
           target(fakeRequest)
         }
           status(result) shouldBe Status.INTERNAL_SERVER_ERROR
@@ -79,7 +79,7 @@ class FinancialPredicateSpec extends ControllerBaseSpec {
 
         lazy val result = {
           mockDateServiceCall()
-          mockCustomerInfo(Future.successful(Right(customerInformationMax)))
+          mockCustomerInfo(Right(customerInformationMax))
           target(fakeRequest)
         }
 
@@ -97,7 +97,7 @@ class FinancialPredicateSpec extends ControllerBaseSpec {
 
         "return 500" in {
           lazy val result = {
-            mockCustomerInfo(Future.successful(Left(UnknownError)))
+            mockCustomerInfo(Left(UnknownError))
             target(fakeRequest)
           }
           status(result) shouldBe Status.INTERNAL_SERVER_ERROR


### PR DESCRIPTION
Apologies for touching on a few unrelated files here - I changed the customer info mock to prevent needing to repeat `Future.successful` each time it's used.

I've added helper functions in for:

- service info call
- auth (principal, agent, unauthorised, unauthenticated)