### PR TITLE
BTAT-10647 Added 4 new interest charge types

### DIFF
--- a/app/models/payments/ChargeType.scala
+++ b/app/models/payments/ChargeType.scala
@@ -199,9 +199,20 @@ case object UnallocatedPayment extends ChargeType {
 case object Refund extends ChargeType {
   override val value: String = "Refund"
 }
-
 case object VatReturn1stLPP extends ChargeType {
   override val value: String = "VAT Return 1st LPP"
+}
+case object VatReturnLPI extends ChargeType {
+  override val value: String = "VAT Return LPI"
+}
+case object VatReturn1stLPPLPI extends ChargeType {
+  override val value: String = "VAT Return 1st LPP LPI"
+}
+case object VatReturn2ndLPPLPI extends ChargeType {
+  override val value: String = "VAT Return 2nd LPP LPI"
+}
+case object VatCentralAssessmentLPI extends ChargeType {
+  override val value: String = "VAT Central Assessment LPI"
 }
 
 object ChargeType extends LoggerUtil {
@@ -267,8 +278,28 @@ object ChargeType extends LoggerUtil {
     PaymentOnAccountInstalments,
     UnallocatedPayment,
     Refund,
-    VatReturn1stLPP
+    VatReturn1stLPP,
+    VatReturnLPI,
+    VatReturn1stLPPLPI,
+    VatReturn2ndLPPLPI,
+    VatCentralAssessmentLPI
   ) ++ positiveOrNegativeChargeTypes
+
+  val interestChargeTypes = Seq(
+    VatReturnLPI,
+    VatReturn1stLPPLPI,
+    VatReturn2ndLPPLPI,
+    VatCentralAssessmentLPI
+  )
+
+  val penaltyInterestChargeTypes = Seq(
+    VatReturn1stLPPLPI,
+    VatReturn2ndLPPLPI,
+  )
+
+  val penaltyChargeTypes = Seq(
+    VatReturn1stLPP
+  )
 
   def apply: String => ChargeType = input => {
     allChargeTypes.find { chargeType =>

--- a/app/views/templates/payments/PaymentMessageHelper.scala
+++ b/app/views/templates/payments/PaymentMessageHelper.scala
@@ -71,30 +71,30 @@ object PaymentMessageHelper {
   object VatReturnDebitCharge extends PaymentMessageHelper(
     ReturnDebitCharge.value,
     "chargeType.vatReturnDebitChargeTitle",
-    Some("chargeType.vatReturnDebitChargeDescription"),
-    Some("chargeType.vatReturnDebitChargeDescription")
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
   )
 
 
   object VatOfficerAssessmentCreditCharge extends PaymentMessageHelper(
     OACreditCharge.value,
     "chargeType.officerAssessmentChargeTitle",
-    Some("chargeType.officerAssessmentCreditChargeDescription"),
-    Some("chargeType.officerAssessmentCreditChargeDescription")
+    Some("chargeType.for"),
+    Some("chargeType.for")
   )
 
   object VatOfficerAssessmentDebitCharge extends PaymentMessageHelper(
     OADebitCharge.value,
     "chargeType.officerAssessmentChargeTitle",
-    Some("chargeType.officerAssessmentDebitChargeDescription"),
-    Some("chargeType.officerAssessmentDebitChargeDescription")
+    Some("chargeType.for"),
+    Some("chargeType.for")
   )
 
   object VatCentralAssessment extends PaymentMessageHelper(
     CentralAssessmentCharge.value,
     "chargeType.vatCentralAssessmentTitle",
-    Some("chargeType.vatCentralAssessmentDescription"),
-    Some("chargeType.vatCentralAssessmentDescription")
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
   )
 
   object VatDebitDefaultSurcharge extends PaymentMessageHelper(
@@ -114,15 +114,15 @@ object PaymentMessageHelper {
   object VatErrorCorrectionDebitCharge extends PaymentMessageHelper(
     ErrorCorrectionDebitCharge.value,
     "chargeType.vatErrorCorrectionDebitChargeTitle",
-    Some("chargeType.vatErrorCorrectionChargeDescription"),
-    Some("chargeType.vatErrorCorrectionChargeDescription")
+    Some("chargeType.for"),
+    Some("chargeType.for")
   )
 
   object VatErrorCorrectionCreditCharge extends PaymentMessageHelper(
     ErrorCorrectionCreditCharge.value,
     "chargeType.vatErrorCorrectionCreditChargeTitle",
-    Some("chargeType.vatErrorCorrectionChargeDescription"),
-    Some("chargeType.vatErrorCorrectionChargeDescription")
+    Some("chargeType.for"),
+    Some("chargeType.for")
   )
 
   object VatRepaymentSupplement extends PaymentMessageHelper(
@@ -184,8 +184,8 @@ object PaymentMessageHelper {
   object VatAdditionalAssessment extends PaymentMessageHelper(
     AACharge.value,
     "chargeType.VatAdditionalAssessmentTitle",
-    Some("chargeType.VatAdditionalAssessmentDescription"),
-    Some("chargeType.VatAdditionalAssessmentDescription")
+    Some("chargeType.for"),
+    Some("chargeType.for")
   )
 
   object VatAADefaultInterest extends PaymentMessageHelper(
@@ -205,29 +205,29 @@ object PaymentMessageHelper {
   object VatAAMonthlyInstalment extends PaymentMessageHelper(
     AAMonthlyInstalment.value,
     "chargeType.VatAnnualAccountMonthlyInstalmentTitle",
-    Some("chargeType.VatAnnualAccountMonthlyInstalmentDescription"),
-    Some("chargeType.VatAnnualAccountMonthlyInstalmentDescription")
+    Some("chargeType.forThePeriod"),
+    Some("chargeType.forThePeriod")
   )
 
   object VatAAQuarterlyInstalments extends PaymentMessageHelper(
     AAQuarterlyInstalments.value,
     "chargeType.VatAnnualAccountQuarterlyInstalmentsTitle",
-    Some("chargeType.VatAnnualAccountQuarterlyInstalmentsDescription"),
-    Some("chargeType.VatAnnualAccountQuarterlyInstalmentsDescription")
+    Some("chargeType.forThePeriod"),
+    Some("chargeType.forThePeriod")
   )
 
   object VatAAReturnDebitCharge extends PaymentMessageHelper(
     AAReturnDebitCharge.value,
     "chargeType.VatAnnualAccountReturnDebitChargeTitle",
-    Some("chargeType.VatAnnualAccountReturnDebitChargeDescription"),
-    Some("chargeType.VatAnnualAccountReturnDebitChargeDescription")
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
   )
 
   object VatAAReturnCreditCharge extends PaymentMessageHelper(
     AAReturnCreditCharge.value,
     "chargeType.VatAnnualAccountReturnCreditChargeTitle",
-    Some("chargeType.VatAnnualAccountReturnCreditChargeDescription"),
-    Some("chargeType.VatAnnualAccountReturnCreditChargeDescription")
+    Some("chargeType.forThePeriod"),
+    Some("chargeType.forThePeriod")
   )
 
   object VatStatutoryInterestCharge extends PaymentMessageHelper(
@@ -394,22 +394,22 @@ object PaymentMessageHelper {
   object VATPOAInstalmentCharge extends PaymentMessageHelper(
     PaymentOnAccountInstalments.value,
     "chargeType.POAInstalmentTitle",
-    Some("chargeType.POAChargeDescription"),
-    Some("chargeType.POAChargeDescription")
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
   )
 
   object VATPOAReturnDebitCharge extends PaymentMessageHelper(
     PaymentOnAccountReturnDebitCharge.value,
     "chargeType.POAReturnDebitChargeTitle",
-    Some("chargeType.POAChargeDescription"),
-    Some("chargeType.POAChargeDescription")
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
   )
 
   object VATPOAReturnCreditCharge extends PaymentMessageHelper(
     PaymentOnAccountReturnCreditCharge.value,
     "chargeType.POAReturnCreditChargeTitle",
-    Some("chargeType.POAChargeDescription"),
-    Some("chargeType.POAChargeDescription")
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
   )
 
   object VATReturn1stLPP extends PaymentMessageHelper(
@@ -417,6 +417,34 @@ object PaymentMessageHelper {
     "chargeType.VATReturn1stLPPTitle",
     Some("chargeType.VATReturn1stLPPDescription"),
     Some("chargeType.VATReturn1stLPPDescription")
+  )
+
+  object VATReturnLPI extends PaymentMessageHelper(
+    VatReturnLPI.value,
+    "chargeType.vatReturnLPITitle",
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
+  )
+
+  object VATReturn1stLPPLPI extends PaymentMessageHelper(
+    VatReturn1stLPPLPI.value,
+    "chargeType.vatReturn1stLPPLPITitle",
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
+  )
+
+  object VATReturn2ndLPPLPI extends PaymentMessageHelper(
+    VatReturn2ndLPPLPI.value,
+    "chargeType.vatReturn2ndLPPLPITitle",
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
+  )
+
+  object VATCentralAssessmentLPI extends PaymentMessageHelper(
+    VatCentralAssessmentLPI.value,
+    "chargeType.vatCentralAssessmentLPITitle",
+    Some("chargeType.forPeriod"),
+    Some("chargeType.forPeriod")
   )
 
   val values: Seq[PaymentMessageHelper] = Seq(
@@ -475,7 +503,11 @@ object PaymentMessageHelper {
     VATPOAInstalmentCharge,
     VATPOAReturnDebitCharge,
     VATPOAReturnCreditCharge,
-    VATReturn1stLPP
+    VATReturn1stLPP,
+    VATReturnLPI,
+    VATReturn1stLPPLPI,
+    VATReturn2ndLPPLPI,
+    VATCentralAssessmentLPI
   )
 
   private def getFullDescription(descriptionMessageKey: String, from: Option[LocalDate], to: Option[LocalDate])

--- a/conf/messages
+++ b/conf/messages
@@ -284,6 +284,10 @@ deregPartial.vatGroup.title = Cancel VAT registration (opens in a new tab)
 deregPartial.vatGroup.content = To disband VAT group, you need to cancel the registration using the VAT7 form.
 
 # Charge types
+chargeType.for = for {0}
+chargeType.forPeriod = for period {0}
+chargeType.forThePeriod = for the period {0}
+
 chargeType.vatUnrepayableOverpaymentTitle = Overpayment
 chargeType.vatUnrepayableOverpaymentDescription = cannot be repaid after 4 years
 
@@ -301,21 +305,16 @@ chargeType.vatReturnCreditChargeTitle = Repayment from HMRC
 chargeType.vatReturnCreditChargeDescription = for the {0} return
 
 chargeType.vatReturnDebitChargeTitle = VAT
-chargeType.vatReturnDebitChargeDescription = for period {0}
 
 chargeType.officerAssessmentChargeTitle = Officer’s assessment of VAT
-chargeType.officerAssessmentDebitChargeDescription = for {0}
-chargeType.officerAssessmentCreditChargeDescription = for {0}
 
 chargeType.vatCentralAssessmentTitle = Central assessment of VAT
-chargeType.vatCentralAssessmentDescription = for period {0}
 
 chargeType.vatDefaultSurchargeTitle = Surcharge
 chargeType.vatDefaultSurchargeDescription = for late payment of the {0} return
 
 chargeType.vatErrorCorrectionDebitChargeTitle = Error correction of VAT
 chargeType.vatErrorCorrectionCreditChargeTitle =  Error correction repayment from HMRC
-chargeType.vatErrorCorrectionChargeDescription = for {0}
 
 chargeType.vatRepaymentSupplementTitle = Late repayment compensation from HMRC
 chargeType.vatRepaymentSupplementDescription = we took too long to repay the {0} return
@@ -345,20 +344,15 @@ chargeType.VatOfficersAssessmentFurtherInterestTitle = VAT officer’s assessmen
 chargeType.VatOfficersAssessmentFurtherInterestDescription = charged on the officer’s assessment
 
 chargeType.VatAdditionalAssessmentTitle = Additional assessment of VAT
-chargeType.VatAdditionalAssessmentDescription = for {0}
 chargeType.VatAdditionalAssessmentDefaultInterestTitle = Additional assessment interest
 chargeType.VatAdditionalAssessmentDefaultInterestDescription = charged on additional tax assessed for the period {0}
 chargeType.VatAdditionalAssessmentFurtherInterestTitle = Additional assessment further interest
 chargeType.VatAdditionalAssessmentFurtherInterestDescription = charged on additional tax assessed for the period {0}
 
 chargeType.VatAnnualAccountMonthlyInstalmentTitle = Annual accounting monthly instalment
-chargeType.VatAnnualAccountMonthlyInstalmentDescription = for the period {0}
 chargeType.VatAnnualAccountQuarterlyInstalmentsTitle = Annual accounting quarterly instalment
-chargeType.VatAnnualAccountQuarterlyInstalmentsDescription = for the period {0}
 chargeType.VatAnnualAccountReturnDebitChargeTitle = Annual accounting balance
-chargeType.VatAnnualAccountReturnDebitChargeDescription = for period {0}
 chargeType.VatAnnualAccountReturnCreditChargeTitle = Annual accounting repayment
-chargeType.VatAnnualAccountReturnCreditChargeDescription = for the period {0}
 
 chargeType.VatStatutoryInterestTitle = Statutory interest
 chargeType.VatStatutoryInterestDescription = interest paid because of an error by HMRC
@@ -447,9 +441,13 @@ chargeType.POAInstalmentTitle = Payment on account instalment
 
 chargeType.POAReturnDebitChargeTitle = Payment on account balance
 chargeType.POAReturnCreditChargeTitle = Payment on account repayment
-chargeType.POAChargeDescription = for period {0}
 
-chargeType.VATReturn1stLPPTitle =  Late payment penalty
+chargeType.vatReturnLPITitle = Interest on VAT
+chargeType.vatReturn1stLPPLPITitle = Interest on penalty
+chargeType.vatReturn2ndLPPLPITitle = Interest on second penalty
+chargeType.vatCentralAssessmentLPITitle = Interest on central assessment of VAT
+
+chargeType.VATReturn1stLPPTitle = Late payment penalty
 chargeType.VATReturn1stLPPDescription = for late payment of VAT for VAT period {0}
 
 unauthorised.agent.title = You can’t use this service yet

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -284,6 +284,10 @@ deregPartial.vatGroup.title = Canslo cofrestriad TAW (yn agor mewn tab newydd)
 deregPartial.vatGroup.content = I ddiddymu’r grŵp TAW, mae’n rhaid i chi ganslo’r cofrestriad drwy ddefnyddio ffurflen VAT7.
 
 # Charge types
+chargeType.for = ar gyfer {0}
+chargeType.forPeriod = ar gyfer y cyfnod {0}
+chargeType.forThePeriod = ar gyfer y cyfnod {0}
+
 chargeType.vatUnrepayableOverpaymentTitle = Gordaliad
 chargeType.vatUnrepayableOverpaymentDescription = ni ellir ad-dalu hyn ar ôl 4 blynedd
 
@@ -301,21 +305,16 @@ chargeType.vatReturnCreditChargeTitle = Ad-daliad gan CThEM
 chargeType.vatReturnCreditChargeDescription = ar gyfer y Ffurflen TAW ar gyfer {0}
 
 chargeType.vatReturnDebitChargeTitle = TAW
-chargeType.vatReturnDebitChargeDescription = ar gyfer y cyfnod {0}
 
 chargeType.officerAssessmentChargeTitle = Asesiad swyddog o TAW
-chargeType.officerAssessmentDebitChargeDescription = ar gyfer {0}
-chargeType.officerAssessmentCreditChargeDescription = ar gyfer y cyfnod {0}
 
 chargeType.vatCentralAssessmentTitle = Asesiad canolog o TAW
-chargeType.vatCentralAssessmentDescription = ar gyfer y cyfnod {0}
 
 chargeType.vatDefaultSurchargeTitle = Gordal
 chargeType.vatDefaultSurchargeDescription = ar gyfer talu’r dreth sy’n codi o’r Ffurflen TAW ar gyfer {0} yn hwyr
 
 chargeType.vatErrorCorrectionDebitChargeTitle = Cywiriad gwall TAW
 chargeType.vatErrorCorrectionCreditChargeTitle =  Ad-daliad gan CThEM ar gyfer cywiro gwall
-chargeType.vatErrorCorrectionChargeDescription =  ar gyfer {0}
 
 chargeType.vatRepaymentSupplementTitle = Iawndal gan CThEM am ad-dalu’n hwyr
 chargeType.vatRepaymentSupplementDescription = gwnaethom gymryd gormod o amser i ad-dalu’r dreth yn codi o’r Ffurflen TAW ar gyfer {0}
@@ -345,20 +344,15 @@ chargeType.VatOfficersAssessmentFurtherInterestTitle = Llog pellach ar asesiad y
 chargeType.VatOfficersAssessmentFurtherInterestDescription = a godir ar asesiad y swyddog
 
 chargeType.VatAdditionalAssessmentTitle = Asesiad ychwanegol o TAW
-chargeType.VatAdditionalAssessmentDescription = ar gyfer {0}
 chargeType.VatAdditionalAssessmentDefaultInterestTitle = Llog asesiad ychwanegol
 chargeType.VatAdditionalAssessmentDefaultInterestDescription = a godir ar y dreth ychwanegol a aseswyd ar gyfer y cyfnod {0}
 chargeType.VatAdditionalAssessmentFurtherInterestTitle = Llog pellach ar asesiad ychwanegol
 chargeType.VatAdditionalAssessmentFurtherInterestDescription = a godir ar y dreth ychwanegol a aseswyd ar gyfer y cyfnod {0}
 
 chargeType.VatAnnualAccountMonthlyInstalmentTitle = Rhandaliad misol cyfrifyddu blynyddol
-chargeType.VatAnnualAccountMonthlyInstalmentDescription = ar gyfer y cyfnod {0}
 chargeType.VatAnnualAccountQuarterlyInstalmentsTitle = Rhandaliad chwarterol cyfrifyddu blynyddol
-chargeType.VatAnnualAccountQuarterlyInstalmentsDescription = ar gyfer y cyfnod {0}
 chargeType.VatAnnualAccountReturnDebitChargeTitle = Balans cyfrifyddu blynyddol
-chargeType.VatAnnualAccountReturnDebitChargeDescription = ar gyfer y cyfnod {0}
 chargeType.VatAnnualAccountReturnCreditChargeTitle = Ad-daliad cyfrifyddu blynyddol
-chargeType.VatAnnualAccountReturnCreditChargeDescription = ar gyfer y cyfnod {0}
 
 chargeType.VatStatutoryInterestTitle = Llog statudol
 chargeType.VatStatutoryInterestDescription = llog a delir oherwydd gwall gan CThEM
@@ -447,7 +441,11 @@ chargeType.POAInstalmentTitle = Rhandaliad taliad ar gyfrif
 
 chargeType.POAReturnDebitChargeTitle = Balans taliad ar gyfrif
 chargeType.POAReturnCreditChargeTitle = Ad-daliad taliad ar gyfrif
-chargeType.POAChargeDescription =  ar gyfer y cyfnod {0}
+
+chargeType.vatReturnLPITitle = ???
+chargeType.vatReturn1stLPPLPITitle = ???
+chargeType.vatReturn2ndLPPLPITitle = ???
+chargeType.vatCentralAssessmentLPITitle = ???
 
 chargeType.VATReturn1stLPPTitle = ???
 chargeType.VATReturn1stLPPDescription = ???

--- a/test/common/MessageLookup.scala
+++ b/test/common/MessageLookup.scala
@@ -104,6 +104,10 @@ object MessageLookup {
         case VATPOAReturnDebitCharge.name => ("Payment on account balance", s"for period $datePeriod")
         case VATPOAReturnCreditCharge.name => ("Payment on account repayment", s"for period $datePeriod")
         case VATReturn1stLPP.name => ("Late payment penalty", s"for late payment of VAT for VAT period $datePeriod")
+        case VATReturnLPI.name => ("Interest on VAT", s"for period $datePeriod")
+        case VATReturn1stLPPLPI.name => ("Interest on penalty", s"for period $datePeriod")
+        case VATReturn2ndLPPLPI.name => ("Interest on second penalty", s"for period $datePeriod")
+        case VATCentralAssessmentLPI.name => ("Interest on central assessment of VAT", s"for period $datePeriod")
         case _ => throw new IllegalArgumentException(s"[MessageLookup][PaymentMessages][getMessagesForChargeType] Charge type not found in message lookup: $chargeType")
       }
     }
@@ -142,7 +146,7 @@ object MessageLookup {
   }
 
   object paymentHistoryMessages {
-    val insetText = "If you cannot see your all of your client’s history, " +
+    val insetText: String = "If you cannot see your all of your client’s history, " +
       "you may be able to access more through your HMRC online services for agents account. You’ll need to sign in separately."
   }
 }

--- a/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
@@ -570,6 +570,54 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155"
+            ),
+            Json.obj(
+              "chargeType" -> VatReturnLPI.value,
+              "periodKey" -> "18AA",
+              "outstandingAmount" -> 202.10,
+              "items" -> Json.arr(
+                Json.obj(
+                  "dueDate" -> "2018-02-01",
+                  "amount" -> 202.10
+                )
+              ),
+              "chargeReference" -> "XD002750002155"
+            ),
+            Json.obj(
+              "chargeType" -> VatReturn1stLPPLPI.value,
+              "periodKey" -> "18AB",
+              "outstandingAmount" -> 202.20,
+              "items" -> Json.arr(
+                Json.obj(
+                  "dueDate" -> "2018-02-01",
+                  "amount" -> 202.20
+                )
+              ),
+              "chargeReference" -> "XD002750002155"
+            ),
+            Json.obj(
+              "chargeType" -> VatReturn2ndLPPLPI.value,
+              "periodKey" -> "18AC",
+              "outstandingAmount" -> 202.30,
+              "items" -> Json.arr(
+                Json.obj(
+                  "dueDate" -> "2018-02-01",
+                  "amount" -> 202.30
+                )
+              ),
+              "chargeReference" -> "XD002750002155"
+            ),
+            Json.obj(
+              "chargeType" -> VatCentralAssessmentLPI.value,
+              "periodKey" -> "18AD",
+              "outstandingAmount" -> 202.40,
+              "items" -> Json.arr(
+                Json.obj(
+                  "dueDate" -> "2018-02-01",
+                  "amount" -> 202.40
+                )
+              ),
+              "chargeReference" -> "XD002750002155"
             )
           )
         ).toString()
@@ -937,6 +985,38 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(200.00),
           periodKey = Some("18AA"),
+          chargeReference = Some("XD002750002155"),
+          ddCollectionInProgress = false
+        ),
+        Payment(
+          VatReturnLPI,
+          due = LocalDate.parse("2018-02-01"),
+          outstandingAmount = BigDecimal(202.10),
+          periodKey = Some("18AA"),
+          chargeReference = Some("XD002750002155"),
+          ddCollectionInProgress = false
+        ),
+        Payment(
+          VatReturn1stLPPLPI,
+          due = LocalDate.parse("2018-02-01"),
+          outstandingAmount = BigDecimal(202.20),
+          periodKey = Some("18AB"),
+          chargeReference = Some("XD002750002155"),
+          ddCollectionInProgress = false
+        ),
+        Payment(
+          VatReturn2ndLPPLPI,
+          due = LocalDate.parse("2018-02-01"),
+          outstandingAmount = BigDecimal(202.30),
+          periodKey = Some("18AC"),
+          chargeReference = Some("XD002750002155"),
+          ddCollectionInProgress = false
+        ),
+        Payment(
+          VatCentralAssessmentLPI,
+          due = LocalDate.parse("2018-02-01"),
+          outstandingAmount = BigDecimal(202.40),
+          periodKey = Some("18AD"),
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false
         )

--- a/test/views/templates/payments/PaymentsHistoryChargeDescriptionTemplateSpec.scala
+++ b/test/views/templates/payments/PaymentsHistoryChargeDescriptionTemplateSpec.scala
@@ -35,22 +35,22 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
     val description = "p"
   }
 
+  val exampleModel: PaymentsHistoryModel = PaymentsHistoryModel(
+    clearingSAPDocument = Some("002828853334"),
+    ReturnDebitCharge,
+    Some(LocalDate.parse("2018-01-12")),
+    Some(LocalDate.parse("2018-03-23")),
+    1,
+    Some(LocalDate.parse("2018-02-14"))
+  )
+
   "The PaymentsHistoryChargeDescription template" when {
 
     "user is not an agent" when {
 
       "there is a vat return debit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          ReturnDebitCharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          123456,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
-        lazy val template = paymentsHistoryChargeDescription(model)
+        lazy val template = paymentsHistoryChargeDescription(exampleModel)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
         "display the correct charge title" in {
@@ -64,15 +64,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a vat return credit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          ReturnCreditCharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          -123456,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = ReturnCreditCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -87,15 +79,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a vat officer assessment debit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          OADebitCharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          123456,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = OADebitCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -110,15 +94,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a vat officer assessment credit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          OACreditCharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          123456,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = OACreditCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -133,15 +109,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a vat central assessment charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          CentralAssessmentCharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          -123456,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = CentralAssessmentCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -156,15 +124,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a VAT Debit Default Surcharge charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          DebitDefaultSurcharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          123456,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = DebitDefaultSurcharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -179,15 +139,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a VAT Credit Default Surcharge charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          CreditDefaultSurcharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          -123456,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = CreditDefaultSurcharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -202,15 +154,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is an error correction credit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          ErrorCorrectionCreditCharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          1000,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = ErrorCorrectionCreditCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -225,15 +169,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is an error correction debit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          ErrorCorrectionDebitCharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          2000,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = ErrorCorrectionDebitCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -248,15 +184,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a vat officer assessment default interest charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          OADefaultInterestCharge,
-          Some(LocalDate.parse("2018-01-12")),
-          Some(LocalDate.parse("2018-03-23")),
-          123456,
-          Some(LocalDate.parse("2018-02-14"))
-        )
-
+        val model = exampleModel.copy(chargeType = OADefaultInterestCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -271,15 +199,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a VAT Officer Assessment Further Interest charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          OAFurtherInterestCharge,
-          Some(LocalDate.parse("2018-02-12")),
-          Some(LocalDate.parse("2018-03-24")),
-          1500.00,
-          Some(LocalDate.parse("2018-04-18"))
-        )
-
+        val model = exampleModel.copy(chargeType = OAFurtherInterestCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -294,15 +214,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a VAT Additional Assessment charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          AACharge,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-04-01")),
-          2000.00,
-          Some(LocalDate.parse("2018-05-01"))
-        )
-
+        val model = exampleModel.copy(chargeType = AACharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -311,22 +223,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "for " +
-            "1 Jan to 1 Apr 2018"
+          elementText(Selectors.description) shouldBe "for 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT AA Default Interest charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          AAInterestCharge,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-04-01")),
-          2000.00,
-          Some(LocalDate.parse("2018-05-01"))
-        )
-
+        val model = exampleModel.copy(chargeType = AAInterestCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -336,21 +239,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
         "display the correct description" in {
           elementText(Selectors.description) shouldBe "charged on additional tax assessed" +
-            " for the period 1 Jan to 1 Apr 2018"
+            " for the period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT AA Further Interest charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          AAFurtherInterestCharge,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-04-01")),
-          2000.00,
-          Some(LocalDate.parse("2018-05-01"))
-        )
-
+        val model = exampleModel.copy(chargeType = AAFurtherInterestCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -360,21 +255,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
         "display the correct description" in {
           elementText(Selectors.description) shouldBe "charged on additional tax assessed" +
-            " for the period 1 Jan to 1 Apr 2018"
+            " for the period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT Statutory Interest charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          StatutoryInterestCharge,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-04-01")),
-          -1500.00,
-          Some(LocalDate.parse("2018-05-01"))
-        )
-
+        val model = exampleModel.copy(chargeType = StatutoryInterestCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -389,15 +276,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a Vat Inaccuracy Assessments Pen charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          InaccuraciesAssessmentsPenCharge,
-          Some(LocalDate.parse("2018-09-10")),
-          Some(LocalDate.parse("2018-10-11")),
-          1000.00,
-          Some(LocalDate.parse("2018-10-15"))
-        )
-
+        val model = exampleModel.copy(chargeType = InaccuraciesAssessmentsPenCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -406,21 +285,14 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "because you submitted an inaccurate document for the period 10 Sep to 11 Oct 2018"
+          elementText(Selectors.description) shouldBe
+            "because you submitted an inaccurate document for the period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a Vat Mp Pre 2009 Charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          MpPre2009Charge,
-          Some(LocalDate.parse("2018-09-10")),
-          Some(LocalDate.parse("2018-10-11")),
-          1100.00,
-          Some(LocalDate.parse("2018-10-15"))
-        )
-
+        val model = exampleModel.copy(chargeType = MpPre2009Charge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -435,15 +307,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a Vat Mp Repeated Pre 2009 Charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          MpRepeatedPre2009Charge,
-          Some(LocalDate.parse("2018-09-10")),
-          Some(LocalDate.parse("2018-10-11")),
-          1100.00,
-          Some(LocalDate.parse("2018-10-15"))
-        )
-
+        val model = exampleModel.copy(chargeType = MpRepeatedPre2009Charge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -458,15 +322,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a Vat Inaccuracies Return Replaced Charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          InaccuraciesReturnReplacedCharge,
-          Some(LocalDate.parse("2018-09-12")),
-          Some(LocalDate.parse("2018-10-13")),
-          390.00,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = InaccuraciesReturnReplacedCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -476,21 +332,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
         "display the correct description" in {
           elementText(Selectors.description) shouldBe "because you have submitted inaccurate information for" +
-            " the period 12 Sep to 13 Oct 2018"
+            " the period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a Vat Wrong Doing Penalty Charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          WrongDoingPenaltyCharge,
-          Some(LocalDate.parse("2018-09-12")),
-          Some(LocalDate.parse("2018-10-13")),
-          390.00,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = WrongDoingPenaltyCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -505,15 +353,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a Vat Credit Return Offset Charge Charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          CreditReturnOffsetCharge,
-          Some(LocalDate.parse("2018-09-12")),
-          Some(LocalDate.parse("2018-10-13")),
-          390.00,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = CreditReturnOffsetCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -522,21 +362,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "partial repayment for period 12 Sep to 13 Oct 2018"
+          elementText(Selectors.description) shouldBe "partial repayment for period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is an Unallocated Payment Charge Type" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          UnallocatedPayment,
-          None,
-          None,
-          -500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = UnallocatedPayment)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -551,15 +383,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is an Refund Charge Type" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          Refund,
-          None,
-          None,
-          500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = Refund)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -574,15 +398,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "there is a VAT POA Instalment charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          PaymentOnAccountInstalments,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-02-02")),
-          500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = PaymentOnAccountInstalments)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -591,21 +407,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "for period 1 Jan to 2 Feb 2018"
+          elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT POA Return Debit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          PaymentOnAccountReturnDebitCharge,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-02-02")),
-          500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = PaymentOnAccountReturnDebitCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -614,21 +422,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "for period 1 Jan to 2 Feb 2018"
+          elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT POA Return Credit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          PaymentOnAccountReturnCreditCharge,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-02-02")),
-          500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = PaymentOnAccountReturnCreditCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -637,21 +437,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "for period 1 Jan to 2 Feb 2018"
+          elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT AA Monthly Instalment charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          AAMonthlyInstalment,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-02-02")),
-          500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = AAMonthlyInstalment)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -660,21 +452,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+          elementText(Selectors.description) shouldBe "for the period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT AA Quarterly Instalment charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          AAQuarterlyInstalments,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-02-02")),
-          500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = AAQuarterlyInstalments)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -683,21 +467,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+          elementText(Selectors.description) shouldBe "for the period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT AA Return Debit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          AAReturnDebitCharge,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-02-02")),
-          500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = AAReturnDebitCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -706,21 +482,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "for period 1 Jan to 2 Feb 2018"
+          elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT AA Return Credit charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          AAReturnCreditCharge,
-          Some(LocalDate.parse("2018-01-01")),
-          Some(LocalDate.parse("2018-02-02")),
-          500,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = AAReturnCreditCharge)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -729,21 +497,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
         }
 
         "display the correct description" in {
-          elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+          elementText(Selectors.description) shouldBe "for the period 12 Jan to 23 Mar 2018"
         }
       }
 
       "there is a VAT Unrepayable Overpayment Charge" should {
 
-        val model: PaymentsHistoryModel = PaymentsHistoryModel(
-          clearingSAPDocument = Some("002828853334"),
-          VatUnrepayableOverpayment,
-          Some(LocalDate.parse("2018-03-02")),
-          Some(LocalDate.parse("2018-04-02")),
-          300,
-          Some(LocalDate.parse("2018-10-16"))
-        )
-
+        val model = exampleModel.copy(chargeType = VatUnrepayableOverpayment)
         lazy val template = paymentsHistoryChargeDescription(model)
         lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -755,6 +515,81 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
           elementText(Selectors.description) shouldBe "cannot be repaid after 4 years"
         }
       }
