### PR TITLE
BTAT-10901 originalAmount to be mandatory

### DIFF
--- a/app/models/payments/Payment.scala
+++ b/app/models/payments/Payment.scala
@@ -27,7 +27,7 @@ sealed trait Payment extends Obligation {
   val chargeType: ChargeType
   val due: LocalDate
   val outstandingAmount: BigDecimal
-  val originalAmount: Option[BigDecimal]
+  val originalAmount: BigDecimal
   val chargeReference: Option[String]
   val clearedAmount: Option[BigDecimal]
   val periodKey: Option[String]
@@ -57,7 +57,7 @@ case class PaymentWithPeriod(chargeType: ChargeType,
                              accruedInterestAmount: Option[BigDecimal],
                              accruedPenaltyAmount: Option[BigDecimal],
                              penaltyType: Option[String],
-                             originalAmount: Option[BigDecimal] = None,
+                             originalAmount: BigDecimal,
                              clearedAmount: Option[BigDecimal] = None) extends Payment {
 
   val auditDetails: Map[String, String] = Map(
@@ -78,7 +78,7 @@ case class PaymentNoPeriod(chargeType: ChargeType,
                            accruedInterestAmount: Option[BigDecimal],
                            accruedPenaltyAmount: Option[BigDecimal],
                            penaltyType: Option[String],
-                           originalAmount: Option[BigDecimal] = None,
+                           originalAmount: BigDecimal,
                            clearedAmount: Option[BigDecimal] = None) extends Payment {
 
   val auditDetails: Map[String, String] = Map(
@@ -101,7 +101,7 @@ object Payment {
                             accruedInterestAmount: Option[BigDecimal],
                             accruedPenaltyAmount: Option[BigDecimal],
                             penaltyType: Option[String],
-                            originalAmount: Option[BigDecimal],
+                            originalAmount: BigDecimal,
                             clearedAmount: Option[BigDecimal]): Payment =
     (periodFrom, periodTo) match {
       case (Some(s), Some(e)) =>
@@ -125,7 +125,7 @@ object Payment {
             accruedInterestAmount: Option[BigDecimal],
             accruedPenaltyAmount: Option[BigDecimal],
             penaltyType: Option[String],
-            originalAmount: Option[BigDecimal],
+            originalAmount: BigDecimal,
             clearedAmount: Option[BigDecimal]): PaymentWithPeriod =
     PaymentWithPeriod(
       chargeType,
@@ -153,7 +153,8 @@ object Payment {
             ddCollectionInProgress: Boolean,
             accruedInterestAmount: Option[BigDecimal],
             accruedPenaltyAmount: Option[BigDecimal],
-            penaltyType: Option[String]): PaymentWithPeriod =
+            penaltyType: Option[String],
+            originalAmount: BigDecimal): PaymentWithPeriod =
     PaymentWithPeriod(
       chargeType,
       periodFrom,
@@ -165,7 +166,8 @@ object Payment {
       ddCollectionInProgress,
       accruedInterestAmount,
       accruedPenaltyAmount,
-      penaltyType
+      penaltyType,
+      originalAmount
     )
 
   def apply(chargeType: ChargeType,
@@ -177,7 +179,7 @@ object Payment {
             accruedInterestAmount: Option[BigDecimal],
             accruedPenaltyAmount: Option[BigDecimal],
             penaltyType: Option[String],
-            originalAmount: Option[BigDecimal],
+            originalAmount: BigDecimal,
             clearedAmount: Option[BigDecimal]
             ): PaymentNoPeriod =
     PaymentNoPeriod(
@@ -202,7 +204,8 @@ object Payment {
             ddCollectionInProgress: Boolean,
             accruedInterestAmount: Option[BigDecimal],
             accruedPenaltyAmount: Option[BigDecimal],
-            penaltyType: Option[String]): PaymentNoPeriod =
+            penaltyType: Option[String],
+            originalAmount: BigDecimal): PaymentNoPeriod =
     PaymentNoPeriod(
       chargeType,
       due,
@@ -212,7 +215,8 @@ object Payment {
       ddCollectionInProgress,
       accruedInterestAmount,
       accruedPenaltyAmount,
-      penaltyType
+      penaltyType,
+      originalAmount
     )
 
   implicit val paymentReads: Reads[Payment] = (
@@ -227,7 +231,7 @@ object Payment {
     (JsPath \ "accruedInterestAmount").readNullable[BigDecimal] and
     (JsPath \ "accruedPenaltyAmount").readNullable[BigDecimal] and
     (JsPath \ "penaltyType").readNullable[String] and
-    (JsPath \ "originalAmount").readNullable[BigDecimal] and
+    (JsPath \ "originalAmount").read[BigDecimal] and
     (JsPath \ "clearedAmount").readNullable[BigDecimal]
 
   )(Payment.createPayment _)

--- a/app/testOnly/controllers/WhatYouOweController.scala
+++ b/app/testOnly/controllers/WhatYouOweController.scala
@@ -108,21 +108,18 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
   }
 
   private[controllers] def buildStandardChargeViewModel(payment: Payment): Option[StandardChargeViewModel] =
-    payment.originalAmount match {
-      case originalAmount =>
-        Some(StandardChargeViewModel(
-          chargeType = payment.chargeType.value,
-          outstandingAmount = payment.outstandingAmount,
-          originalAmount = originalAmount,
-          clearedAmount = payment.clearedAmount.getOrElse(0),
-          dueDate = payment.due,
-          periodKey = payment.periodKey,
-          isOverdue = payment.isOverdue(dateService.now()),
-          chargeReference = payment.chargeReference,
-          periodFrom = periodFrom(payment),
-          periodTo = periodTo(payment)
-        ))
-    }
+    Some(StandardChargeViewModel(
+      chargeType = payment.chargeType.value,
+      outstandingAmount = payment.outstandingAmount,
+      originalAmount = payment.originalAmount,
+      clearedAmount = payment.clearedAmount.getOrElse(0),
+      dueDate = payment.due,
+      periodKey = payment.periodKey,
+      isOverdue = payment.isOverdue(dateService.now()),
+      chargeReference = payment.chargeReference,
+      periodFrom = periodFrom(payment),
+      periodTo = periodTo(payment)
+    ))
 
   private[controllers] def buildEstimatedIntViewModel(payment: PaymentWithPeriod): Option[EstimatedInterestViewModel] =
     payment.accruedInterestAmount match {
@@ -139,15 +136,15 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
     }
 
   private[controllers] def buildCrystallisedIntViewModel(payment: PaymentWithPeriod): Option[CrystallisedInterestViewModel] =
-    (payment.chargeReference, payment.originalAmount) match {
-      case (Some(chargeRef), originalAmount) =>
+    payment.chargeReference match {
+      case Some(chargeRef) =>
         Some(CrystallisedInterestViewModel(
           periodFrom = payment.periodFrom,
           periodTo = payment.periodTo,
           chargeType = payment.chargeType.value,
           interestRate = 5.00, // TODO replace with API field
           dueDate = payment.due,
-          interestAmount = originalAmount,
+          interestAmount = payment.originalAmount,
           amountReceived = payment.clearedAmount.getOrElse(0),
           leftToPay = payment.outstandingAmount,
           isOverdue = payment.isOverdue(dateService.now()),
@@ -158,12 +155,12 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
     }
 
   private[controllers] def buildLateSubmissionPenaltyViewModel(payment: PaymentWithPeriod): Option[LateSubmissionPenaltyViewModel] =
-    (payment.chargeReference, payment.originalAmount) match {
-      case (Some(chargeRef), originalAmount) =>
+    payment.chargeReference match {
+      case Some(chargeRef) =>
         Some(LateSubmissionPenaltyViewModel(
           chargeType = payment.chargeType.value,
           dueDate = payment.due,
-          penaltyAmount = originalAmount,
+          penaltyAmount = payment.originalAmount,
           amountReceived = payment.clearedAmount.getOrElse(0),
           leftToPay = payment.outstandingAmount,
           isOverdue = payment.isOverdue(dateService.now()),
@@ -203,9 +200,9 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
 
   private[controllers] def buildCrystallisedLPPViewModel(payment: PaymentWithPeriod,
                                                          penaltyDetails: Option[LPPDetails]): Option[ChargeDetailsViewModel] =
-    (penaltyDetails, payment.originalAmount, payment.chargeReference) match {
+    (penaltyDetails, payment.chargeReference) match {
       case (Some(LPPDetails(_, "LPP1", Some(calcAmountLR), Some(daysLR), Some(rateLR), calcAmountHR, Some(daysHR), rateHR, _, _, _)),
-            originalAmnt, Some(chargeRef)) =>
+            Some(chargeRef)) =>
         val numOfDays = if (calcAmountHR.isDefined) daysHR else daysLR
         Some(CrystallisedLPP1ViewModel(
           numberOfDays = numOfDays,
@@ -216,7 +213,7 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
           part1UnpaidVAT = calcAmountLR,
           part2UnpaidVAT = calcAmountHR,
           dueDate = payment.due,
-          penaltyAmount = originalAmnt,
+          penaltyAmount = payment.originalAmount,
           amountReceived = payment.clearedAmount.getOrElse(0),
           leftToPay = payment.outstandingAmount,
           periodFrom = payment.periodFrom,

--- a/app/testOnly/controllers/WhatYouOweController.scala
+++ b/app/testOnly/controllers/WhatYouOweController.scala
@@ -109,7 +109,7 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
 
   private[controllers] def buildStandardChargeViewModel(payment: Payment): Option[StandardChargeViewModel] =
     payment.originalAmount match {
-      case Some(originalAmount) =>
+      case originalAmount =>
         Some(StandardChargeViewModel(
           chargeType = payment.chargeType.value,
           outstandingAmount = payment.outstandingAmount,
@@ -122,7 +122,6 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
           periodFrom = periodFrom(payment),
           periodTo = periodTo(payment)
         ))
-      case _ => None
     }
 
   private[controllers] def buildEstimatedIntViewModel(payment: PaymentWithPeriod): Option[EstimatedInterestViewModel] =
@@ -141,7 +140,7 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
 
   private[controllers] def buildCrystallisedIntViewModel(payment: PaymentWithPeriod): Option[CrystallisedInterestViewModel] =
     (payment.chargeReference, payment.originalAmount) match {
-      case (Some(chargeRef), Some(originalAmount)) =>
+      case (Some(chargeRef), originalAmount) =>
         Some(CrystallisedInterestViewModel(
           periodFrom = payment.periodFrom,
           periodTo = payment.periodTo,
@@ -160,7 +159,7 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
 
   private[controllers] def buildLateSubmissionPenaltyViewModel(payment: PaymentWithPeriod): Option[LateSubmissionPenaltyViewModel] =
     (payment.chargeReference, payment.originalAmount) match {
-      case (Some(chargeRef), Some(originalAmount)) =>
+      case (Some(chargeRef), originalAmount) =>
         Some(LateSubmissionPenaltyViewModel(
           chargeType = payment.chargeType.value,
           dueDate = payment.due,
@@ -206,7 +205,7 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
                                                          penaltyDetails: Option[LPPDetails]): Option[ChargeDetailsViewModel] =
     (penaltyDetails, payment.originalAmount, payment.chargeReference) match {
       case (Some(LPPDetails(_, "LPP1", Some(calcAmountLR), Some(daysLR), Some(rateLR), calcAmountHR, Some(daysHR), rateHR, _, _, _)),
-            Some(originalAmnt), Some(chargeRef)) =>
+            originalAmnt, Some(chargeRef)) =>
         val numOfDays = if (calcAmountHR.isDefined) daysHR else daysLR
         Some(CrystallisedLPP1ViewModel(
           numberOfDays = numOfDays,

--- a/it/connectors/FinancialDataConnectorISpec.scala
+++ b/it/connectors/FinancialDataConnectorISpec.scala
@@ -53,7 +53,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(2),
           chargeReference = Some("XD002750002155"),
-          originalAmount = Some(10000),
+          originalAmount = BigDecimal(10000),
           accruedPenaltyAmount = None,
           penaltyType = None
         ),
@@ -67,7 +67,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
           chargeReference = Some("XD002750002156"),
-          originalAmount = Some(10000),
+          originalAmount = BigDecimal(10000),
           accruedPenaltyAmount = Some(3),
           penaltyType = Some("LPP1")
         ),
@@ -81,7 +81,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
           chargeReference = Some("XD002750002157"),
-          originalAmount = Some(55.55),
+          originalAmount = BigDecimal(55.55),
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP1")
         )

--- a/test/audit/ViewNextOutstandingVatPaymentAuditModelSpec.scala
+++ b/test/audit/ViewNextOutstandingVatPaymentAuditModelSpec.scala
@@ -38,7 +38,8 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends AnyWordSpecLike with M
         ddCollectionInProgress = false,
         accruedInterestAmount = Some(BigDecimal(2)),
         accruedPenaltyAmount = None,
-        penaltyType = None
+        penaltyType = None,
+        originalAmount = BigDecimal(10000)
       )
     )
   )
@@ -56,7 +57,8 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends AnyWordSpecLike with M
         ddCollectionInProgress = false,
         accruedInterestAmount = Some(BigDecimal(2)),
         accruedPenaltyAmount = None,
-        penaltyType = None
+        penaltyType = None,
+        originalAmount = BigDecimal(10000)
       ),
       Payment(
         ReturnDebitCharge,
@@ -69,7 +71,8 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends AnyWordSpecLike with M
         ddCollectionInProgress = false,
         accruedInterestAmount = Some(BigDecimal(2)),
         accruedPenaltyAmount = None,
-        penaltyType = None
+        penaltyType = None,
+        originalAmount = BigDecimal(10000)
       )
     )
   )

--- a/test/common/TestModels.scala
+++ b/test/common/TestModels.scala
@@ -49,7 +49,8 @@ object TestModels {
     ddCollectionInProgress = false,
     accruedInterestAmount = Some(BigDecimal(2)),
     accruedPenaltyAmount = None,
-    penaltyType = None
+    penaltyType = None,
+    originalAmount = BigDecimal(10000)
   )))
 
   val payment: PaymentWithPeriod = Payment(
@@ -62,7 +63,7 @@ object TestModels {
     chargeReference = Some("XD002750002155"),
     ddCollectionInProgress = false,
     accruedInterestAmount = Some(BigDecimal(2)),
-    originalAmount = Some(10000),
+    originalAmount = BigDecimal(10000),
     clearedAmount = Some(0),
     accruedPenaltyAmount = Some(50.55),
     penaltyType = Some("LPP1")
@@ -83,7 +84,7 @@ object TestModels {
     accruedInterestAmount = Some(BigDecimal(2)),
     accruedPenaltyAmount = None,
     penaltyType = None,
-    originalAmount = Some(1000.00),
+    originalAmount = BigDecimal(10000),
     clearedAmount = Some(00.00)
   )
 
@@ -100,7 +101,8 @@ object TestModels {
     ddCollectionInProgress = false,
     accruedInterestAmount = Some(BigDecimal(2)),
     accruedPenaltyAmount = None,
-    penaltyType = None
+    penaltyType = None,
+    originalAmount = BigDecimal(10000)
   )
 
   val obligations: VatReturnObligations = VatReturnObligations(Seq(VatReturnObligation(

--- a/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
@@ -52,7 +52,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 3,
-              "penaltyType" -> "LPP1"
+              "penaltyType" -> "LPP1",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT Return Charge",
@@ -65,7 +66,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.51,
               "periodKey" -> "#002",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT Officer's Assessment",
@@ -78,7 +80,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.52,
               "periodKey" -> "#003",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT Officer's Assessment",
@@ -91,7 +94,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.53,
               "periodKey" -> "#004",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> CentralAssessmentCharge.value,
@@ -104,7 +108,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.25,
               "periodKey" -> "#005",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> DebitDefaultSurcharge.value,
@@ -117,7 +122,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.27,
               "periodKey" -> "#006",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> CreditDefaultSurcharge.value,
@@ -130,7 +136,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> -1000.27,
               "periodKey" -> "#006",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT Error Correction",
@@ -143,7 +150,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.29,
               "periodKey" -> "#007",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT Error Correction",
@@ -156,7 +164,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.30,
               "periodKey" -> "#007",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> AAInterestCharge.value,
@@ -169,7 +178,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.30,
               "periodKey" -> "#008",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT AA Return Charge",
@@ -182,7 +192,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.30,
               "periodKey" -> "#009",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT AA Return Charge",
@@ -195,7 +206,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.30,
               "periodKey" -> "#010",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT Annual Accounting",
@@ -208,7 +220,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.30,
               "periodKey" -> "#011",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT Annual Accounting",
@@ -221,7 +234,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.30,
               "periodKey" -> "#012",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> OADefaultInterestCharge.value,
@@ -234,7 +248,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "outstandingAmount" -> 1000.30,
               "periodKey" -> "#018",
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> AACharge.value,
@@ -251,7 +266,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> OAFurtherInterestCharge.value,
@@ -268,7 +284,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> BnpRegPre2010Charge.value,
@@ -285,7 +302,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> BnpRegPost2010Charge.value,
@@ -302,7 +320,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT FTN PRE 2010",
@@ -319,7 +338,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> "VAT FTN POST 2010",
@@ -336,7 +356,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> MiscPenaltyCharge.value,
@@ -353,7 +374,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> FtnEachPartnerCharge.value,
@@ -370,7 +392,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> MpPre2009Charge.value,
@@ -387,7 +410,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> MpRepeatedPre2009Charge.value,
@@ -404,7 +428,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> CivilEvasionPenaltyCharge.value,
@@ -421,7 +446,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> VatOAInaccuraciesFrom2009.value,
@@ -438,7 +464,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> InaccuraciesAssessmentsPenCharge.value,
@@ -455,7 +482,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> InaccuraciesReturnReplacedCharge.value,
@@ -472,7 +500,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> CarterPenaltyCharge.value,
@@ -489,7 +518,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> WrongDoingPenaltyCharge.value,
@@ -504,7 +534,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> FailureToSubmitRCSLCharge.value,
@@ -519,7 +550,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> FailureToNotifyRCSLCharge.value,
@@ -534,7 +566,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> paymentOnAccountInstalmentsMainType,
@@ -549,7 +582,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> paymentOnAccountReturnChargeMainType,
@@ -564,7 +598,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> paymentOnAccountReturnChargeMainType,
@@ -579,7 +614,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> VatUnrepayableOverpayment.value,
@@ -594,7 +630,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "mainType" -> VatReturn1stLPP.value,
@@ -609,7 +646,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatReturnLPI.value,
@@ -622,7 +660,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatPALPICharge.value,
@@ -635,7 +674,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatReturn1stLPPLPI.value,
@@ -650,7 +690,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
 
             ),
             Json.obj(
@@ -666,7 +707,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatCentralAssessmentLPI.value,
@@ -679,7 +721,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatCA1stLPPLPI.value,
@@ -694,7 +737,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatCA2ndLPPLPI.value,
@@ -709,7 +753,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatOfficersAssessmentLPI.value,
@@ -722,7 +767,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatOA1stLPPLPI.value,
@@ -737,7 +783,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatOA2ndLPPLPI.value,
@@ -752,7 +799,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatPA1stLPPLPI.value,
@@ -767,7 +815,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002156",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatPA2ndLPPLPI.value,
@@ -782,7 +831,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002157",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatPA1stLPP.value,
@@ -797,7 +847,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatPA2ndLPP.value,
@@ -812,7 +863,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAA1stLPP.value,
@@ -827,7 +879,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAA2ndLPP.value,
@@ -842,7 +895,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAA1stLPPLPI.value,
@@ -857,7 +911,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAA2ndLPPLPI.value,
@@ -872,7 +927,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAdditionalAssessmentLPI.value,
@@ -885,7 +941,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatLateSubmissionPen.value,
@@ -898,7 +955,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatLspInterest.value,
@@ -913,7 +971,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatReturnAA1stLPPLPI.value,
@@ -928,7 +987,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatReturnAA2ndLPPLPI.value,
@@ -943,7 +1003,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatManualLPP.value,
@@ -958,7 +1019,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatManualLPPLPI.value,
@@ -973,7 +1035,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAAQuarterlyInstalLPI.value,
@@ -986,7 +1049,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAAMonthlyInstalLPI.value,
@@ -999,7 +1063,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
                 )
               ),
               "chargeReference" -> "XD002750002155",
-              "accruedInterestAmount" -> 2
+              "accruedInterestAmount" -> 2,
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAAReturnCharge1stLPP.value,
@@ -1014,7 +1079,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             ),
             Json.obj(
               "chargeType" -> VatAAReturnCharge2ndLPP.value,
@@ -1029,7 +1095,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
               "chargeReference" -> "XD002750002155",
               "accruedInterestAmount" -> 2,
               "accruedPenaltyAmount" -> 100.00,
-              "penaltyType" -> "LPP"
+              "penaltyType" -> "LPP",
+              "originalAmount" -> 10000
             )
           )
         ).toString()
@@ -1047,7 +1114,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(3),
-          penaltyType = Some("LPP1")
+          penaltyType = Some("LPP1"),
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           ReturnCreditCharge,
@@ -1060,7 +1128,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           OACreditCharge,
@@ -1073,7 +1142,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           OADebitCharge,
@@ -1086,7 +1156,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           CentralAssessmentCharge,
@@ -1099,7 +1170,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           DebitDefaultSurcharge,
@@ -1112,7 +1184,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           CreditDefaultSurcharge,
@@ -1125,7 +1198,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           ErrorCorrectionCreditCharge,
@@ -1138,7 +1212,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           ErrorCorrectionDebitCharge,
@@ -1151,7 +1226,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           AAInterestCharge,
@@ -1164,7 +1240,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           AAReturnDebitCharge,
@@ -1177,7 +1254,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           AAReturnCreditCharge,
@@ -1190,7 +1268,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           AAMonthlyInstalment,
@@ -1203,7 +1282,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           AAQuarterlyInstalments,
@@ -1216,7 +1296,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           OADefaultInterestCharge,
@@ -1229,7 +1310,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           AACharge,
@@ -1242,7 +1324,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           OAFurtherInterestCharge,
@@ -1255,7 +1338,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           BnpRegPre2010Charge,
@@ -1268,7 +1352,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           BnpRegPost2010Charge,
@@ -1281,7 +1366,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           FtnMatPre2010Charge,
@@ -1294,7 +1380,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           FtnMatPost2010Charge,
@@ -1307,7 +1394,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           MiscPenaltyCharge,
@@ -1320,7 +1408,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           FtnEachPartnerCharge,
@@ -1333,7 +1422,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           MpPre2009Charge,
@@ -1346,7 +1436,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           MpRepeatedPre2009Charge,
@@ -1359,7 +1450,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         PaymentWithPeriod(
           CivilEvasionPenaltyCharge,
@@ -1372,7 +1464,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatOAInaccuraciesFrom2009,
@@ -1385,7 +1478,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           InaccuraciesAssessmentsPenCharge,
@@ -1398,7 +1492,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           InaccuraciesReturnReplacedCharge,
@@ -1411,7 +1506,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           CarterPenaltyCharge,
@@ -1424,7 +1520,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           WrongDoingPenaltyCharge,
@@ -1435,7 +1532,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           FailureToSubmitRCSLCharge,
@@ -1446,7 +1544,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           FailureToNotifyRCSLCharge,
@@ -1457,7 +1556,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           PaymentOnAccountInstalments,
@@ -1468,7 +1568,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           PaymentOnAccountReturnDebitCharge,
@@ -1479,7 +1580,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           PaymentOnAccountReturnCreditCharge,
@@ -1490,7 +1592,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatUnrepayableOverpayment,
@@ -1501,7 +1604,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatReturn1stLPP,
@@ -1512,7 +1616,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatReturnLPI,
@@ -1523,7 +1628,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatPALPICharge,
@@ -1534,7 +1640,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatReturn1stLPPLPI,
@@ -1545,7 +1652,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatReturn2ndLPPLPI,
@@ -1556,7 +1664,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatCentralAssessmentLPI,
@@ -1567,7 +1676,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatCA1stLPPLPI,
@@ -1578,7 +1688,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.0)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatCA2ndLPPLPI,
@@ -1589,7 +1700,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.0)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatOfficersAssessmentLPI,
@@ -1600,7 +1712,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatOA1stLPPLPI,
@@ -1611,7 +1724,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatOA2ndLPPLPI,
@@ -1622,7 +1736,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatPA1stLPPLPI,
@@ -1633,7 +1748,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatPA2ndLPPLPI,
@@ -1644,7 +1760,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatPA1stLPP,
@@ -1655,7 +1772,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatPA2ndLPP,
@@ -1666,7 +1784,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAA1stLPP,
@@ -1677,7 +1796,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAA2ndLPP,
@@ -1688,7 +1808,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAA1stLPPLPI,
@@ -1699,7 +1820,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAA2ndLPPLPI,
@@ -1710,7 +1832,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAdditionalAssessmentLPI,
@@ -1721,7 +1844,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatLateSubmissionPen,
@@ -1732,7 +1856,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatLspInterest,
@@ -1743,7 +1868,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatReturnAA1stLPPLPI,
@@ -1754,7 +1880,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatReturnAA2ndLPPLPI,
@@ -1765,7 +1892,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatManualLPP,
@@ -1776,7 +1904,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatManualLPPLPI,
@@ -1787,7 +1916,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAAQuarterlyInstalLPI,
@@ -1798,7 +1928,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAAMonthlyInstalLPI,
@@ -1809,7 +1940,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAAReturnCharge1stLPP,
@@ -1820,7 +1952,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         ),
         Payment(
           VatAAReturnCharge2ndLPP,
@@ -1831,7 +1964,8 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP")
+          penaltyType = Some("LPP"),
+          originalAmount = BigDecimal(10000)
         )
       )))
 

--- a/test/controllers/OpenPaymentsControllerSpec.scala
+++ b/test/controllers/OpenPaymentsControllerSpec.scala
@@ -264,7 +264,8 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
                 ddCollectionInProgress = true,
                 accruedInterestAmount = Some(BigDecimal(2)),
                 accruedPenaltyAmount = Some(BigDecimal(100.00)),
-                penaltyType = Some("LPP1")
+                penaltyType = Some("LPP1"),
+                BigDecimal(10000)
               )
 
               val expected: OpenPaymentsViewModel = OpenPaymentsViewModel(
@@ -304,7 +305,8 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
                 ddCollectionInProgress = false,
                 accruedInterestAmount = Some(BigDecimal(2)),
                 accruedPenaltyAmount = Some(100.00),
-                penaltyType = Some("LPP1")
+                penaltyType = Some("LPP1"),
+                BigDecimal(10000)
               )
 
               val expected: OpenPaymentsViewModel = OpenPaymentsViewModel(
@@ -345,7 +347,8 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
               ddCollectionInProgress = false,
               accruedInterestAmount = Some(BigDecimal(2)),
               accruedPenaltyAmount = Some(BigDecimal(100.00)),
-              penaltyType = Some("LPP1")
+              penaltyType = Some("LPP1"),
+              BigDecimal(10000)
             )
 
             val expected: OpenPaymentsViewModel = OpenPaymentsViewModel(

--- a/test/controllers/VatDetailsControllerSpec.scala
+++ b/test/controllers/VatDetailsControllerSpec.scala
@@ -748,7 +748,8 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
                 ddCollectionInProgress = true,
                 accruedInterestAmount = Some(BigDecimal(2)),
                 accruedPenaltyAmount = Some(BigDecimal(100.00)),
-                penaltyType = Some("LPP1")
+                penaltyType = Some("LPP1"),
+                BigDecimal(10000)
               )
 
               val result: VatDetailsDataModel = {
@@ -773,7 +774,8 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
                 ddCollectionInProgress = false,
                 accruedInterestAmount = Some(BigDecimal(2)),
                 accruedPenaltyAmount = Some(BigDecimal(100.00)),
-                penaltyType = Some("LPP1")
+                penaltyType = Some("LPP1"),
+                BigDecimal(10000)
               )
 
               val result: VatDetailsDataModel = {
@@ -799,7 +801,8 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
               ddCollectionInProgress = false,
               accruedInterestAmount = Some(BigDecimal(2)),
               accruedPenaltyAmount = Some(BigDecimal(100.00)),
-              penaltyType = Some("LPP1")
+              penaltyType = Some("LPP1"),
+              BigDecimal(10000)
             )
 
             val result: VatDetailsDataModel = {

--- a/test/models/payments/OpenPaymentsModelSpec.scala
+++ b/test/models/payments/OpenPaymentsModelSpec.scala
@@ -34,7 +34,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
       ddCollectionInProgress = false,
       accruedInterestAmount = Some(BigDecimal(2)),
       accruedPenaltyAmount = Some(100.00),
-      penaltyType = Some("LPP1")
+      penaltyType = Some("LPP1"),
+      originalAmount = BigDecimal(10000)
     ),
     isOverdue = false
   )
@@ -49,7 +50,8 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
       ddCollectionInProgress = false,
       accruedInterestAmount = Some(BigDecimal(2)),
       accruedPenaltyAmount = Some(BigDecimal(100.00)),
-      penaltyType = Some("LPP1")
+      penaltyType = Some("LPP1"),
+      originalAmount = BigDecimal(10000)
     ),
     isOverdue = false
   )

--- a/test/models/payments/PaymentSpec.scala
+++ b/test/models/payments/PaymentSpec.scala
@@ -44,7 +44,8 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
           "outstandingAmount" -> 9999,
           "periodKey" -> "#001",
           "chargeReference" -> "XD002750002155",
-          "accruedInterestAmount" -> 2
+          "accruedInterestAmount" -> 2,
+          "originalAmount" -> 10000
         )
 
         val paymentWithPeriodModel = PaymentWithPeriod(
@@ -58,7 +59,8 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         )
         paymentJson.as[Payment] shouldBe paymentWithPeriodModel
       }
@@ -77,7 +79,8 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
           "outstandingAmount" -> -9999,
           "periodKey" -> "#001",
           "chargeReference" -> "XD002750002155",
-          "accruedInterestAmount" -> 2
+          "accruedInterestAmount" -> 2,
+          "originalAmount" -> 10000
         )
 
         val paymentNoPeriodModel = PaymentNoPeriod(
@@ -89,7 +92,8 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          originalAmount = BigDecimal(10000)
         )
         paymentJson.as[Payment] shouldBe paymentNoPeriodModel
       }
@@ -108,7 +112,8 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
           ),
           "outstandingAmount" -> 9999,
           "periodKey" -> "#001",
-          "chargeReference" -> "XD002750002155"
+          "chargeReference" -> "XD002750002155",
+          "originalAmount" -> 10000
         )
 
         val exception = intercept[Exception] {
@@ -133,7 +138,8 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
         "accruedInterestAmount" -> 2,
         "outstandingAmount" -> 0,
         "periodKey" -> "#001",
-        "chargeReference" -> "XD002750002155"
+        "chargeReference" -> "XD002750002155",
+        "originalAmount" -> 10000
       )
 
       val model = PaymentWithPeriod(
@@ -147,7 +153,8 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
         ddCollectionInProgress = true,
         accruedInterestAmount = Some(BigDecimal(2)),
         accruedPenaltyAmount = None,
-        penaltyType = None
+        penaltyType = None,
+        originalAmount = BigDecimal(10000)
       )
 
       "read from json correctly" in {
@@ -155,7 +162,7 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
       }
     }
 
