### PR TITLE
[BTAT-10468] Add link to view VAT return on breakdown pages

### DIFF
--- a/app/models/viewModels/StandardChargeViewModel.scala
+++ b/app/models/viewModels/StandardChargeViewModel.scala
@@ -22,7 +22,6 @@ import models.payments._
 import play.api.i18n.Messages
 import utils.LoggerUtil
 import views.templates.payments.PaymentMessageHelper
-
 import java.time.LocalDate
 
 case class StandardChargeViewModel(chargeType: String,
@@ -73,6 +72,15 @@ case class StandardChargeViewModel(chargeType: String,
       message
     }
   }
+
+  def viewReturnEnabled: Boolean = ChargeType.apply(chargeType) match {
+    case ReturnDebitCharge |
+         ErrorCorrectionDebitCharge |
+         PaymentOnAccountReturnDebitCharge |
+         AAReturnDebitCharge => true
+    case _ => false
+  }
+
 }
 
 object StandardChargeViewModel extends LoggerUtil {
@@ -100,11 +108,4 @@ object StandardChargeViewModel extends LoggerUtil {
     case _ => None
   }
 
-  def viewReturnEnabled(chargeValue: String): Boolean = ChargeType.apply(chargeValue) match {
-    case ReturnDebitCharge |
-         ErrorCorrectionDebitCharge |
-         PaymentOnAccountReturnDebitCharge |
-         AAReturnDebitCharge => true
-    case _ => false
-  }
 }

--- a/app/testOnly/controllers/WhatYouOweController.scala
+++ b/app/testOnly/controllers/WhatYouOweController.scala
@@ -21,10 +21,9 @@ import common.SessionKeys
 import config.AppConfig
 import controllers.AuthorisedController
 import controllers.predicates.DDInterruptPredicate
-import models.User
 import models.payments.{Payment, PaymentOnAccount}
 import models.viewModels._
-import play.api.i18n.{I18nSupport, Messages}
+import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.{AccountDetailsService, DateService, PaymentsService, ServiceInfoService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -99,8 +98,7 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
         )
     }
 
