### PR TITLE
BTAT-10712 Added WYO database and config

### DIFF
--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -125,4 +125,5 @@ object ConfigKeys {
   val penaltiesFrontendHost: String = "penalties-frontend.host"
   val penaltiesFrontendUrl: String = "penalties-frontend.endpointUrl"
 
+  val timeToLive: String = "mongodb.timeToLiveInSeconds"
 }

--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -99,6 +99,7 @@ trait AppConfig {
   val penaltiesFrontendUrl: String
   val fixEmailUrl: String
   val govUkHoldingUrl: String
+  val timeToLiveInSeconds: Int
 }
 
 @Singleton
@@ -246,4 +247,6 @@ class FrontendAppConfig @Inject()(val runModeConfiguration: Configuration, sc: S
 
   override lazy val penaltiesFrontendUrl: String = sc.getString(Keys.penaltiesFrontendHost) + sc.getString(Keys.penaltiesFrontendUrl)
   override val govUkHoldingUrl: String = sc.getString(Keys.govUkHoldingUrl)
+
+  override lazy val timeToLiveInSeconds: Int = sc.getInt(Keys.timeToLive)
 }

--- a/app/repositories/WYOSessionRepository.scala
+++ b/app/repositories/WYOSessionRepository.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import config.AppConfig
+import models.WYODatabaseModel
+import org.mongodb.scala.model.Filters.equal
+import org.mongodb.scala.model.{IndexModel, IndexOptions, ReplaceOptions}
+import org.mongodb.scala.model.Indexes.ascending
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class WYOSessionRepository @Inject()(appConfig: AppConfig, mongo: MongoComponent)
+                                    (implicit ec: ExecutionContext)
+  extends PlayMongoRepository[WYODatabaseModel](
+    collectionName = "wyoSessionData",
+    mongoComponent = mongo,
+    domainFormat = WYODatabaseModel.format,
+    indexes = Seq(
+      IndexModel(
+        ascending("creationTimestamp"),
+        IndexOptions()
+          .name("expiry")
+          .expireAfter(appConfig.timeToLiveInSeconds, TimeUnit.SECONDS)
+      )
+    )
+  ) {
+
+  def write(model: WYODatabaseModel): Future[Boolean] = collection.replaceOne(
+    equal("_id", model._id),
+    model,
+    ReplaceOptions().upsert(true)
+  ).map(_.wasAcknowledged()).head()
+
+  def read(id: String): Future[Option[WYODatabaseModel]] = collection.find(
+    equal("_id", id)
+  ).headOption()
+}

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ val compile: Seq[ModuleID] = Seq(
   "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.24.0",
   "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.21.0-play-28",
   "com.typesafe.play" %% "play-json-joda"             % "2.9.2",
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % "0.62.0",
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % "0.67.0",
 )
 
 def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
@@ -56,7 +56,7 @@ def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
   "org.pegdown"             %  "pegdown"                     % "1.6.0"      % scope,
   "org.jsoup"               %  "jsoup"                       % "1.14.3"     % scope,
   "org.scalamock"           %% "scalamock-scalatest-support" % "3.6.0"      % scope,
-  "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28"     % "0.62.0"    % scope
+  "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28"     % "0.67.0"    % scope
 )
 
 TwirlKeys.templateImports ++= Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -27,6 +27,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
+play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 # Application loader
 # ~~~~
@@ -130,6 +131,11 @@ features {
   penaltiesService.enabled = true
   penaltiesAndInterestWYO.enabled = true
   chargeReferenceInset.enabled = true
+}
+
+mongodb {
+  uri = "mongodb://localhost:27017/vat-summary-frontend"
+  timeToLiveInSeconds = 900
 }
 
 timeout {

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -100,4 +100,6 @@ class MockAppConfig(val runModeConfiguration: Configuration, val mode: Mode = Mo
   override val penaltiesFrontendUrl: String = "/vat-through-software/test-only/penalties-stub"
   override val mtdGuidance: String = "/when-to-start-using-making-tax-digital-for-vat-if-youve-not-before"
   override val govUkHoldingUrl: String = "/gov-uk"
+
+  override val timeToLiveInSeconds: Int = 100
 }

--- a/test/repositories/WYOSessionRepositorySpec.scala
+++ b/test/repositories/WYOSessionRepositorySpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import config.AppConfig
+import mocks.MockAppConfig
+import models.WYODatabaseModel
+import org.mongodb.scala.bson.{BsonInt64, BsonString}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.libs.json.{JsObject, Json}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+import java.time.LocalDateTime
+import scala.concurrent.ExecutionContext
+
+class WYOSessionRepositorySpec extends AnyWordSpecLike with Matchers with GuiceOneAppPerSuite with
+  DefaultPlayMongoRepositorySupport[WYODatabaseModel] {
+
+  lazy val mockAppConfig: AppConfig = new MockAppConfig(app.configuration)
+  implicit lazy val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+  override lazy val repository = new WYOSessionRepository(mockAppConfig, mongoComponent)
+
+  val time: LocalDateTime = LocalDateTime.parse("2022-01-01T09:00:00.000")
+  val exampleJson: JsObject = Json.obj("chargeType" -> "VAT Return Debit Charge", "periodKey" -> "18AA")
+  val exampleModel: WYODatabaseModel = WYODatabaseModel("abc", "StandardChargeViewModel", exampleJson, time)
+
+  "The WYOSessionRepository" should {
+
+    "have a TTL index on the creationTimestamp field, with an expiry time set by AppConfig" in {
+      val indexes = {
+        await(repository.ensureIndexes)
+        await(repository.collection.listIndexes().toFuture())
+      }
+      val ttlIndex = indexes.find(_.get("name").contains(BsonString("expiry")))
+
+      ttlIndex.get("key").toString shouldBe """{"creationTimestamp": 1}"""
+      ttlIndex.get("expireAfterSeconds") shouldBe BsonInt64(mockAppConfig.timeToLiveInSeconds)
+    }
+  }
+
+  "Writing to the WYOSessionRepository" when {
+
+    "there is no document with the given ID" should {
+
+      "write the document to the database" in {
+        await(repository.write(exampleModel)) shouldBe true
+        await(repository.collection.countDocuments().toFuture()) shouldBe 1
+      }
+    }
+
+    "there is an existing document with the same ID" should {
+
+      "replace the existing document in the database" in {
+        await(repository.write(exampleModel))
+        await(repository.write(exampleModel.copy(creationTimestamp = time.plusMinutes(1)))) shouldBe true
+        await(repository.collection.countDocuments().toFuture()) shouldBe 1
+      }
+    }
+  }
+
+  "Reading from the WYOSessionRepository" when {
+
+    "a document is found for the given ID" should {
+
+      "return a WYODatabaseModel made up of data from the document" in {
+        await(repository.write(exampleModel))
+        await(repository.read("abc")) shouldBe Some(exampleModel)
+      }
+    }
+
+    "no document is found for the given ID" should {
+
+      "return None" in {
+        await(repository.read("abc")) shouldBe None
+      }
+    }
+  }
+}


### PR DESCRIPTION
Attempt number 2 at this PR. The only differences between this PR and #742 are:
- Updated `hmrc-mongo` to 0.67.0
- Changed the TTL index test so that all repository calls are inside of `await` functions and so that `ensureIndexes` is called first
- Set top level vals in the test spec that call the guice app to be lazy