-    "given JSON with no original amount or cleared amount fields" should {
+    "given JSON with no cleared amount fields" should {
 
       val paymentJson = Json.obj(
         "chargeType" -> ReturnDebitCharge.value,
@@ -169,21 +176,17 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
         ),
         "outstandingAmount" -> 0,
         "periodKey" -> "#001",
-        "chargeReference" -> "XD002750002155"
+        "chargeReference" -> "XD002750002155",
+        "originalAmount" -> 10000
       )
 
       val result = paymentJson.as[Payment]
 
       "return a model" that {
 
-        "has None in the originalAmount field" in {
-          result.originalAmount shouldBe None
-        }
-
         "has None in the clearedAmount field" in {
           result.clearedAmount shouldBe None
         }
-
       }
 
     }
@@ -222,7 +225,7 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = Some(10000),
+          originalAmount = BigDecimal(10000),
           clearedAmount = Some(100)
         )
 
@@ -261,7 +264,7 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = Some(10000),
+          originalAmount = BigDecimal(10000),
           clearedAmount = Some(100)
         )
 

--- a/test/models/payments/PaymentsSpec.scala
+++ b/test/models/payments/PaymentsSpec.scala
@@ -36,7 +36,8 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
       ddCollectionInProgress = false,
       Some(2),
       Some(BigDecimal(100.00)),