+
+      "there is a VAT return 1st LPP Charge" should {
+
+        val model = exampleModel.copy(chargeType = VatReturn1stLPP)
+        lazy val template = paymentsHistoryChargeDescription(model)
+        lazy implicit val document: Document = Jsoup.parse(template.body)
+
+        "display the correct charge title" in {
+          elementText(Selectors.chargeTitle) shouldBe "Late payment penalty"
+        }
+
+        "display the correct description" in {
+          elementText(Selectors.description) shouldBe "for late payment of VAT for VAT period 12 Jan to 23 Mar 2018"
+        }
+      }
+
+      "there is a VAT Return LPI charge" should {
+
+        val model = exampleModel.copy(chargeType = VatReturnLPI)
+        lazy val template = paymentsHistoryChargeDescription(model)
+        lazy implicit val document: Document = Jsoup.parse(template.body)
+
+        "display the correct charge title" in {
+          elementText(Selectors.chargeTitle) shouldBe "Interest on VAT"
+        }
+
+        "display the correct description" in {
+          elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
+        }
+      }
+
+      "there is a VAT Return 1st LPP LPI charge" should {
+
+        val model = exampleModel.copy(chargeType = VatReturn1stLPPLPI)
+        lazy val template = paymentsHistoryChargeDescription(model)
+        lazy implicit val document: Document = Jsoup.parse(template.body)
+
+        "display the correct charge title" in {
+          elementText(Selectors.chargeTitle) shouldBe "Interest on penalty"
+        }
+
+        "display the correct description" in {
+          elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
+        }
+      }
+
+      "there is a VAT Return 2nd LPP LPI charge" should {
+
+        val model = exampleModel.copy(chargeType = VatReturn2ndLPPLPI)
+        lazy val template = paymentsHistoryChargeDescription(model)
+        lazy implicit val document: Document = Jsoup.parse(template.body)
+
+        "display the correct charge title" in {
+          elementText(Selectors.chargeTitle) shouldBe "Interest on second penalty"
+        }
+
+        "display the correct description" in {
+          elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
+        }
+      }
+
+      "there is a VAT Central Assessment LPI charge" should {
+
+        val model = exampleModel.copy(chargeType = VatCentralAssessmentLPI)
+        lazy val template = paymentsHistoryChargeDescription(model)
+        lazy implicit val document: Document = Jsoup.parse(template.body)
+
+        "display the correct charge title" in {
+          elementText(Selectors.chargeTitle) shouldBe "Interest on central assessment of VAT"
+        }
+
+        "display the correct description" in {
+          elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
+        }
+      }
     }
   }
 
