### PR TITLE
BTAT-10713 Added WYO session service to speak to repository layer

### DIFF
--- a/app/services/WYOSessionService.scala
+++ b/app/services/WYOSessionService.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import models.WYODatabaseModel
+import models.viewModels._
+import play.api.libs.json.Json
+import repositories.WYOSessionRepository
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class WYOSessionService @Inject()(repository: WYOSessionRepository) {
+
+  def storeChargeModels(viewModels: Seq[ChargeDetailsViewModel], vrn: String)
+                       (implicit ec: ExecutionContext): Future[Seq[Boolean]] = {
+
+    val results: Seq[Future[Boolean]] = viewModels.map { model =>
+
+      val json = model match {
+        case m: StandardChargeViewModel => Json.toJson(m)
+        case m: EstimatedInterestViewModel => Json.toJson(m)
+        case m: CrystallisedInterestViewModel => Json.toJson(m)
+        case m: CrystallisedLPP1ViewModel => Json.toJson(m)
+        case m: CrystallisedLPP2ViewModel => Json.toJson(m)
+      }
+      val databaseModel = WYODatabaseModel(model.generateHash(vrn), model.getClass.getSimpleName, json)
+
+      repository.write(databaseModel)
+    }
+
+    Future.sequence(results)
+  }
+
+  def retrieveViewModel(id: String): Future[Option[WYODatabaseModel]] =
+    repository.read(id)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -52,11 +52,11 @@ val compile: Seq[ModuleID] = Seq(
 )
 
 def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
-  "uk.gov.hmrc"             %% "bootstrap-test-play-28"      % "5.24.0",
-  "org.pegdown"             %  "pegdown"                     % "1.6.0"      % scope,
-  "org.jsoup"               %  "jsoup"                       % "1.14.3"     % scope,
-  "org.scalamock"           %% "scalamock-scalatest-support" % "3.6.0"      % scope,
-  "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28"     % "0.67.0"    % scope
+  "uk.gov.hmrc"        %% "bootstrap-test-play-28"      % "5.24.0"  % scope,
+  "org.scalatestplus"  %% "mockito-3-4"                 % "3.2.9.0" % scope,
+  "org.jsoup"          %  "jsoup"                       % "1.14.3"  % scope,
+  "org.scalamock"      %% "scalamock-scalatest-support" % "3.6.0"   % scope,
+  "uk.gov.hmrc.mongo"  %% "hmrc-mongo-test-play-28"     % "0.67.0"  % scope
 )
 
 TwirlKeys.templateImports ++= Seq(

--- a/test/services/WYOSessionServiceSpec.scala
+++ b/test/services/WYOSessionServiceSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import common.TestModels._
+import models.WYODatabaseModel
+import models.viewModels.ChargeDetailsViewModel
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.libs.json.Json
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import repositories.WYOSessionRepository
+
+import java.time.LocalDateTime
+import scala.concurrent.{ExecutionContext, Future}
+
+class WYOSessionServiceSpec extends AnyWordSpecLike with Matchers with MockitoSugar with GuiceOneAppPerSuite {
+
+  val mockRepo: WYOSessionRepository = mock[WYOSessionRepository]
+  val service = new WYOSessionService(mockRepo)
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+
+  def mockRepoWrite(result: Boolean): Any = when(mockRepo.write(any())).thenReturn(Future.successful(result))
+  def mockRepoRead(result: Option[WYODatabaseModel]): Any = when(mockRepo.read(any())).thenReturn(Future.successful(result))
+
+  "The storeChargeModels function" should {
+
+    "take a sequence of ChargeDetailsViewModel and write an entry to the database for each one" in {
+      mockRepoWrite(true)
+      val charges =
+        Seq(chargeModel1, estimatedInterestModel, crystallisedInterestCharge, crystallisedLPP1Model, crystallisedLPP2Model)
+      val result = service.storeChargeModels(charges, "999999999")
+
+      await(result) shouldBe Seq.fill(charges.length)(true)
+    }
+
+    "throw an exception when an unsupported view model is provided" in {
+      val unsupportedModel = new ChargeDetailsViewModel {
+        override val outstandingAmount: BigDecimal = 0
+      }
+
+      intercept[MatchError](service.storeChargeModels(Seq(unsupportedModel), "999999999"))
+    }
+  }
+
+  "The retrieveViewModel function" should {
+
+    "return the result from the database's read operation" in {
+      val databaseModel = WYODatabaseModel("abc", "StandardChargeViewModel", Json.obj(), LocalDateTime.now())
+      mockRepoRead(Some(databaseModel))
+      await(service.retrieveViewModel("abc")) shouldBe Some(databaseModel)
+    }
+  }
+}


### PR DESCRIPTION
- I have added Mockito dependency as ScalaMock does not play nice with mocking out mongo repositories
- I had to add the reptitive `Json.toJson` line into the write function as there is no JSON writes for the generic type
- I elected to keep the read function simple considering the controller action will need to have a match statement for the view model type again anyway - it seemed pointless to duplicate it
- The tests are quite simple as they are essentially just returning what the database does (extra scenarios would simply be - when I mock a `false`, return `false` - when I mock a `None`, return `None` - etc)