-      Some("LPP1")
+      Some("LPP1"),
+      BigDecimal(10000)
     )
 
     val exampleInputString =
@@ -50,7 +51,8 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
         |"chargeReference": "XD002750002155",
         |"accruedInterestAmount": 2,
         |"accruedPenaltyAmount" : 100.00,
-        |"penaltyType" : "LPP1"
+        |"penaltyType" : "LPP1",
+        |"originalAmount" : 10000
         |}"""
         .stripMargin.replace("\n", "")
 
@@ -76,7 +78,8 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           Some(2),
           Some(BigDecimal(100.00)),
-          Some("LPP1")
+          Some("LPP1"),
+          BigDecimal(10000)
         ),
         PaymentWithPeriod(
           ReturnCreditCharge,
@@ -89,7 +92,8 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
           ddCollectionInProgress = false,
           Some(2),
           Some(BigDecimal(100.00)),
-          Some("LPP1")
+          Some("LPP1"),
+          BigDecimal(10000)
         )
       )
     )
@@ -106,7 +110,8 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
         |"chargeReference": "XD002750002155",
         |"accruedInterestAmount": 2,
         |"accruedPenaltyAmount" : 100.00,
-        |"penaltyType" : "LPP1"
+        |"penaltyType" : "LPP1",
+        |"originalAmount" : 10000
         |},{
         |"chargeType":"VAT Return Credit Charge",
         |"taxPeriodFrom":"2017-02-01",
@@ -117,7 +122,8 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
         |"chargeReference": "XD002750002155",
         |"accruedInterestAmount": 2,
         |"accruedPenaltyAmount" : 100.00,
-        |"penaltyType" : "LPP1"
+        |"penaltyType" : "LPP1",
+        |"originalAmount" : 10000
         |}]}"""
         .stripMargin.replace("\n", "")
 

