### PR TITLE
BTAT-10400 Updated WYO CSS to align overdue label and link text

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,13 +35,16 @@ dl.govuk-\!-margin-bottom-0 > .govuk-summary-list__row > .govuk-summary-list__ke
   }
 }
 
-button.what-you-owe-link {
-  background: none;
-  border: none;
-  padding: 0;
+.what-you-owe-link {
+  display: contents;
+}
+
+.what-you-owe-link > .govuk-tag {
+  pointer-events: none;
+}
+
+.what-you-owe-link > a {
   color: #069;
-  text-decoration: underline;
   cursor: pointer;
-  text-align: left!important;
-  font-size: 1em;
+  font-size: 1.1875rem;
 }

--- a/app/views/payments/WhatYouOwe.scala.html
+++ b/app/views/payments/WhatYouOwe.scala.html
@@ -65,10 +65,6 @@
 }
 
 @paymentHtml(charge: WhatYouOweChargeModel) = {
-  @if(charge.isOverdue){@govukTag(Tag(
-    content = Text(messages("common.overdue")),
-    classes = "govuk-tag--red"
-  ))}
   @form(action = testOnly.controllers.routes.ChargeBreakdownController.showBreakdown) {
     <input type="hidden" name="chargeDescription" value="@charge.chargeDescription">
     <input type="hidden" name="chargeTitle" value="@charge.chargeTitle">
@@ -82,7 +78,13 @@
     <input type="hidden" name="makePaymentRedirect" value="@charge.makePaymentRedirect">
     <input type="hidden" name="periodFrom" value="@charge.periodFrom">
     <input type="hidden" name="periodTo" value="@charge.periodTo">
-    <button class="what-you-owe-link" type="submit">@charge.chargeTitle @charge.chargeDescription</button>
+    <button class="what-you-owe-link" type="submit">
+      @if(charge.isOverdue){@govukTag(Tag(
+        content = Text(messages("common.overdue")),
+        classes = "govuk-tag--red"
+        ))}
+      <a class="govuk-link" tabindex="0">@charge.chargeTitle @charge.chargeDescription</a>
+    </button>
   }
   <span class="govuk-hint govuk-!-margin-0">
     @messages("whatYouOwe.due") @displayDate(charge.dueDate)

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ val compile: Seq[ModuleID] = Seq(
   ws,
   "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.19.0",
   "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "2.0.0-play-28",
-  "uk.gov.hmrc"       %% "play-language"              % "5.1.0-play-28",
+  "uk.gov.hmrc"       %% "play-language"              % "5.2.0-play-28",
   "com.typesafe.play" %% "play-json-joda"             % "2.9.2"
 )
 

--- a/test/views/payments/WhatYouOweViewSpec.scala
+++ b/test/views/payments/WhatYouOweViewSpec.scala
@@ -113,7 +113,7 @@ class WhatYouOweViewSpec extends ViewBaseSpec {
         }
 
         "has an overdue label" in {
-          elementText(tableBodyCell(1, 1) + " > strong") shouldBe "overdue"
+          elementText(tableBodyCell(1, 1) + " .govuk-tag") shouldBe "overdue"
         }
 
         "has the correct due hint text" in {
@@ -137,7 +137,7 @@ class WhatYouOweViewSpec extends ViewBaseSpec {
         }
 
         "does not have an overdue label" in {
-          elementExtinct(tableBodyCell(2, 1) + "> strong")
+          elementExtinct(tableBodyCell(2, 1) + " .govuk-tag")
         }
 
         "has the correct due hint text" in {


### PR DESCRIPTION
The overdue label was moved inside of the button itself in order to fix the alignment issue. I've also added the `tabindex` attribute to the link text so that you can tab to the items in the table with the same behaviour as other links. Other custom CSS was still needed. Here are the explanations:

**.what-you-owe-link**
Ensures the button background does not extend beyond the text on screen, to avoid loading the next page when clicking the nearby empty space

**.what-you-owe-link > govuk-tag**
Disables mouse events for the overdue label itself, to avoid loading the next page when clicking the label

**.what-you-owe-link > a**
Overrides to make the button text look and behave like GOVUK link text