### PR TITLE
BTAT-10642 WIP

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,27 +38,11 @@ dl.govuk-\!-margin-bottom-0 > .govuk-summary-list__row > .govuk-summary-list__ke
 }
 
 .what-you-owe-link {
-  display: contents;
-}
-
-.what-you-owe-link > .govuk-tag {
-  pointer-events: none;
-}
-
-.what-you-owe-link > a {
   color: #069;
   cursor: pointer;
   font-size: 1.1875rem;
-}
-
-.what-you-owe-link-charge {
-  text-align: left;
-  font-size: 1.1875rem;
-  color: #069;
-  cursor: pointer;
-  text-decoration: underline;
-  border: none;
-  background-color: #FFFFFF;
   padding: 0;
-  display: inline-block;
+  background-color: white;
+  border: none;
+  text-align: left;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -62,13 +62,3 @@ dl.govuk-\!-margin-bottom-0 > .govuk-summary-list__row > .govuk-summary-list__ke
   padding: 0;
   display: inline-block;
 }
-
-.overflow {
-
-}
-.float-right {
-
-}
-.flex {
-
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,3 +50,25 @@ dl.govuk-\!-margin-bottom-0 > .govuk-summary-list__row > .govuk-summary-list__ke
   cursor: pointer;
   font-size: 1.1875rem;
 }
+
+.what-you-owe-link-charge {
+  text-align: left;
+  font-size: 1.1875rem;
+  color: #069;
+  cursor: pointer;
+  text-decoration: underline;
+  border: none;
+  background-color: #FFFFFF;
+  padding: 0;
+  display: inline-block;
+}
+
+.overflow {
+
+}
+.float-right {
+
+}
+.flex {
+
+}

--- a/app/views/templates/payments/wyoCharges/CrystallisedCharge.scala.html
+++ b/app/views/templates/payments/wyoCharges/CrystallisedCharge.scala.html
@@ -20,29 +20,30 @@
 
 @this(form: FormWithCSRF, govukTag: GovukTag)
 
-@(charge: CrystallisedInterestViewModel)(implicit request: Request[_], messages: Messages, appConfig: AppConfig, user: User)
+@(charge: CrystallisedInterestViewModel)(implicit request: Request[_], messages: Messages, user: User)
 
 @form(action = testOnly.controllers.routes.ChargeBreakdownController.crystallisedInterestBreakdown) {
-<input type="hidden" name="periodFrom" value="@charge.periodFrom">
-<input type="hidden" name="periodTo" value="@charge.periodTo">
-<input type="hidden" name="chargeType" value="@charge.chargeType">
-<input type="hidden" name="interestRate" value="@charge.interestRate">
-<input type="hidden" name="dueDate" value="@charge.dueDate">
-<input type="hidden" name="interestAmount" value="@charge.interestAmount">
-<input type="hidden" name="amountReceived" value="@charge.amountReceived">
-<input type="hidden" name="leftToPay" value="@charge.leftToPay">
-<input type="hidden" name="isOverdue" value="@charge.isOverdue">
-<input type="hidden" name="chargeReference" value="@charge.chargeReference">
-<input type="hidden" name="isPenalty" value="@charge.isPenalty">
-<input type="hidden" name="makePaymentRedirect" value="@charge.makePaymentRedirect">
+  <input type="hidden" name="periodFrom" value="@charge.periodFrom">
+  <input type="hidden" name="periodTo" value="@charge.periodTo">
+  <input type="hidden" name="chargeType" value="@charge.chargeType">
+  <input type="hidden" name="interestRate" value="@charge.interestRate">
+  <input type="hidden" name="dueDate" value="@charge.dueDate">
+  <input type="hidden" name="interestAmount" value="@charge.interestAmount">
+  <input type="hidden" name="amountReceived" value="@charge.amountReceived">
+  <input type="hidden" name="leftToPay" value="@charge.leftToPay">
+  <input type="hidden" name="isOverdue" value="@charge.isOverdue">
+  <input type="hidden" name="chargeReference" value="@charge.chargeReference">
+  <input type="hidden" name="isPenalty" value="@charge.isPenalty">
+  <input type="hidden" name="makePaymentRedirect" value="@charge.makePaymentRedirect">
 
-<button class="what-you-owe-link" type="submit">
-    @if(charge.isOverdue){@govukTag(Tag(
+  @if(charge.isOverdue){@govukTag(Tag(
     content = Text(messages("common.overdue")),
     classes = "govuk-tag--red"
-    ))}
-    <a class="govuk-link" tabindex="0">@charge.title @charge.description(user.isAgent)</a>
-</button>
+  ))}
+
+  <button class="what-you-owe-link govuk-link" type="submit">
+    @charge.title @charge.description(user.isAgent)
+  </button>
 }
 <span class="govuk-hint govuk-!-margin-0">
   @messages("whatYouOwe.due") @displayDate(charge.dueDate)