@@ -762,16 +597,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a vat return debit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        ReturnDebitCharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        123456,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
-      lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
+      lazy val template = paymentsHistoryChargeDescription(exampleModel)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
       "display the correct charge title" in {
@@ -785,15 +611,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a vat return credit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        ReturnCreditCharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        -123456,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = ReturnCreditCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -808,15 +626,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a vat officer assessment debit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        OADebitCharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        123456,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = OADebitCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -831,15 +641,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a vat officer assessment credit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        OACreditCharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        123456,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = OACreditCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -854,15 +656,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a vat central assessment charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        CentralAssessmentCharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        -123456,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = CentralAssessmentCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -877,15 +671,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a VAT Debit Default Surcharge charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        DebitDefaultSurcharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        123456,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = DebitDefaultSurcharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -900,15 +686,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a VAT Credit Default Surcharge charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        CreditDefaultSurcharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        -123456,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = CreditDefaultSurcharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -923,15 +701,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is an error correction credit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        ErrorCorrectionCreditCharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        1000,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = ErrorCorrectionCreditCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -946,15 +716,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is an error correction debit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        ErrorCorrectionDebitCharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        2000,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = ErrorCorrectionDebitCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -969,15 +731,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a vat officer assessment default interest charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        OADefaultInterestCharge,
-        Some(LocalDate.parse("2018-01-12")),
-        Some(LocalDate.parse("2018-03-23")),
-        123456,
-        Some(LocalDate.parse("2018-02-14"))
-      )
-
+      val model = exampleModel.copy(chargeType = OADefaultInterestCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -992,15 +746,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a VAT Officer Assessment Further Interest charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        OAFurtherInterestCharge,
-        Some(LocalDate.parse("2018-02-12")),
-        Some(LocalDate.parse("2018-03-24")),
-        1500.00,
-        Some(LocalDate.parse("2018-04-18"))
-      )
-
+      val model = exampleModel.copy(chargeType = OAFurtherInterestCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1015,15 +761,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a VAT Additional Assessment charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        AACharge,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-04-01")),
-        2000.00,
-        Some(LocalDate.parse("2018-05-01"))
-      )
-
+      val model = exampleModel.copy(chargeType = AACharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1032,22 +770,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for " +
-          "1 Jan to 1 Apr 2018"
+        elementText(Selectors.description) shouldBe "for 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT AA Default Interest charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        AAInterestCharge,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-04-01")),
-        2000.00,
-        Some(LocalDate.parse("2018-05-01"))
-      )
-
+      val model = exampleModel.copy(chargeType = AAInterestCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1057,21 +786,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "display the correct description" in {
         elementText(Selectors.description) shouldBe "charged on additional tax assessed" +
-          " for the period 1 Jan to 1 Apr 2018"
+          " for the period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT AA Further Interest charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        AAFurtherInterestCharge,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-04-01")),
-        2000.00,
-        Some(LocalDate.parse("2018-05-01"))
-      )
-
+      val model = exampleModel.copy(chargeType = AAFurtherInterestCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1081,21 +802,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "display the correct description" in {
         elementText(Selectors.description) shouldBe "charged on additional tax assessed" +
-          " for the period 1 Jan to 1 Apr 2018"
+          " for the period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT Statutory Interest charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        StatutoryInterestCharge,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-04-01")),
-        -1500.00,
-        Some(LocalDate.parse("2018-05-01"))
-      )
-
+      val model = exampleModel.copy(chargeType = StatutoryInterestCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1110,15 +823,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a Vat Inaccuracy Assessments Pen charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        InaccuraciesAssessmentsPenCharge,
-        Some(LocalDate.parse("2018-09-10")),
-        Some(LocalDate.parse("2018-10-11")),
-        1000.00,
-        Some(LocalDate.parse("2018-10-15"))
-      )
-
+      val model = exampleModel.copy(chargeType = InaccuraciesAssessmentsPenCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1127,21 +832,14 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "because your client submitted an inaccurate document for the period 10 Sep to 11 Oct 2018"
+        elementText(Selectors.description) shouldBe
+          "because your client submitted an inaccurate document for the period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a Vat Mp Pre 2009 Charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        MpPre2009Charge,
-        Some(LocalDate.parse("2018-09-10")),
-        Some(LocalDate.parse("2018-10-11")),
-        1100.00,
-        Some(LocalDate.parse("2018-10-15"))
-      )
-
+      val model = exampleModel.copy(chargeType = MpPre2009Charge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1156,15 +854,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a Vat Mp Repeated Pre 2009 Charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        MpRepeatedPre2009Charge,
-        Some(LocalDate.parse("2018-09-10")),
-        Some(LocalDate.parse("2018-10-11")),
-        1100.00,
-        Some(LocalDate.parse("2018-10-15"))
-      )
-
+      val model = exampleModel.copy(chargeType = MpRepeatedPre2009Charge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1179,15 +869,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a Vat Inaccuracies Return Replaced Charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        InaccuraciesReturnReplacedCharge,
-        Some(LocalDate.parse("2018-09-12")),
-        Some(LocalDate.parse("2018-10-13")),
-        390.00,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = InaccuraciesReturnReplacedCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1197,21 +879,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
       "display the correct description" in {
         elementText(Selectors.description) shouldBe "because your client submitted inaccurate information for" +
-          " the period 12 Sep to 13 Oct 2018"
+          " the period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a Vat Wrong Doing Penalty Charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        WrongDoingPenaltyCharge,
-        Some(LocalDate.parse("2018-09-12")),
-        Some(LocalDate.parse("2018-10-13")),
-        390.00,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = WrongDoingPenaltyCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1226,15 +900,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a Vat Credit Return Offset Charge Charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        CreditReturnOffsetCharge,
-        Some(LocalDate.parse("2018-09-12")),
-        Some(LocalDate.parse("2018-10-13")),
-        390.00,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = CreditReturnOffsetCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1243,21 +909,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "partial repayment for period 12 Sep to 13 Oct 2018"
+        elementText(Selectors.description) shouldBe "partial repayment for period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is an Unallocated Payment Charge Type" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        UnallocatedPayment,
-        None,
-        None,
-        -500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = UnallocatedPayment)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1266,21 +924,14 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "your client made an overpayment which can be refunded to them or left on account"
+        elementText(Selectors.description) shouldBe
+          "your client made an overpayment which can be refunded to them or left on account"
       }
     }
 
     "there is an Refund Charge Type" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        Refund,
