### PR TITLE
BTAT-10712 Increased PatienceConfig for repository spec

### DIFF
--- a/test/repositories/WYOSessionRepositorySpec.scala
+++ b/test/repositories/WYOSessionRepositorySpec.scala
@@ -16,7 +16,6 @@
 
 package repositories
 
-import akka.util.Timeout
 import config.AppConfig
 import mocks.MockAppConfig
 import models.WYODatabaseModel
@@ -26,7 +25,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsObject, Json}
-import play.api.test.Helpers.await
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
 import java.time.LocalDateTime
@@ -40,7 +39,7 @@ class WYOSessionRepositorySpec extends AnyWordSpecLike with Matchers with GuiceO
   val mockAppConfig: AppConfig = new MockAppConfig(app.configuration)
   implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
   override lazy val repository = new WYOSessionRepository(mockAppConfig, mongoComponent)
-  implicit val timeout: Timeout = 40.seconds
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 60.seconds, interval = 200.millis)
 
   val time: LocalDateTime = LocalDateTime.parse("2022-01-01T09:00:00.000")
   val exampleJson: JsObject = Json.obj("chargeType" -> "VAT Return Debit Charge", "periodKey" -> "18AA")


### PR DESCRIPTION
The issue seems to be with starting up the test repo even before any tests run so I doubled the default values we are getting from `DefaultPlayMongoRepositorySupport`