--- a/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
+++ b/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
@@ -34,14 +34,15 @@
   <input type="hidden" name="makePaymentRedirect" value="@charge.makePaymentRedirect">
   <input type="hidden" name="periodFrom" value="@charge.periodFrom">
   <input type="hidden" name="periodTo" value="@charge.periodTo">
-  <button class="what-you-owe-link" type="submit">
+  <button class = "what-you-owe-link-charge govuk-link" type="submit">
     @if(charge.isOverdue){@govukTag(Tag(
       content = Text(messages("common.overdue")),
       classes = "govuk-tag--red"
       ))}
-    <a class="govuk-link" tabindex="0">@charge.title @charge.description(user.isAgent)</a>
+    @charge.title @charge.description(user.isAgent)
   </button>
 }
+
 <span class="govuk-hint govuk-!-margin-0">
   @messages("whatYouOwe.due") @displayDate(charge.dueDate)
   @if(charge.viewReturnEnabled && charge.periodKey.isDefined) {

--- a/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
+++ b/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
@@ -34,13 +34,18 @@
   <input type="hidden" name="makePaymentRedirect" value="@charge.makePaymentRedirect">
   <input type="hidden" name="periodFrom" value="@charge.periodFrom">
   <input type="hidden" name="periodTo" value="@charge.periodTo">
-  <button class = "what-you-owe-link-charge govuk-link" type="submit">
+  <div class='flex'>
+  <span class="overflow">
     @if(charge.isOverdue){@govukTag(Tag(
       content = Text(messages("common.overdue")),
       classes = "govuk-tag--red"
-      ))}
+    ))}
+  </span>
+  <span class="float-right">
+  <button class="what-you-owe-link-charge govuk-link" type="submit">
     @charge.title @charge.description(user.isAgent)
   </button>
+  </span></div>
 }
 
 <span class="govuk-hint govuk-!-margin-0">

--- a/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
+++ b/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
@@ -35,18 +35,16 @@
   <input type="hidden" name="periodFrom" value="@charge.periodFrom">
   <input type="hidden" name="periodTo" value="@charge.periodTo">
 
-  <button class="what-you-owe-link-charge govuk-link" type="submit">
   @if(charge.isOverdue){
     @govukTag(Tag(
       content = Text(messages("common.overdue")),
       classes = "govuk-tag--red"
     ))
   }
-  <span class="what-you-owe-link-charge govuk-link">
-    @charge.title @charge.description(user.isAgent)
-  </span>
-  </button>
 
+  <button class="what-you-owe-link govuk-link" type="submit">
+    @charge.title @charge.description(user.isAgent)
+  </button>
 }
 
 <span class="govuk-hint govuk-!-margin-0">

--- a/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
+++ b/app/views/templates/payments/wyoCharges/StandardCharge.scala.html
@@ -34,18 +34,19 @@
   <input type="hidden" name="makePaymentRedirect" value="@charge.makePaymentRedirect">
   <input type="hidden" name="periodFrom" value="@charge.periodFrom">
   <input type="hidden" name="periodTo" value="@charge.periodTo">