-        None,
-        None,
-        500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = Refund)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1295,15 +946,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a VAT POA Instalment charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        PaymentOnAccountInstalments,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-02-02")),
-        500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = PaymentOnAccountInstalments)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1312,21 +955,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for period 1 Jan to 2 Feb 2018"
+        elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT POA Return Debit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        PaymentOnAccountReturnDebitCharge,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-02-02")),
-        500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = PaymentOnAccountReturnDebitCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1335,21 +970,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for period 1 Jan to 2 Feb 2018"
+        elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT POA Return Credit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        PaymentOnAccountReturnCreditCharge,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-02-02")),
-        500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = PaymentOnAccountReturnCreditCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1358,21 +985,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for period 1 Jan to 2 Feb 2018"
+        elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT AA Monthly Instalment charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        AAMonthlyInstalment,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-02-02")),
-        500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = AAMonthlyInstalment)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1381,21 +1000,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+        elementText(Selectors.description) shouldBe "for the period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT AA Quarterly Instalment charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        AAQuarterlyInstalments,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-02-02")),
-        500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = AAQuarterlyInstalments)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1404,21 +1015,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+        elementText(Selectors.description) shouldBe "for the period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT AA Return Debit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        AAReturnDebitCharge,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-02-02")),
-        500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = AAReturnDebitCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1427,21 +1030,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for period 1 Jan to 2 Feb 2018"
+        elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT AA Return Credit charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        AAReturnCreditCharge,
-        Some(LocalDate.parse("2018-01-01")),
-        Some(LocalDate.parse("2018-02-02")),
-        500,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = AAReturnCreditCharge)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1450,21 +1045,13 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for the period 1 Jan to 2 Feb 2018"
+        elementText(Selectors.description) shouldBe "for the period 12 Jan to 23 Mar 2018"
       }
     }
 
     "there is a VAT Unrepayable Overpayment Charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        VatUnrepayableOverpayment,
