### PR TITLE
BTAT-10401 VAT certificate to use GDS components

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,10 +25,6 @@ dl.govuk-\!-margin-bottom-0 > .govuk-summary-list__row > .govuk-summary-list__ke
   width: 30%;
 }
 
-.card-full > dl:last-child > div > *, #stp-dt, #stp-dd, #nstp-card > dl > div > dd {
-  border-bottom: none;
-}
-
 @media screen {
   #nstp-card > dl > div {
     border-bottom: 1px solid $govuk-border-colour;

--- a/app/views/certificate/VatCertificate.scala.html
+++ b/app/views/certificate/VatCertificate.scala.html
@@ -26,7 +26,8 @@
       nonStandardReturnFrequency: NonStandardReturnFrequency,
       govukBreadcrumbs: GovukBreadcrumbs,
       govukBackLink: GovukBackLink,
-      govukButton: GovukButton)
+      govukButton: GovukButton,
+      govukSummaryList: GovukSummaryList)
 
 @(serviceInfoContent: Html = HtmlFormat.empty,
   model: VatCertificateViewModel)(implicit messages: Messages,
@@ -58,17 +59,22 @@
   }
 }
 
-@fieldRow(title: String, content: Any, id: String) = {
-  <dl class="govuk-summary-list govuk-!-margin-bottom-0">
-    <div id="@id" class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key govuk-!-font-weight-bold">
-        @title
-      </dt>
-      <dd class="govuk-summary-list__value">
-        @content
-      </dd>
-    </div>
-  </dl>
+
+@fieldRow(title: String, content: String, id: String, displayRow: Boolean = true) = @{
+
+ if (displayRow) { Seq(
+      SummaryListRow(
+        key = Key(
+          content = Text(messages(title)),
+          classes = id
+        ),
+        value = Value(
+          content = HtmlContent(content),
+            classes = id
+        )
+      )
+  )} else Seq()
+
 }
 
 @isSoleTrader = @{
@@ -98,17 +104,30 @@
       </h2>
     </div>
     <div class="govuk-grid-column-full card-full">
-      @fieldRow(messages("vatCertificate.aboutYourRegistration.vrn"), model.vrn, "vrn")
-      @fieldRow(
-        messages("vatCertificate.aboutYourRegistration.registrationDate"),
-        model.registrationDate.map(displayDate(_)).getOrElse(messages("common.notProvided")),
-        "registration-date"
-      )
-      @fieldRow(
-        messages("vatCertificate.aboutYourRegistration.certificateDate"),
-        displayDate(model.certificateDate),
-        "certificate-date"
-      )
+
+      @govukSummaryList(SummaryList(
+        rows =
+
+            fieldRow(
+                messages("vatCertificate.aboutYourRegistration.vrn"),
+                model.vrn,
+                "vrn"
+            ) ++
+
+            fieldRow(
+                messages("vatCertificate.aboutYourRegistration.registrationDate"),
+                model.registrationDate.map(displayDate(_)).getOrElse(messages("common.notProvided")),
+                "registration-date"
+            ) ++
+
+            fieldRow(
+                messages("vatCertificate.aboutYourRegistration.certificateDate"),
+                displayDate(model.certificateDate),
+                "certificate-date"
+            ),
+        classes = "govuk-!-margin-bottom-0"
+      ))
+
     </div>
   </div>
 
@@ -117,41 +136,58 @@
       <h2 id="about-the-business-heading" class="govuk-heading-m card-heading">@messages("vatCertificate.aboutTheBusiness.title")</h2>
     </div>
     <div class="govuk-grid-column-full card-full">
-      @if(isSoleTrader && model.fullName.nonEmpty) {
-        @fieldRow(messages("vatCertificate.aboutYourRegistration.fullName"), model.fullName.get, "full-name")
-      }
-      @if(!isSoleTrader) {
-        @fieldRow(
-          messages("vatCertificate.aboutTheBusiness.businessName"),
-          model.businessName.getOrElse(messages("common.notProvided")),
-          "business-name"
-        )
-      }
-      @if(isSoleTrader) {
-        @if(model.tradingName.nonEmpty) {
-          @fieldRow(messages("vatCertificate.aboutTheBusiness.tradingName"), model.tradingName.get, "trading-name")
-        }
-      } else {
-        @fieldRow(
-          messages("vatCertificate.aboutTheBusiness.tradingName"),
-          model.tradingName.getOrElse(messages("common.notProvided")),
-          "trading-name"
-        )
-      }
-      @fieldRow(
-        messages("vatCertificate.aboutTheBusiness.businessType"),
-        messages(model.businessTypeMsgKey),
-        "business-type")
-      @fieldRow(
-        messages("vatCertificate.aboutTheBusiness.tradeClassification"),
-        model.tradeClassification,
-        "trade-classification"
-      )
-      @fieldRow(
-        messages("vatCertificate.aboutTheBusiness.principalPlaceOfBusiness"),
-        fullAddress(model.ppob),
-        "ppob"
-      )
+
+      @govukSummaryList(SummaryList(
+        rows =
+
+            fieldRow(
+              messages("vatCertificate.aboutYourRegistration.fullName"),
+              model.fullName.getOrElse(messages("common.notProvided")),
+              "full-name",
+              isSoleTrader && model.fullName.nonEmpty
+            ) ++
+
+            fieldRow(
+              messages("vatCertificate.aboutTheBusiness.businessName"),
+              model.businessName.getOrElse(messages("common.notProvided")),
+              "business-name",
+              !isSoleTrader
+            ) ++
+
+            fieldRow(
+              messages("vatCertificate.aboutTheBusiness.tradingName"),
+              model.tradingName.getOrElse(messages("common.notProvided")),
+              "trading-name",
+              isSoleTrader && model.tradingName.nonEmpty
+            ) ++
+
+            fieldRow(
+              messages("vatCertificate.aboutTheBusiness.tradingName"),
+              model.tradingName.getOrElse(messages("common.notProvided")),
+              "trading-name",
+              !isSoleTrader
+            ) ++
+
+            fieldRow(
+              messages("vatCertificate.aboutTheBusiness.businessType"),
+              messages(model.businessTypeMsgKey),
+              "business-type"
+            ) ++
+
+            fieldRow(
+              messages("vatCertificate.aboutTheBusiness.tradeClassification"),
+              model.tradeClassification.getOrElse(messages("common.notProvided")),
+              "trade-classification"
+            ) ++
+
+            fieldRow(
+              messages("vatCertificate.aboutTheBusiness.principalPlaceOfBusiness"),
+              fullAddress(model.ppob).toString,
+              "ppob"
+            ),
+        classes = "govuk-!-margin-bottom-0"
+      ))
+
     </div>
   </div>
 

--- a/app/views/certificate/helpers/StandardReturnFrequency.scala.html
+++ b/app/views/certificate/helpers/StandardReturnFrequency.scala.html
@@ -14,22 +14,30 @@
  * limitations under the License.
  *@
 
-@this()
+@this(govukSummaryList: GovukSummaryList)
 
 @(returnPeriod: String)(implicit messages: Messages)
 
 <div class="card-full-container govuk-grid-column-full">
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m card-heading">@messages("vatCertificate.returnDetails.title")</h2>
-    <dl class="govuk-summary-list govuk-check-your-answers govuk-!-margin-bottom-0">
-      <div class="govuk-summary-list__row">
-        <dt id="stp-dt" class="govuk-summary-list__key govuk-!-font-weight-bold">
-          @messages("vatCertificate.returnDetails.returnDates")
-        </dt>
-        <dd id="stp-dd" class="govuk-summary-list__value">
-          @messages(returnPeriod)
-        </dd>
-      </div>
-    </dl>
+
+
+    @govukSummaryList(SummaryList(
+      classes = "govuk-summary-list--no-border govuk-!-margin-bottom-0 govuk-!-padding-bottom-3",
+        rows = Seq(
+            SummaryListRow(
+                key = Key(
+                    content = Text(messages("vatCertificate.returnDetails.returnDates")),
+                    classes = "stp"
+                ),
+                value = Value(
+                    content = Text(messages(returnPeriod)),
+                    classes = "stp"
+                )
+            )
+        )
+    ))
+
   </div>
 </div>

--- a/public/stylesheets/print.css
+++ b/public/stylesheets/print.css
@@ -13,11 +13,13 @@
   .govuk-back-link,
   #get-help-action,
   #content > .float--right,
-  footer
+  footer,
+  .hmrc-account-menu__main
   { display: none; }
 
   h1 {
     font-size: 200% !important;
+    padding-top: 20px !important;
   }
 
   h2 {

--- a/test/views/certificate/VatCertificateViewSpec.scala
+++ b/test/views/certificate/VatCertificateViewSpec.scala
@@ -17,7 +17,6 @@
 package views.certificate
 
 import java.time.LocalDate
-
 import common.TestModels.{exampleNonNSTP, exampleNonStandardTaxPeriods}
 import models.Address
 import models.viewModels.VatCertificateViewModel
@@ -37,33 +36,25 @@ class VatCertificateViewSpec extends ViewBaseSpec {
     val breadcrumb2 = ".govuk-breadcrumbs__list-item:nth-child(2) > a"
     val cardClass = ".card-full-container"
     val aboutYourRegHeading = "#about-your-registration-heading"
-    val vrnRow = "#vrn"
-    val vrnTitle = s"$vrnRow > dt"
-    val vrn = s"$vrnRow > dd"
-    val regDateRow = "#registration-date"
-    val regDateTitle = s"$regDateRow > dt"
-    val regDate = s"$regDateRow > dd"
-    val certDateRow = "#certificate-date"
-    val certDateTitle = s"$certDateRow > dt"
-    val certDate = s"$certDateRow > dd"
+    val vrnTitle = "dt.vrn"
+    val vrn = "dd.vrn"
+    val regDateTitle = "dt.registration-date"
+    val regDate = "dd.registration-date"
+    val certDateTitle = "dt.certificate-date"
+    val certDate = "dd.certificate-date"
     val aboutTheBusinessHeading = "#about-the-business-heading"
-    val businessNameRow = "#business-name"
-    val businessNameTitle = s"$businessNameRow > dt"
-    val businessName = s"$businessNameRow > dd"
-    val tradingNameRow = "#trading-name"
-    val tradingNameTitle = s"$tradingNameRow > dt"
-    val tradingName = s"$tradingNameRow > dd"
-    val businessTypeRow = "#business-type"
-    val businessTypeTitle = s"$businessTypeRow > dt"
-    val businessType = s"$businessTypeRow > dd"
-    val tradeClassificationRow = "#trade-classification"
-    val tradeClassificationTitle = s"$tradeClassificationRow > dt"
-    val tradeClassification = s"$tradeClassificationRow > dd"
-    val ppobRow = "#ppob"
-    val ppobRowTitle = s"$ppobRow > dt"
-    val ppob = s"$ppobRow > dd"
+    val businessNameTitle = "dt.business-name"
+    val businessName = "dd.business-name"
+    val tradingNameTitle = "dt.trading-name"
+    val tradingName = "dd.trading-name"
+    val businessTypeTitle = "dt.business-type"
+    val businessType = "dd.business-type"
+    val tradeClassificationTitle = "dt.trade-classification"
+    val tradeClassification = "dd.trade-classification"
+    val ppobRowTitle = "dt.ppob"
+    val ppob = "dd.ppob"
     val printButton = ".govuk-button"
-    val fullNameSelector = "#full-name > dd"
+    val fullNameSelector = "dd.full-name"
     val backLink = ".govuk-back-link"
   }
 
@@ -255,8 +246,8 @@ class VatCertificateViewSpec extends ViewBaseSpec {
         }
 
         "contains the return frequency" in {
-          document.select("#stp-dt").text() shouldBe "VAT Return dates"
-          document.select("#stp-dd").text() shouldBe "Every month"
+          document.select("dt.stp").text() shouldBe "VAT Return dates"
+          document.select("dd.stp").text() shouldBe "Every month"
         }
 
       }


### PR DESCRIPTION
I couldn’t change NonStandardReturnFrequency view because summary list doesn’t support our current layout therefore this helper cannot be changed into a twirl component. Another thing to note is the bottom border of the summary list- in staging we don’t have it due to custom css but I’ve ran it by Robin and he agrees we should put the line back in.

I’ve ran wave, axe, validity and also checked the print preview (safari, chrome, Firefox and edge) and all seems fine, but please do double check 🙂 

Here are few VRNs that would be useful to check the different variations of VAT certificate: 999999999, 931564132, 555555555