-  def constructViewModel(payments: Seq[Payment], mandationStatus: String)
-                        (implicit user: User, messages: Messages): Option[WhatYouOweViewModel] = {
+  def constructViewModel(payments: Seq[Payment], mandationStatus: String): Option[WhatYouOweViewModel] = {
 
     val totalAmount = payments.map(_.outstandingAmount).sum
     val chargeModels = categoriseCharges(payments)

--- a/app/views/payments/ChargeTypeDetailsView.scala.html
+++ b/app/views/payments/ChargeTypeDetailsView.scala.html
@@ -94,6 +94,14 @@
                 @model.title
             </h1>
 
+            @if(model.viewReturnEnabled) {
+                <p class="govuk-body" id="view-return">
+                    @messages("chargeTypeDetails.viewThis")
+                    <a href="@appConfig.vatReturnUrl(model.periodKey.getOrElse("0000"))"
+                       class="govuk-link">@messages("chargeTypeDetails.vatReturn")</a>.
+                </p>
+            }
+
             @govukSummaryList(SummaryList(
                 rows = Seq(
                     SummaryListRow(

--- a/app/views/payments/WhatYouOwe.scala.html
+++ b/app/views/payments/WhatYouOwe.scala.html
@@ -93,11 +93,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      @mtdNotificationBanner(model.mandationStatus)
-
       <h1 class="govuk-heading-xl">
         @if(user.isAgent) {@messages("whatYouOwe.agentTitle")} else {@messages("whatYouOwe.title")}
       </h1>
+
+      @mtdNotificationBanner(model.mandationStatus)
 
       <p class="govuk-body govuk-!-font-size-24">@messages("whatYouOwe.totalAmountToPay")</p>
       <p class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold govuk-!-margin-bottom-8">

--- a/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
+++ b/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
@@ -44,7 +44,7 @@
 }
 <span class="govuk-hint govuk-!-margin-0">
   @messages("whatYouOwe.due") @displayDate(charge.dueDate)
-  @if(StandardChargeViewModel.viewReturnEnabled(charge.chargeType)) {
+  @if(charge.viewReturnEnabled) {
     <a class="govuk-link govuk-!-padding-left-1" href="@appConfig.vatReturnUrl(charge.periodKey.getOrElse("0000"))">
       @messages("whatYouOwe.viewReturn")
     </a>

--- a/conf/messages
+++ b/conf/messages
@@ -121,6 +121,8 @@ whatYouOwe.details.agent.paymentHelpTwo = If your client cannot pay a tax bill, 
 whatYouOwe.details.agent.paymentHelpThree = setting up a Time to Pay Arrangement (opens in a new tab)
 whatYouOwe.details.agent.paymentHelpFour = This allows them to pay their bill in instalments.
 
+chargeTypeDetails.viewThis = View this
+chargeTypeDetails.vatReturn = VAT Return
 chargeTypeDetails.dueDate = Due date
 chargeTypeDetails.chargeDue = Charge due
 chargeTypeDetails.amountReceived = Amount received

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -113,6 +113,9 @@ openPayments.whatOweHelp.headingAgent = Mae’r swm sy’n ddyledus yn anghywir 
 openPayments.vatReturn = ar gyfer y cyfnod {0}
 openPayments.errorCorrectionReturnContext = y gwnaethoch gywiro ar gyfer y cyfnod {0}
 
+chargeTypeDetails.viewThis = Bwrw golwg dros y
+chargeTypeDetails.vatReturn = Ffurflen TAW hon
+
 whatYouOwe.viewReturn = Bwrw golwg dros y Ffurflen TAW
 
 noPayments.oweNothing = Nid oes arnoch unrhyw beth ar hyn o bryd.

--- a/test/common/TestModels.scala
+++ b/test/common/TestModels.scala
@@ -363,4 +363,33 @@ object TestModels {
 
   val whatYouOweViewModel2Charge: WhatYouOweViewModel =
     WhatYouOweViewModel(567.11, Seq(chargeModel1, chargeModel2), mandationStatus = "")
+
+  val whatYouOweCharge: StandardChargeViewModel = StandardChargeViewModel(
+    chargeType = "VAT Return Debit Charge",
+    outstandingAmount = BigDecimal(1111.11),
+    originalAmount = BigDecimal(3333.33),
+    clearedAmount = Some(BigDecimal(2222.22)),
+    dueDate = LocalDate.parse("2021-04-08"),
+    periodKey = None,
+    isOverdue = false,
+    chargeReference = None,
+    periodFrom = Some(LocalDate.parse("2021-01-01")),
+    periodTo = Some(LocalDate.parse("2021-03-31"))
+  )
+
+  val whatYouOweChargeOverdue: StandardChargeViewModel = whatYouOweCharge.copy(isOverdue = true)
+
+  val whatYouOweChargeNoPeriod: StandardChargeViewModel = whatYouOweCharge.copy(periodFrom = None, periodTo = None)
+
+  val whatYouOweChargeNoPeriodFrom: StandardChargeViewModel = whatYouOweCharge.copy(periodFrom = None)
+
+  val whatYouOweChargeNoPeriodTo: StandardChargeViewModel = whatYouOweCharge.copy(periodTo = None)
+
+  val whatYouOweChargeNoClearedAmount: StandardChargeViewModel = whatYouOweCharge.copy(clearedAmount = None)
+
+  val whatYouOweChargeNoViewReturn: StandardChargeViewModel = whatYouOweCharge.copy(chargeType = "VAT Repayment Supplement Rec")
+
+  val whatYouOweUrl: String = testOnly.controllers.routes.WhatYouOweController.show.url
+
+  val vatDetailsUrl: String = controllers.routes.VatDetailsController.details.url
 }

--- a/test/views/payments/WhatYouOweViewSpec.scala
+++ b/test/views/payments/WhatYouOweViewSpec.scala
@@ -95,8 +95,16 @@ class WhatYouOweViewSpec extends ViewBaseSpec {
           elementText(tableBodyCell(1, 1) + " .govuk-tag") shouldBe "overdue"
         }
 
-        "has the correct due hint text" in {
-          elementText(tableBodyCell(1, 1) + "> span") shouldBe "due 1 March 2018 View VAT Return"
+        "has due hint text" which {
+
+          "has the correct text" in {
+            elementText(tableBodyCell(1, 1) + "> span") shouldBe "due 1 March 2018 View VAT Return"
+          }
+
+          "has the correct href" in {
+            element(tableBodyCell(1, 1) + "> span > a").attr("href") shouldBe mockConfig.vatReturnUrl("18AA")
+          }
+
         }
 
         "has a form with the correct action" in {


### PR DESCRIPTION
The logic I added recently had a method call to the view model inside the view, which was causing some tight coupling and making the unit tests quite annoying to change, so I refactored this in both the WhatYouOwe view and the charge detail view so that the logic is in the controller instead, which is the better way to do it in general I think