--- a/test/services/PaymentsServiceSpec.scala
+++ b/test/services/PaymentsServiceSpec.scala
@@ -56,7 +56,8 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP1")
+          penaltyType = Some("LPP1"),
+          BigDecimal("10000")
         )
         val payment2 = PaymentWithPeriod(
           ReturnDebitCharge,
@@ -69,7 +70,8 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP1")
+          penaltyType = Some("LPP1"),
+          BigDecimal("10000")
         )
         val payment3 = PaymentWithPeriod(
           ReturnDebitCharge,
@@ -82,7 +84,8 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP1")
+          penaltyType = Some("LPP1"),
+          BigDecimal("10000")
         )
         val payment4 = PaymentWithPeriod(
           ReturnDebitCharge,
@@ -95,7 +98,8 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP1")
+          penaltyType = Some("LPP1"),
+          BigDecimal("10000")
         )
 
         val payments = Payments(Seq(payment1, payment2, payment3, payment4))
@@ -127,7 +131,8 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP1")
+          penaltyType = Some("LPP1"),
+          BigDecimal("10000")
         )))
         lazy val responseFromFinancialDataConnector = Right(payments)
 
@@ -156,7 +161,8 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          BigDecimal("10000")
         )
 
         val payments = Payments(Seq(payment1))
