### PR TITLE
BTAT-10614 Added Crystallised LPP1 view & view model

### DIFF
--- a/app/models/viewModels/CrystallisedInterestViewModel.scala
+++ b/app/models/viewModels/CrystallisedInterestViewModel.scala
@@ -34,10 +34,10 @@ case class CrystallisedInterestViewModel(periodFrom: LocalDate,
                                          chargeReference: String,
                                          isPenalty: Boolean) extends ChargeDetailsViewModel {
 
-  override val outstandingAmount: BigDecimal = interestAmount
+  override val outstandingAmount: BigDecimal = leftToPay
 
   val makePaymentRedirect: String = controllers.routes.MakePaymentController.makePayment(
-    amountInPence = (interestAmount * 100).toLong,
+    amountInPence = (leftToPay * 100).toLong,
     taxPeriodMonth = periodTo.getMonthValue,
     taxPeriodYear = periodTo.getYear,
     vatPeriodEnding = periodTo.toString,

--- a/app/models/viewModels/CrystallisedLPP1ViewModel.scala
+++ b/app/models/viewModels/CrystallisedLPP1ViewModel.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.viewModels
+
+import play.api.i18n.Messages
+import views.templates.payments.PaymentMessageHelper
+
+import java.time.LocalDate
+
+case class CrystallisedLPP1ViewModel(numberOfDays: Int,
+                                     part1Days: Int,
+                                     part2Days: Option[Int],
+                                     interestRate: BigDecimal,
+                                     part1UnpaidVAT: BigDecimal,
+                                     part2UnpaidVAT: Option[BigDecimal],
+                                     dueDate: LocalDate,
+                                     penaltyAmount: BigDecimal,
+                                     amountReceived: BigDecimal,
+                                     leftToPay: BigDecimal,
+                                     periodFrom: LocalDate,
+                                     periodTo: LocalDate,
+                                     chargeType: String,
+                                     chargeReference: String,
+                                     isOverdue: Boolean) extends ChargeDetailsViewModel {
+
+  override val outstandingAmount: BigDecimal = leftToPay
+
+  val makePaymentRedirect: String = controllers.routes.MakePaymentController.makePayment(
+    amountInPence = (leftToPay * 100).toLong,
+    taxPeriodMonth = periodTo.getMonthValue,
+    taxPeriodYear = periodTo.getYear,
+    vatPeriodEnding = periodTo.toString,
+    chargeType = chargeType,
+    dueDate = dueDate.toString,
+    chargeReference = chargeReference
+  ).url
+
+  def title(implicit messages: Messages): String = messages(PaymentMessageHelper.getChargeType(chargeType).title)
+}

--- a/app/models/viewModels/EstimatedInterestViewModel.scala
+++ b/app/models/viewModels/EstimatedInterestViewModel.scala
@@ -33,7 +33,7 @@ case class EstimatedInterestViewModel(periodFrom: LocalDate,
                                       leftToPay: BigDecimal,
                                       isPenalty: Boolean) extends ChargeDetailsViewModel {
 
-  override val outstandingAmount: BigDecimal = currentAmount
+  override val outstandingAmount: BigDecimal = leftToPay
 
   def title(implicit messages: Messages): String = messages(PaymentMessageHelper.getChargeType(chargeType).title)
 

--- a/app/views/payments/CrystallisedLPP1View.scala.html
+++ b/app/views/payments/CrystallisedLPP1View.scala.html
@@ -1,0 +1,144 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import models.viewModels.CrystallisedLPP1ViewModel
+@import views.templates.formatters.dates.DisplayDateRangeHelper._
+@import views.html.templates.formatters.money.DisplayMoney
+
+@this(mainTemplate: MainTemplate,
+      displayMoney: DisplayMoney,
+      govukBreadcrumbs: GovukBreadcrumbs,
+      govukSummaryList: GovukSummaryList,
+      govukBackLink: GovukBackLink,
+      govukButton: GovukButton,
+      govukTag: GovukTag)
+
+@(model: CrystallisedLPP1ViewModel, serviceInfoContent: Html)(
+  implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, user: User)
+
+@breadcrumbs = {
+  @govukBreadcrumbs(Breadcrumbs(
+    items = Seq(
+      BreadcrumbsItem(
+        content = Text(messages("breadcrumbs.bta")),
+        href = Some(appConfig.btaHomeUrl)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("vatDetails.title")),
+        href = Some(controllers.routes.VatDetailsController.details.url)
+      ),
+      BreadcrumbsItem(
+        content = Text(messages("openPayments.title")),
+        href = Some(testOnly.controllers.routes.WhatYouOweController.show.url)
+      )
+    )
+  ))
+}
+
+@backLink = {
+  @govukBackLink(BackLink(
+    content = Text(messages("base.back")),
+    href = testOnly.controllers.routes.WhatYouOweController.show.url
+  ))
+}
+
+@dueDateHtml = {
+  @displayDate(model.dueDate) @if(model.isOverdue) {@govukTag(Tag(
+    content = Text(messages("common.overdue")),
+    classes = "govuk-tag--red"))
+  }
+}
+
+@mainTemplate(
+  title = model.title,
+  appConfig = appConfig,
+  serviceInfoContent = serviceInfoContent,
+  user = Some(user),
+  navLinkContent = if(user.isAgent) Some(backLink) else Some(breadcrumbs)
+) {
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-xl">
+        @displayDateRange(model.periodFrom, model.periodTo, alwaysUseYear = true)
+      </span>
+      <h1 class="govuk-heading-xl">@messages(model.title)</h1>
+      <p class="govuk-body">@messages("crystallisedLPP1.explanation", model.numberOfDays)</p>
+
+      @(model.part2Days, model.part2UnpaidVAT) match {
+        case (Some(part2Days), Some(part2UnpaidVAT)) => {
+          <p class="govuk-body">@messages("crystallisedLPP1.twoParts")</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>@Html(messages(
+              "crystallisedLPP1.calculation", model.interestRate, displayMoney(model.part1UnpaidVAT), model.part1Days
+            ))</li>
+            <li>@Html(messages(
+              "crystallisedLPP1.calculation", model.interestRate, displayMoney(part2UnpaidVAT), part2Days
+            ))</li>
+          </ul>
+        }
+        case _ => {
+          <p class="govuk-body">
+            @messages("crystallisedLPP1.onePart")
+            <br>
+            @Html(messages("crystallisedLPP1.calculation", model.interestRate, displayMoney(model.part1UnpaidVAT), model.part1Days))
+          </p>
+        }
+      }
+
+      @govukSummaryList(SummaryList(
+        rows = Seq(
+          SummaryListRow(
+            key = Key(content = Text(messages("crystallisedLPP1.dueDate"))),
+            value = Value(content = HtmlContent(dueDateHtml))
+          ),
+          SummaryListRow(
+            key = Key(content = Text(messages("crystallisedLPP1.penaltyAmount"))),
+            value = Value(content = HtmlContent(displayMoney(model.penaltyAmount)))
+          ),
+          SummaryListRow(
+            key = Key(content = Text(messages("crystallisedLPP1.amountReceived"))),
+            value = Value(content = HtmlContent(displayMoney(model.amountReceived)))
+          ),
+          SummaryListRow(
+            key = Key(content = Text(messages("crystallisedLPP1.leftToPay"))),
+            value = Value(content = HtmlContent(displayMoney(model.leftToPay)))
+          )
+        )
+      ))
+
+      @if(!user.isAgent) {
+        @govukButton(Button(
+          content = Text(messages("chargeTypeDetails.button")),
+          href = Some(model.makePaymentRedirect)
+        ))
+      }
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="@appConfig.govUkHoldingUrl" target="_blank" rel="noreferrer noopener">
+          @messages("crystallisedLPP1.guidanceLink")
+        </a>
+      </p>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="@testOnly.controllers.routes.WhatYouOweController.show.url">
+          @if(user.isAgent) {@messages("chargeTypeDetails.agentLink")} else {@messages("chargeTypeDetails.link")}
+        </a>
+      </p>
+    </div>
+  </div>
+}

--- a/conf/messages
+++ b/conf/messages
@@ -164,6 +164,16 @@ crystallisedInterest.amountReceived = Amount received
 crystallisedInterest.leftToPay = Left to pay
 crystallisedInterest.guidanceLink = Read the guidance about how interest is calculated (opens in a new tab)
 
+crystallisedLPP1.explanation = This penalty applies if VAT has not been paid for {0} days.
+crystallisedLPP1.onePart = The calculation we use is:
+crystallisedLPP1.twoParts = It is made up of 2 parts:
+crystallisedLPP1.calculation = {0}% of {1} (the unpaid VAT {2} days after the due date)
+crystallisedLPP1.dueDate = Due date
+crystallisedLPP1.penaltyAmount = Penalty amount
+crystallisedLPP1.amountReceived = Amount received
+crystallisedLPP1.leftToPay = Left to pay
+crystallisedLPP1.guidanceLink = Read the guidance about late payment penalties (opens in a new tab)
+
 noPayments.oweNothing = You do not owe anything right now.
 noPayments.oweNothingAgent = Your client does not owe anything right now.
 noPayments.twentyFourHours = If you have submitted a return and need to pay VAT, it can take up to 24 hours to see what you owe.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -123,6 +123,16 @@ chargeTypeDetails.vatReturn = Ffurflen TAW hon
 
 whatYouOwe.viewReturn = Bwrw golwg dros y Ffurflen TAW
 
+crystallisedLPP1.explanation = ???
+crystallisedLPP1.onePart = ???
+crystallisedLPP1.twoParts = ???
+crystallisedLPP1.calculation = ???
+crystallisedLPP1.dueDate = Dyddiad dyledus
+crystallisedLPP1.penaltyAmount = ???
+crystallisedLPP1.amountReceived = Swm a gafwyd
+crystallisedLPP1.leftToPay = Yn weddill i’w dalu
+crystallisedLPP1.guidanceLink = ???
+
 noPayments.oweNothing = Nid oes arnoch unrhyw beth ar hyn o bryd.
 noPayments.oweNothingAgent = Nid oes ar eich cleient unrhyw beth ar hyn o bryd.
 noPayments.twentyFourHours = Os ydych wedi cyflwyno Ffurflen TAW, ac mae angen i chi dalu TAW, gall gymryd hyd at 24 awr i chi weld yr hyn sydd arnoch.

--- a/test/models/viewModels/CrystallisedInterestViewModelSpec.scala
+++ b/test/models/viewModels/CrystallisedInterestViewModelSpec.scala
@@ -42,7 +42,7 @@ class CrystallisedInterestViewModelSpec extends AnyWordSpecLike with Matchers {
   "The makePaymentRedirect value" should {
 
     "be a payment handoff URL generated from the model's parameters" in {
-      val amountInPence = (model.interestAmount * 100).toLong
+      val amountInPence = (model.leftToPay * 100).toLong
       val chargeTypeEncoded = model.chargeType.replace(" ", "%20")
 
       model.makePaymentRedirect should include(

--- a/test/models/viewModels/CrystallisedLPP1ViewModelSpec.scala
+++ b/test/models/viewModels/CrystallisedLPP1ViewModelSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.viewModels
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.time.LocalDate
+
+class CrystallisedLPP1ViewModelSpec extends AnyWordSpecLike with Matchers {
+
+  val model: CrystallisedLPP1ViewModel = CrystallisedLPP1ViewModel(
+    99,
+    10,
+    Some(20),
+    2.4,
+    111.11,
+    Some(222.22),
+    LocalDate.parse("2020-01-01"),
+    500.55,
+    100.11,
+    400.44,
+    LocalDate.parse("2020-03-03"),
+    LocalDate.parse("2020-04-04"),
+    "VAT Return 1st LPP",
+    "CHARGEREF",
+    isOverdue = false
+  )
+
+  "The makePaymentRedirect value" should {
+
+    "be a payment handoff URL generated from the model's parameters" in {
+      val amountInPence = (model.leftToPay * 100).toLong
+      val chargeTypeEncoded = model.chargeType.replace(" ", "%20")
+
+      model.makePaymentRedirect should include(
+        s"/make-payment/$amountInPence/${model.periodTo.getMonthValue}/${model.periodTo.getYear}" +
+          s"/${model.periodTo}/$chargeTypeEncoded/${model.dueDate}/${model.chargeReference}"
+      )
+    }
+  }
+}

--- a/test/views/payments/CrystallisedLPP1ViewSpec.scala
+++ b/test/views/payments/CrystallisedLPP1ViewSpec.scala
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.payments
+
+import models.viewModels.CrystallisedLPP1ViewModel
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.Html
+import views.ViewBaseSpec
+import views.html.payments.CrystallisedLPP1View
+
+import java.time.LocalDate
+
+class CrystallisedLPP1ViewSpec extends ViewBaseSpec {
+
+  val injectedView: CrystallisedLPP1View = injector.instanceOf[CrystallisedLPP1View]
+  val whatYouOweLink: String = testOnly.controllers.routes.WhatYouOweController.show.url
+
+  val viewModel: CrystallisedLPP1ViewModel = CrystallisedLPP1ViewModel(
+    99,
+    10,
+    Some(20),
+    2.4,
+    111.11,
+    Some(222.22),
+    LocalDate.parse("2020-01-01"),
+    500.55,
+    100.11,
+    400.44,
+    LocalDate.parse("2020-03-03"),
+    LocalDate.parse("2020-04-04"),
+    "VAT Return 1st LPP",
+    "CHARGEREF",
+    isOverdue = false
+  )
+
+  "Rendering the Crystallised LPP1 Page for a principal user" when {
+
+    "there are two penalty parts" should {
+
+      lazy val view = injectedView(viewModel, Html(""))(request, messages, mockConfig, user)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "have the correct document title" in {
+        document.title shouldBe "Late payment penalty - Manage your VAT account - GOV.UK"
+      }
+
+      "have the correct page heading" in {
+        elementText("h1") shouldBe "Late payment penalty"
+      }
+
+      "have a period caption" in {
+        elementText(".govuk-caption-xl") shouldBe "3 March 2020 to 4 April 2020"
+      }
+
+      "render breadcrumbs which" should {
+
+        "have the text 'Business tax account'" in {
+          elementText("body > div > div.govuk-breadcrumbs > ol > li:nth-child(1) > a") shouldBe "Business tax account"
+        }
+        "link to bta" in {
+          element("body > div > div.govuk-breadcrumbs > ol > li:nth-child(1) > a").attr("href") shouldBe "bta-url"
+        }
+        "have the text 'Your VAT account'" in {
+          elementText("body > div > div.govuk-breadcrumbs > ol > li:nth-child(2) > a") shouldBe "Your VAT account"
+        }
+        "link to VAT overview page" in {
+          element("body > div > div.govuk-breadcrumbs > ol > li:nth-child(2) > a").attr("href") shouldBe
+            controllers.routes.VatDetailsController.details.url
+        }
+        "have the text 'What You Owe'" in {
+          elementText("body > div > div.govuk-breadcrumbs > ol > li:nth-child(3) > a") shouldBe "What you owe"
+        }
+        "link to the what you owe page" in {
+          element("body > div > div.govuk-breadcrumbs > ol > li:nth-child(3) > a").attr("href") shouldBe
+            whatYouOweLink
+        }
+      }
+
+      "have the correct first explanation paragraph" in {
+        elementText("#content > div > div > p:nth-child(3)") shouldBe
+          "This penalty applies if VAT has not been paid for 99 days."
+      }
+
+      "have the correct calculation explanation paragraph" in {
+        elementText("#content > div > div > p:nth-child(4)") shouldBe "It is made up of 2 parts:"
+      }
+
+      "have a bullet list" which {
+
+        "has the first penalty part calculation as the first bullet point" in {
+          elementText("#content ul > li:nth-child(1)") shouldBe s"${viewModel.interestRate}% of " +
+            s"£${viewModel.part1UnpaidVAT} (the unpaid VAT ${viewModel.part1Days} days after the due date)"
+        }
+
+        "has the second penalty part calculation as the second bullet point" in {
+          elementText("#content ul > li:nth-child(2)") shouldBe s"${viewModel.interestRate}% of " +
+            s"£${viewModel.part2UnpaidVAT.get} (the unpaid VAT ${viewModel.part2Days.get} days after the due date)"
+        }
+      }
+
+      "have the correct heading for the first row" in {
+        elementText(".govuk-summary-list__row:nth-child(1) > dt") shouldBe "Due date"
+      }
+
+      "display when the penalty is due by" in {
+        elementText(".govuk-summary-list__row:nth-child(1) > dd") shouldBe "1 January 2020"
+      }
+
+      "have the correct heading for the second row" in {
+        elementText(".govuk-summary-list__row:nth-child(2) > dt") shouldBe "Penalty amount"
+      }
+
+      "display the original amount of the penalty charge" in {
+        elementText(".govuk-summary-list__row:nth-child(2) > dd") shouldBe s"£${viewModel.penaltyAmount}"
+      }
+
+      "have the correct heading for the third row" in {
+        elementText(".govuk-summary-list__row:nth-child(3) > dt") shouldBe "Amount received"
+      }
+
+      "display the amount received" in {
+        elementText(".govuk-summary-list__row:nth-child(3) > dd") shouldBe s"£${viewModel.amountReceived}"
+      }
+
+      "have the correct heading for the fourth row" in {
+        elementText(".govuk-summary-list__row:nth-child(4) > dt") shouldBe "Left to pay"
+      }
+
+      "display the outstanding amount" in {
+        elementText(".govuk-summary-list__row:nth-child(4) > dd") shouldBe s"£${viewModel.leftToPay}"
+      }
+
+      "have a pay now button" which {
+
+        "has the correct link text" in {
+          elementText("#content > div > div > a") shouldBe "Pay now"
+        }
+
+        "has the correct href" in {
+          element("#content > div > div > a").attr("href") shouldBe
+            "/vat-through-software/make-payment/40044/4/2020/2020-04-04/VAT%20Return%201st%20LPP/2020-01-01/CHARGEREF"
+        }
+      }
+
+      "have a link to guidance on late payment penalties" which {
+
+        "has the correct link text" in {
+          elementText("#content > div > div > p:nth-child(8) > a") shouldBe
+            "Read the guidance about late payment penalties (opens in a new tab)"
+        }
+
+        "has the correct href" in {
+          element("#content > div > div > p:nth-child(8) > a").attr("href") shouldBe mockConfig.govUkHoldingUrl
+        }
+      }
+
+      "have a link to the what you owe page" which {
+
+        "has the correct link text" in {
+          elementText("#content > div > div > p:nth-child(9) > a") shouldBe "Return to what you owe"
+        }
+
+        "has the correct href" in {
+          element("#content > div > div > p:nth-child(9) > a").attr("href") shouldBe whatYouOweLink
+        }
+      }
+    }
+
+    "there is one penalty part" should {
+
+      lazy val view =
+        injectedView(viewModel.copy(part2Days = None, part2UnpaidVAT = None), Html(""))(request, messages, mockConfig, user)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "have the correct calculation explanation paragraph" in {
+        elementText("#content > div > div > p:nth-child(4)") shouldBe
+          s"The calculation we use is: ${viewModel.interestRate}% of £${viewModel.part1UnpaidVAT} " +
+          s"(the unpaid VAT ${viewModel.part1Days} days after the due date)"
+      }
+
+      "not have a bullet list" in {
+        elementExtinct("#content ul")
+      }
+    }
+  }
+
+  "Rendering the Crystallised LPP1 Page for an agent" should {
+
+    lazy val view = injectedView(viewModel, Html(""))(request, messages, mockConfig, agentUser)
+    lazy implicit val document: Document = Jsoup.parse(view.body)
+
+    "have the correct document title" in {
+      document.title shouldBe "Late payment penalty - Your client’s VAT details - GOV.UK"
+    }
+
+    "have a link to the what you owe page" which {
+
+      "has the correct link text" in {
+        elementText("#content > div > div > p:nth-child(8) > a") shouldBe "Return to what your client owes"
+      }
+
+      "has the correct href" in {
+        element("#content > div > div > p:nth-child(8) > a").attr("href") shouldBe whatYouOweLink
+      }
+    }
+
+    "not render breadcrumbs" in {
+      elementExtinct(".govuk-breadcrumbs")
+    }
+
+    "have a back link" which {
+
+      "has the text Back" in {
+        elementText(".govuk-back-link") shouldBe "Back"
+      }
+
+      "has the correct href" in {
+        element(".govuk-back-link").attr("href") shouldBe whatYouOweLink
+      }
+    }
+
+    "not have a pay now button" in {
+      elementExtinct("#content > div > div > a")
+    }
+  }
+}


### PR DESCRIPTION
A few notes:

- I confirmed with Martin that we don’t have the guidance link yet; this is set to a placeholder for now
- I confirmed with Anirban that it’s unrealistic that any of the day values will be “1”, so the relevant text is fine to be statically set to the plural “days” and not cater for "day"
- I fixed a bug in a few existing view models that were using an incorrect field for their outstanding amount