### PR TITLE
BTAT-10570 Added penalty logic to crystallised interest view

### DIFF
--- a/app/models/viewModels/CrystallisedInterestViewModel.scala
+++ b/app/models/viewModels/CrystallisedInterestViewModel.scala
@@ -31,7 +31,8 @@ case class CrystallisedInterestViewModel(periodFrom: LocalDate,
                                          amountReceived: BigDecimal,
                                          leftToPay: BigDecimal,
                                          isOverdue: Boolean,
-                                         chargeReference: String) extends ChargeDetailsViewModel {
+                                         chargeReference: String,
+                                         isPenalty: Boolean) extends ChargeDetailsViewModel {
 
   override val outstandingAmount: BigDecimal = interestAmount
 
@@ -68,6 +69,7 @@ object CrystallisedInterestViewModel {
     "amountReceived" -> bigDecimal,
     "leftToPay" -> bigDecimal,
     "isOverdue" -> boolean,
-    "chargeReference" -> text
+    "chargeReference" -> text,
+    "isPenalty" -> boolean
   )(CrystallisedInterestViewModel.apply)(CrystallisedInterestViewModel.unapply))
 }

--- a/app/views/payments/CrystallisedInterestView.scala.html
+++ b/app/views/payments/CrystallisedInterestView.scala.html
@@ -63,6 +63,10 @@
     }
 }
 
+@interestTypeMessageKey = @{
+  if(model.isPenalty) "penalty" else "vat"
+}
+
 @mainTemplate(
   title = model.title,
   appConfig = appConfig,
@@ -78,12 +82,12 @@
         @displayDateRange(model.periodFrom, model.periodTo, alwaysUseYear = true)
       </span>
         <h1 class="govuk-heading-xl">@messages(model.title)</h1>
-        <p class="govuk-body">@messages("crystallisedInterest.vatChargeInterest")</p>
-        <p class="govuk-body">@messages("crystallisedInterest.vatIncreaseDaily")</p>
+        <p class="govuk-body">@messages(s"crystallisedInterest.${interestTypeMessageKey}ChargeInterest")</p>
+        <p class="govuk-body">@messages(s"crystallisedInterest.${interestTypeMessageKey}IncreaseDaily")</p>
         <p class="govuk-body">
             @messages(s"crystallisedInterest.calculation")
             <br>
-            @messages(s"crystallisedInterest.vatCalculation", model.interestRate)
+            @messages(s"crystallisedInterest.${interestTypeMessageKey}Calculation", model.interestRate)
         </p>
 
         @govukSummaryList(SummaryList(

--- a/build.sbt
+++ b/build.sbt
@@ -53,13 +53,10 @@ val compile: Seq[ModuleID] = Seq(
 )
 
 def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
-  "org.scalatest"           %% "scalatest"                    % "3.1.4"             % scope,
-  "org.pegdown"             %  "pegdown"                      % "1.6.0"             % scope,
-  "org.jsoup"               %  "jsoup"                        % "1.14.3"            % scope,
-  "org.scalatestplus.play"  %% "scalatestplus-play"           % "5.1.0"             % scope,
-  "org.scalamock"           %% "scalamock-scalatest-support"  % "3.6.0"             % scope,
-  "com.github.tomakehurst"  %  "wiremock-jre8"                % "2.26.3"            % scope,
-  "com.vladsch.flexmark"    % "flexmark-all"                  % "0.36.8"            % scope
+  "uk.gov.hmrc"   %% "bootstrap-test-play-28"      % "5.24.0",
+  "org.pegdown"   %  "pegdown"                     % "1.6.0"   % scope,
+  "org.jsoup"     %  "jsoup"                       % "1.14.3"  % scope,
+  "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0"   % scope,
 )
 
 TwirlKeys.templateImports ++= Seq(

--- a/conf/messages
+++ b/conf/messages
@@ -152,9 +152,12 @@ estimatedInterest.estimatesExplanation = Penalties and interest will show as est
 estimatedInterest.calculationLink = Read the guidance about how interest is calculated (opens in a new tab)
 
 crystallisedInterest.vatChargeInterest = We charge interest on any unpaid VAT.
+crystallisedInterest.penaltyChargeInterest = We charge interest on any unpaid penalties.
 crystallisedInterest.vatIncreaseDaily = The total increases daily based on the amount of unpaid VAT for the period.
+crystallisedInterest.penaltyIncreaseDaily = The total increases daily based on the unpaid amount.
 crystallisedInterest.calculation = The calculation we use for each day is:
 crystallisedInterest.vatCalculation = (Interest rate of {0}% × VAT amount unpaid) ÷ days in a year
+crystallisedInterest.penaltyCalculation = (Interest rate of {0}% × penalty amount unpaid) ÷ days in a year
 crystallisedInterest.dueDate = Due date
 crystallisedInterest.interestAmount = Interest amount
 crystallisedInterest.amountReceived = Amount received

--- a/test/models/viewModels/CrystallisedInterestViewModelSpec.scala
+++ b/test/models/viewModels/CrystallisedInterestViewModelSpec.scala
@@ -35,7 +35,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
     200.22,
     100.11,
     isOverdue = false,
-    "XXXXXX1234567890"
+    "XXXXXX1234567890",
+    isPenalty = false
   )
 
   "The makePaymentRedirect value" should {
@@ -44,9 +45,10 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
       val amountInPence = (model.interestAmount * 100).toLong
       val chargeTypeEncoded = model.chargeType.replace(" ", "%20")
 
-      model.makePaymentRedirect shouldBe
-        s"/vat-through-software/make-payment/$amountInPence/${model.periodTo.getMonthValue}/${model.periodTo.getYear}" +
+      model.makePaymentRedirect should include(
+        s"/make-payment/$amountInPence/${model.periodTo.getMonthValue}/${model.periodTo.getYear}" +
         s"/${model.periodTo}/$chargeTypeEncoded/${model.dueDate}/${model.chargeReference}"
+      )
     }
   }
 
@@ -65,7 +67,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Right(model)
       }
     }