@@ -187,7 +193,8 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          BigDecimal("10000")
         )
 
         val payments = Payments(Seq(payment1))

--- a/test/services/VatDetailsServiceSpec.scala
+++ b/test/services/VatDetailsServiceSpec.scala
@@ -51,7 +51,8 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
         ddCollectionInProgress = false,
         accruedInterestAmount = Some(BigDecimal(2)),
         accruedPenaltyAmount = Some(BigDecimal(100.00)),
-        penaltyType = Some("LPP1")
+        penaltyType = Some("LPP1"),
+        originalAmount = BigDecimal(10000)
       )
     )
 
@@ -67,7 +68,8 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
         ddCollectionInProgress = false,
         accruedInterestAmount = Some(BigDecimal(2)),
         accruedPenaltyAmount = Some(BigDecimal(100.00)),
-        penaltyType = Some("LPP1")
+        penaltyType = Some("LPP1"),
+        originalAmount = BigDecimal(10000)
       ),
       PaymentWithPeriod(
         CentralAssessmentCharge,
@@ -80,7 +82,8 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
         ddCollectionInProgress = false,
         accruedInterestAmount = Some(BigDecimal(2)),
         accruedPenaltyAmount = Some(BigDecimal(100.00)),
-        penaltyType = Some("LPP1")
+        penaltyType = Some("LPP1"),
+        originalAmount = BigDecimal(10000)
       )
     )
 