-        Some(LocalDate.parse("2018-03-02")),
-        Some(LocalDate.parse("2018-04-02")),
-        300,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = VatUnrepayableOverpayment)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1479,15 +1066,7 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
 
     "there is a VAT return 1st LPP Charge" should {
 
-      val model: PaymentsHistoryModel = PaymentsHistoryModel(
-        clearingSAPDocument = Some("002828853334"),
-        VatReturn1stLPP,
-        Some(LocalDate.parse("2018-03-02")),
-        Some(LocalDate.parse("2018-04-02")),
-        300,
-        Some(LocalDate.parse("2018-10-16"))
-      )
-
+      val model = exampleModel.copy(chargeType = VatReturn1stLPP)
       lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
       lazy implicit val document: Document = Jsoup.parse(template.body)
 
@@ -1496,7 +1075,67 @@ class PaymentsHistoryChargeDescriptionTemplateSpec extends ViewBaseSpec {
       }
 
       "display the correct description" in {
-        elementText(Selectors.description) shouldBe "for late payment of VAT for VAT period 2 Mar to 2 Apr 2018"
+        elementText(Selectors.description) shouldBe "for late payment of VAT for VAT period 12 Jan to 23 Mar 2018"
+      }
+    }
+
+    "there is a VAT Return LPI charge" should {
+
+      val model = exampleModel.copy(chargeType = VatReturnLPI)
+      lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
+      lazy implicit val document: Document = Jsoup.parse(template.body)
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Interest on VAT"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
+      }
+    }
+
+    "there is a VAT Return 1st LPP LPI charge" should {
+
+      val model = exampleModel.copy(chargeType = VatReturn1stLPPLPI)
+      lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
+      lazy implicit val document: Document = Jsoup.parse(template.body)
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Interest on penalty"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
+      }
+    }
+
+    "there is a VAT Return 2nd LPP LPI charge" should {
+
+      val model = exampleModel.copy(chargeType = VatReturn2ndLPPLPI)
+      lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
+      lazy implicit val document: Document = Jsoup.parse(template.body)
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Interest on second penalty"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
+      }
+    }
+
+    "there is a VAT Central Assessment LPI charge" should {
+
+      val model = exampleModel.copy(chargeType = VatCentralAssessmentLPI)
+      lazy val template = paymentsHistoryChargeDescription(model)(messages, agentUser)
+      lazy implicit val document: Document = Jsoup.parse(template.body)
+
+      "display the correct charge title" in {
+        elementText(Selectors.chargeTitle) shouldBe "Interest on central assessment of VAT"
+      }
+
+      "display the correct description" in {
+        elementText(Selectors.description) shouldBe "for period 12 Jan to 23 Mar 2018"
       }
     }
   }