@@ -82,7 +85,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("chargeType", List("error.required"), List())))
       }
 
@@ -97,7 +101,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("periodFrom", List("error.date"), List())))
       }
 
@@ -112,7 +117,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("periodTo", List("error.date"), List())))
       }
 
@@ -127,7 +133,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("interestRate", List("error.real"), List())))
       }
 
@@ -142,7 +149,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("dueDate", List("error.date"), List())))
       }
 
@@ -157,7 +165,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("interestAmount", List("error.real"), List())))
       }
 
@@ -172,7 +181,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "nope",
           "leftToPay" -> "100.11",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("amountReceived", List("error.real"), List())))
       }
 
@@ -187,7 +197,8 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11.0",
           "isOverdue" -> "false",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("leftToPay", List("error.real"), List())))
       }
 
@@ -202,9 +213,26 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
           "amountReceived" -> "200.22",
           "leftToPay" -> "100.11",
           "isOverdue" -> "5",
-          "chargeReference" -> "XXXXXX1234567890"
+          "chargeReference" -> "XXXXXX1234567890",
+          "isPenalty" -> "false"
         )) shouldBe Left(List(FormError("isOverdue", List("error.boolean"), List())))
       }
+    }
+
+    "the isPenalty field is invalid" in {
+      form.mapping.bind(Map(
+        "periodFrom" -> "2018-01-01",
+        "periodTo" -> "2018-02-02",
+        "chargeType" -> "VAT Default Interest",
+        "interestRate" -> "2.6",
+        "dueDate" -> "2018-03-03",
+        "interestAmount" -> "300.33",
+        "amountReceived" -> "200.22",
+        "leftToPay" -> "100.11",
+        "isOverdue" -> "true",
+        "chargeReference" -> "XXXXXX1234567890",
+        "isPenalty" -> "100"
+      )) shouldBe Left(List(FormError("isPenalty", List("error.boolean"), List())))
     }
   }
 }