-  <div class='flex'>
-  <span class="overflow">
-    @if(charge.isOverdue){@govukTag(Tag(
+
+  <button class="what-you-owe-link-charge govuk-link" type="submit">
+  @if(charge.isOverdue){
+    @govukTag(Tag(
       content = Text(messages("common.overdue")),
       classes = "govuk-tag--red"
-    ))}
-  </span>
-  <span class="float-right">
-  <button class="what-you-owe-link-charge govuk-link" type="submit">
+    ))
+  }
+  <span class="what-you-owe-link-charge govuk-link">
     @charge.title @charge.description(user.isAgent)
+  </span>
   </button>
-  </span></div>
+
 }
 
 <span class="govuk-hint govuk-!-margin-0">

--- a/public/stylesheets/vat-v1.8.css
+++ b/public/stylesheets/vat-v1.8.css
@@ -111,3 +111,15 @@ html[data-useragent*='MSIE 10.0'] .flex-container {
 .js-enabled .govuk-header__navigation {
     display: block;
 }
+
+.what-you-owe-link-charge {
+    text-align: left;
+    font-size: 1.1875rem;
+    color: #069;
+    cursor: pointer;
+    text-decoration: underline;
+    border: none;
+    background-color: #FFFFFF;
+    padding: 0;
+}
+

--- a/public/stylesheets/vat-v1.8.css
+++ b/public/stylesheets/vat-v1.8.css
@@ -111,15 +111,3 @@ html[data-useragent*='MSIE 10.0'] .flex-container {
 .js-enabled .govuk-header__navigation {
     display: block;
 }
-
-.what-you-owe-link-charge {
-    text-align: left;
-    font-size: 1.1875rem;
-    color: #069;
-    cursor: pointer;
-    text-decoration: underline;
-    border: none;
-    background-color: #FFFFFF;
-    padding: 0;
-}
-

--- a/test/views/templates/payments/wyoCharges/CrystallisedChargeViewSpec.scala
+++ b/test/views/templates/payments/wyoCharges/CrystallisedChargeViewSpec.scala
@@ -34,7 +34,7 @@ class CrystallisedChargeViewSpec extends ViewBaseSpec{
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "have the correct charge description text" in {
-        elementText(".what-you-owe-link") shouldBe
+        elementText("form") shouldBe
           "overdue Interest on central assessment of VAT for period 1 Jan to 1 Mar 2021"
       }
 
@@ -58,7 +58,7 @@ class CrystallisedChargeViewSpec extends ViewBaseSpec{
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "have the correct charge description text" in {
-        elementText(".what-you-owe-link") shouldBe
+        elementText("form") shouldBe
           "Interest on central assessment of VAT for period 1 Jan to 1 Mar 2021"
       }
 

--- a/test/views/templates/payments/wyoCharges/StandardChargeViewSpec.scala
+++ b/test/views/templates/payments/wyoCharges/StandardChargeViewSpec.scala
@@ -34,7 +34,7 @@ class StandardChargeViewSpec extends ViewBaseSpec {
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "have the correct charge description text" in {
-        elementText(".what-you-owe-link") shouldBe
+        elementText("form") shouldBe
           s"overdue ${chargeModel1.title} ${chargeModel1.description(isAgent = false)}"
       }
 
@@ -69,7 +69,7 @@ class StandardChargeViewSpec extends ViewBaseSpec {
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "have the correct charge description text" in {
-        elementText(".what-you-owe-link") shouldBe
+        elementText("form") shouldBe
           s"${chargeModel2.title} ${chargeModel2.description(isAgent = false)}"
       }
 


### PR DESCRIPTION
The validity issue is gone, and I've ran it against Wave and Axe too and there aren't any concerning issues raised (the same usual ones). 

However, in the screenshot attached you can see there is a bit of line between the charge and overdue label, and if you hover over the overdue label and click it will take you to the charge breakdown page, this wasn't present in the old WYO page but caused by the code change I implemented, but if I separate them the Overdue label and charge will be in separate lines. I've been fiddling around with it to sort it out but I have not found a solution for this. 


![Screenshot 2022-06-30 at 16 07 28](https://user-images.githubusercontent.com/63787618/176719013-da96cee7-d02c-4e5a-82c8-a75cd3107923.png)