--- a/test/views/templates/payments/WhatYouOweChargeHelperSpec.scala
+++ b/test/views/templates/payments/WhatYouOweChargeHelperSpec.scala
@@ -370,6 +370,42 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
           helper.description shouldBe Some("for late payment of VAT for VAT period 1 Jan to 2 Feb 2018")
         }
       }
+
+      "there is a VAT Return LPI charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatReturnLPI), false, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for period 1 Jan to 2 Feb 2018")
+        }
+      }
+
+      "there is a VAT Return 1st LPP LPI charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatReturn1stLPPLPI), false, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for period 1 Jan to 2 Feb 2018")
+        }
+      }
+
+      "there is a VAT Return 2nd LPP LPI charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatReturn2ndLPPLPI), false, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for period 1 Jan to 2 Feb 2018")
+        }
+      }
+
+      "there is a VAT Central Assessment LPI charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatCentralAssessmentLPI), false, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for period 1 Jan to 2 Feb 2018")
+        }
+      }
     }
 
     "the user is an agent" when {
@@ -689,6 +725,51 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
           helper.description shouldBe Some("cannot be repaid after 4 years")
         }
       }
+
+      "there is a VAT Return 1st LPP Charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatReturn1stLPP), true, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for late payment of VAT for VAT period 1 Jan to 2 Feb 2018")
+        }
+      }
+
+      "there is a VAT Return LPI charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatReturnLPI), true, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for period 1 Jan to 2 Feb 2018")
+        }
+      }
+
+      "there is a VAT Return 1st LPP LPI charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatReturn1stLPPLPI), true, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for period 1 Jan to 2 Feb 2018")
+        }
+      }
+
+      "there is a VAT Return 2nd LPP LPI charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatReturn2ndLPPLPI), true, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for period 1 Jan to 2 Feb 2018")
+        }
+      }
+
+      "there is a VAT Central Assessment LPI charge" should {
+
+        val helper = new WhatYouOweChargeHelper(paymentModel(VatCentralAssessmentLPI), true, messages)
+
+        "display the correct description" in {
+          helper.description shouldBe Some("for period 1 Jan to 2 Feb 2018")
+        }
+      }
     }
 
     "WhatYouOweChargeHelper .title" should {
@@ -759,15 +840,6 @@ class WhatYouOweChargeHelperSpec extends ViewBaseSpec {
           helper.viewReturnEnabled shouldBe false
         }
       }
-      "there is a VAT Return 1st LPP Charge" should {
-
-        val helper = new WhatYouOweChargeHelper(paymentModel(VatReturn1stLPP), true, messages)
-
-        "display the correct description" in {
-          helper.description shouldBe Some("for late payment of VAT for VAT period 1 Jan to 2 Feb 2018")
-        }
-      }
-
     }
   }
 


### PR DESCRIPTION
Also removed loads of repetitive code in `PaymentsHistoryChargeDescriptionTemplateSpec`, some repetitive messages ("for", "for period", "for the period") and added a few missing tests for 1st LPP penalty charge.