--- a/test/views/payments/CrystallisedInterestViewSpec.scala
+++ b/test/views/payments/CrystallisedInterestViewSpec.scala
@@ -40,20 +40,19 @@ class CrystallisedInterestViewSpec extends ViewBaseSpec {
     0.00,
     7.71,
     isOverdue = true,
-    "chargeRef"
+    "chargeRef",
+    isPenalty = false
   )
 
   "Rendering the Crystallised Interest Page for a principal user" when {
 
-    "the user has interest on VAT charge" should {
+    "the interest is not for a penalty charge" should {
 
       lazy val view = injectedView(viewModel, Html(""))(request, messages, mockConfig, user)
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "have the correct document title" in {
-
         document.title shouldBe "VAT officer’s assessment interest - Manage your VAT account - GOV.UK"
-
       }
 
       "have the correct page heading" in {
@@ -87,6 +86,7 @@ class CrystallisedInterestViewSpec extends ViewBaseSpec {
             whatYouOweLink
         }
       }
+
       "have the correct first explanation paragraph" in {
         elementText("#content > div > div > p:nth-child(3)") shouldBe "We charge interest on any unpaid VAT."
       }
@@ -100,6 +100,7 @@ class CrystallisedInterestViewSpec extends ViewBaseSpec {
         elementText("#content > div > div > p:nth-child(5)") shouldBe "The calculation we use for each day is: " +
           s"(Interest rate of ${viewModel.interestRate}% × VAT amount unpaid) ÷ days in a year"
       }
+
       "have the correct heading for the first row" in {
         elementText(".govuk-summary-list__row:nth-child(1) > dt") shouldBe "Due date"
       }
@@ -137,11 +138,11 @@ class CrystallisedInterestViewSpec extends ViewBaseSpec {
         "has the correct link text" in {
           elementText("#content > div > div > a") shouldBe "Pay now"
         }
+
         "has the correct href" in {
           element("#content > div > div > a").attr("href") shouldBe
             "/vat-through-software/make-payment/771/12/2022/2022-12-31/VAT%20OA%20Default%20Interest/2023-03-30/chargeRef"
         }
-
       }
 
       "have a link to guidance on how interest is calculated" which {
@@ -152,7 +153,7 @@ class CrystallisedInterestViewSpec extends ViewBaseSpec {
         }
 
         "has the correct href" in {
-          element("#content > div > div > p:nth-child(8) > a").attr("href") shouldBe "/gov-uk"
+          element("#content > div > div > p:nth-child(8) > a").attr("href") shouldBe mockConfig.govUkHoldingUrl
         }
       }
 
@@ -167,7 +168,27 @@ class CrystallisedInterestViewSpec extends ViewBaseSpec {
         }
       }
     }
+
+    "the interest is for a penalty charge" should {
+
+      lazy val view = injectedView(viewModel.copy(isPenalty = true), Html(""))(request, messages, mockConfig, user)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "have the correct first explanation paragraph" in {
+        elementText("#content > div > div > p:nth-child(3)") shouldBe "We charge interest on any unpaid penalties."
+      }
+
+      "have the correct second explanation paragraph" in {
+        elementText("#content > div > div > p:nth-child(4)") shouldBe "The total increases daily based on the unpaid amount."
+      }
+
+      "have the correct third explanation paragraph" in {
+        elementText("#content > div > div > p:nth-child(5)") shouldBe "The calculation we use for each day is: " +
+          s"(Interest rate of ${viewModel.interestRate}% × penalty amount unpaid) ÷ days in a year"
+      }
+    }
   }
+
   "Rendering the Crystallised Interest Page for an agent" should {
 
     lazy val view = injectedView(viewModel, Html(""))(request, messages, mockConfig, agentUser)
@@ -183,6 +204,7 @@ class CrystallisedInterestViewSpec extends ViewBaseSpec {
         element("#content > div > div > p:nth-child(8) > a").attr("href") shouldBe whatYouOweLink
       }
     }
+
     "not render breadcrumbs" in {
       elementExtinct(".govuk-breadcrumbs")
     }
@@ -197,9 +219,9 @@ class CrystallisedInterestViewSpec extends ViewBaseSpec {
         element(".govuk-back-link").attr("href") shouldBe whatYouOweLink
       }
     }
+
     "not have a pay now button" in {
       elementExtinct("#content > div > div > a")
     }
-
   }
 }


### PR DESCRIPTION
The makePaymentRedirect test in the view model was changed due to inconsistent results when running full tests (`sbt test`) compared with running repeat tests inside the sbt interpreter. For some reason in the interpreter when running more than once it would exclude the prod route `/vat-through-software`.