--- a/test/testOnly/controllers/WhatYouOweControllerSpec.scala
+++ b/test/testOnly/controllers/WhatYouOweControllerSpec.scala
@@ -250,32 +250,6 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
       }
     }
 
-    "there is a payment with the originalAmount not defined" should {
-
-      "return None" in {
-        val result = {
-          mockDateServiceCall()
-          controller.constructViewModel(Seq(payment.copy(originalAmount = None)), mandationStatus = "MTDfB", Seq(LPPDetailsModelMax))
-        }
-        result shouldBe None
-      }
-    }
-
-    "there are multiple payments and some do not have these fields defined" should {
-
-      "return None" in {
-        val result = {
-          mockDateServiceCall()
-          controller.constructViewModel(
-            Seq(payment, payment, payment.copy(originalAmount = None)),
-            mandationStatus = "MTDfB",
-            Seq(LPPDetailsModelMax)
-          )
-        }
-        result shouldBe None
-      }
-    }
-
     "an interest payment doesn't have the charge reference defined" should {
 
       "not build a view model" in {
@@ -289,23 +263,6 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
         }
         result shouldBe None
       }
-
-    }
-
-    "an interest payment doesn't have the original amount defined" should {
-
-      "not build a view model" in {
-        val result = {
-          mockDateServiceCall()
-          controller.constructViewModel(
-            Seq(payment.copy(originalAmount = None, chargeType = VatReturn1stLPPLPI)),
-            mandationStatus = "MTDfB",
-            Seq(LPPDetailsModelMax)
-          )
-        }
-        result shouldBe None
-      }
-
     }
 
     "description() cannot retrieve a charge description" should {
@@ -517,13 +474,13 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
       }
     }
 
