### PR TITLE
BTAT-10797 Added charge type -> LPI charge type map

### DIFF
--- a/app/models/payments/ChargeType.scala
+++ b/app/models/payments/ChargeType.scala
@@ -399,13 +399,13 @@ object ChargeType extends LoggerUtil {
   val interestChargeTypes: Set[ChargeType] = Set(
     VatReturnLPI,
     VatReturn1stLPPLPI,
-    VatReturn2ndLPPLPI,
+    VatReturn2ndLPPLPI, // TODO add interest mapping when parent charge available
     VatCentralAssessmentLPI,
-    VatCA1stLPPLPI,
-    VatCA2ndLPPLPI,
+    VatCA1stLPPLPI, // TODO add interest mapping when parent charge available
+    VatCA2ndLPPLPI, // TODO add interest mapping when parent charge available
     VatOfficersAssessmentLPI,
-    VatOA1stLPPLPI,
-    VatOA2ndLPPLPI,
+    VatOA1stLPPLPI, // TODO add interest mapping when parent charge available
+    VatOA2ndLPPLPI, // TODO add interest mapping when parent charge available
     VatPA1stLPPLPI,
     VatPA2ndLPPLPI,
     VatPALPICharge,
@@ -449,11 +449,29 @@ object ChargeType extends LoggerUtil {
     VatAAReturnCharge2ndLPP
   )
 
+  val interestChargeMapping: Map[ChargeType, ChargeType] = Map(
+    ReturnDebitCharge -> VatReturnLPI,
+    VatReturn1stLPP -> VatReturn1stLPPLPI,
+    CentralAssessmentCharge -> VatCentralAssessmentLPI,
+    OADebitCharge -> VatOfficersAssessmentLPI,
+    VatPA1stLPP -> VatPA1stLPPLPI,
+    VatPA2ndLPP -> VatPA2ndLPPLPI,
+    VatProtectiveAssessmentCharge -> VatPALPICharge,
+    AACharge -> VatAdditionalAssessmentLPI,
+    VatAA1stLPP -> VatAA1stLPPLPI,
+    VatAA2ndLPP -> VatAA2ndLPPLPI,
+    VatLateSubmissionPen -> VatLspInterest,
+    VatAAReturnCharge1stLPP -> VatReturnAA1stLPPLPI,
+    VatAAReturnCharge2ndLPP -> VatReturnAA2ndLPPLPI,
+    VatManualLPP -> VatManualLPPLPI,
+    AAQuarterlyInstalments -> VatAAQuarterlyInstalLPI,
+    AAMonthlyInstalment -> VatAAMonthlyInstalLPI
+  )
+
   def apply: String => ChargeType = input => {
     allChargeTypes.find { chargeType =>
       chargeType.value.toUpperCase.equals(input.trim.toUpperCase)
     }.getOrElse(throw new IllegalArgumentException("Invalid Charge Type"))
-
   }
 
   def unapply(arg: ChargeType): String = arg.value

--- a/test/models/payments/ChargeTypeSpec.scala
+++ b/test/models/payments/ChargeTypeSpec.scala
@@ -90,4 +90,35 @@ class ChargeTypeSpec extends AnyWordSpecLike with Matchers {
 
   }
 
+  "The interestChargeMapping collection" when {
+
+    "provided with a supported charge type" should {
+
+      "return the corresponding interest charge" in {
+        ChargeType.interestChargeMapping(ReturnDebitCharge) shouldBe VatReturnLPI
+        ChargeType.interestChargeMapping(VatReturn1stLPP) shouldBe VatReturn1stLPPLPI
+        ChargeType.interestChargeMapping(CentralAssessmentCharge) shouldBe VatCentralAssessmentLPI
+        ChargeType.interestChargeMapping(OADebitCharge) shouldBe VatOfficersAssessmentLPI
+        ChargeType.interestChargeMapping(VatPA1stLPP) shouldBe VatPA1stLPPLPI
+        ChargeType.interestChargeMapping(VatPA2ndLPP) shouldBe VatPA2ndLPPLPI
+        ChargeType.interestChargeMapping(VatProtectiveAssessmentCharge) shouldBe VatPALPICharge
+        ChargeType.interestChargeMapping(AACharge) shouldBe VatAdditionalAssessmentLPI
+        ChargeType.interestChargeMapping(VatAA1stLPP) shouldBe VatAA1stLPPLPI
+        ChargeType.interestChargeMapping(VatAA2ndLPP) shouldBe VatAA2ndLPPLPI
+        ChargeType.interestChargeMapping(VatLateSubmissionPen) shouldBe VatLspInterest
+        ChargeType.interestChargeMapping(VatAAReturnCharge1stLPP) shouldBe VatReturnAA1stLPPLPI
+        ChargeType.interestChargeMapping(VatAAReturnCharge2ndLPP) shouldBe VatReturnAA2ndLPPLPI
+        ChargeType.interestChargeMapping(VatManualLPP) shouldBe VatManualLPPLPI
+        ChargeType.interestChargeMapping(AAQuarterlyInstalments) shouldBe VatAAQuarterlyInstalLPI
+        ChargeType.interestChargeMapping(AAMonthlyInstalment) shouldBe VatAAMonthlyInstalLPI
+      }
+    }
+
+    "provided with an unsupported charge type" should {
+
+      "throw an exception" in {
+        intercept[NoSuchElementException](ChargeType.interestChargeMapping(ReturnCreditCharge))
+      }
+    }
+  }
 }


### PR DESCRIPTION
I have added TODO statements for the LPI charges that we currently don't define a parent charge for, to make it clear where the gaps are. The collection I've added will need to be updated when we do the upcoming work for the parent charges.