-    "return None" should {
-
-      "originalAmount is missing" in {
-        val charge = payment.copy(originalAmount = None)
-        controller.buildStandardChargeViewModel(charge) shouldBe None
-      }
-    }
+//    "return None" should {
+//
+//      "originalAmount is missing" in {
+//        val charge = payment.copy(originalAmount = None)
+//        controller.buildStandardChargeViewModel(charge) shouldBe None
+//      }
+//    }
   }
 
   "The buildCrystallisedIntViewModel function" should {
@@ -550,11 +507,6 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
     }
 
     "return None" when {
-
-      "originalAmount is missing" in {
-        val charge = payment.copy(chargeType = VatReturnLPI, originalAmount = None)
-        controller.buildCrystallisedIntViewModel(charge) shouldBe None
-      }
 
       "chargeReference is missing" in {
         val charge = payment.copy(chargeType = VatReturnLPI, chargeReference = None)
@@ -702,11 +654,6 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
 
     "return None" when {
 
-      "originalAmount is missing" in {
-        val charge = penaltyCharge.copy(originalAmount = None)
-        controller.buildCrystallisedLPPViewModel(charge, Some(LPPDetailsModelMax)) shouldBe None
-      }
-
       "chargeType is missing" in {
         val charge = penaltyCharge.copy(chargeReference = None)
         controller.buildCrystallisedLPPViewModel(charge, Some(LPPDetailsModelMax)) shouldBe None
@@ -751,11 +698,6 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
     }
 
     "return None" when {
-
-      "originalAmount is missing" in {
-        val charge = payment.copy(chargeType = VatLateSubmissionPen, originalAmount = None)
-        controller.buildLateSubmissionPenaltyViewModel(charge) shouldBe None
-      }
 
       "chargeReference is missing" in {
         val charge = payment.copy(chargeType = VatLateSubmissionPen, chargeReference = None)


### PR DESCRIPTION
AT will fail without this stub data change, as originalAmount is now mandatory and the field was missing it caused the page to not load: https://github.com/hmrc/vat-view-change-stub-data/pull/164
