### PR TITLE
BTAT-11020 Payment reads for interest rate

### DIFF
--- a/app/controllers/WhatYouOweController.scala
+++ b/app/controllers/WhatYouOweController.scala
@@ -122,29 +122,31 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
     ))
 
   private[controllers] def buildEstimatedIntViewModel(payment: PaymentWithPeriod): Option[EstimatedInterestViewModel] =
-    payment.accruedInterestAmount match {
-      case Some(interestAmnt) =>
+    (payment.accruedInterestAmount, payment.interestRate) match {
+      case (Some(interestAmnt), Some(intRate)) =>
         Some(EstimatedInterestViewModel(
           periodFrom = payment.periodFrom,
           periodTo = payment.periodTo,
           chargeType = ChargeType.interestChargeMapping(payment.chargeType).value,
-          interestRate = 5.00, // TODO replace with API field
+          interestRate = intRate,
           interestAmount = interestAmnt,
           isPenalty = payment.chargeType.isPenaltyInterest
         ))
       case _ =>
-        logger.warn("[WhatYouOweController][buildEstimatedIntViewModel] - Missing accrued interest amount")
+        logger.warn("[WhatYouOweController][buildEstimatedIntViewModel] - Missing one or more required values:" +
+          s"${payment.accruedInterestAmount.fold("\naccrued interest amount")(_ => "")}" +
+          s"${payment.interestRate.fold("\ninterest rate")(_ => "")}")
         None
     }
 
   private[controllers] def buildCrystallisedIntViewModel(payment: PaymentWithPeriod): Option[CrystallisedInterestViewModel] =
-    payment.chargeReference match {
-      case Some(chargeRef) =>
+    (payment.chargeReference, payment.interestRate) match {
+      case (Some(chargeRef), Some(intRate)) =>
         Some(CrystallisedInterestViewModel(
           periodFrom = payment.periodFrom,
           periodTo = payment.periodTo,
           chargeType = payment.chargeType.value,
-          interestRate = 5.00, // TODO replace with API field
+          interestRate = intRate,
           dueDate = payment.due,
           interestAmount = payment.originalAmount,
           amountReceived = payment.clearedAmount.getOrElse(0),
@@ -154,7 +156,9 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
           isPenalty = payment.chargeType.isPenaltyInterest
         ))
       case _ =>
-        logger.warn("[WhatYouOweController][buildCrystallisedIntViewModel] - Missing charge reference")
+        logger.warn("[WhatYouOweController][buildCrystallisedIntViewModel] - Missing one or more required values:" +
+          s"${payment.chargeReference.fold("\ncharge reference")(_ => "")}" +
+          s"${payment.interestRate.fold("\ninterest rate")(_ => "")}")
         None
     }
 

--- a/app/models/payments/ChargeType.scala
+++ b/app/models/payments/ChargeType.scala
@@ -455,7 +455,7 @@ object ChargeType extends LoggerUtil {
   val interestChargeTypes: Set[ChargeType] = Set(
     VatReturnLPI,
     VatReturn1stLPPLPI,
-    VatReturn2ndLPPLPI, // TODO add interest mapping when parent charge available
+    VatReturn2ndLPPLPI,
     VatCentralAssessmentLPI,
     VatCA1stLPPLPI, // TODO add interest mapping when parent charge available
     VatCA2ndLPPLPI, // TODO add interest mapping when parent charge available

--- a/it/connectors/FinancialDataConnectorISpec.scala
+++ b/it/connectors/FinancialDataConnectorISpec.scala
@@ -27,7 +27,6 @@ import stubs.FinancialDataStub
 import uk.gov.hmrc.http.HeaderCarrier
 import play.api.test.Helpers._
 
-
 class FinancialDataConnectorISpec extends IntegrationBaseSpec {
 
   private trait Test {
@@ -42,7 +41,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
     "return all outstanding payments for a given period" in new Test {
       override def setupStubs(): StubMapping = FinancialDataStub.stubOutstandingTransactions
 
-      val expected = Right(Payments(Seq(
+      val expected: Right[Nothing, Payments] = Right(Payments(Seq(
         PaymentWithPeriod(
           chargeType = ReturnDebitCharge,
           periodFrom = LocalDate.parse("2015-03-01"),
@@ -52,10 +51,12 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           periodKey = Some("15AC"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(2),
+          interestRate = Some(2.22),
           chargeReference = Some("XD002750002155"),
           originalAmount = 10000,
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           chargeType = ReturnDebitCharge,
@@ -66,10 +67,12 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           periodKey = Some("16AC"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           chargeReference = Some("XD002750002156"),
           originalAmount = 10000,
           accruedPenaltyAmount = Some(3),
-          penaltyType = Some("LPP1")
+          penaltyType = Some("LPP1"),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           chargeType = VatProtectiveAssessmentCharge,
@@ -80,10 +83,12 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           periodKey = Some("17AC"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           chargeReference = Some("XD002750002157"),
           originalAmount = 10000,
           accruedPenaltyAmount = Some(5),
-          penaltyType = Some("LPP2")
+          penaltyType = Some("LPP2"),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           chargeType = VatReturn1stLPP,
@@ -94,10 +99,12 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           periodKey = None,
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           originalAmount = 55.55,
           chargeReference = Some("XD002750002158"),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           chargeType = VatReturn1stLPP,
@@ -108,10 +115,12 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           periodKey = None,
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           originalAmount = 555.55,
           chargeReference = Some("X-PART-1-ONLY-X"),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           chargeType = VatPA2ndLPP,
@@ -122,10 +131,12 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
           periodKey = None,
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           originalAmount = 99.99,
           chargeReference = Some("XD002750002159"),
           accruedPenaltyAmount = None,
-          penaltyType = None
+          penaltyType = None,
+          clearedAmount = None
         )
       )))
 
@@ -138,7 +149,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
     "return an empty list of payments" in new Test {
       override def setupStubs(): StubMapping = FinancialDataStub.stubNoPayments
 
-      val expected = Right(Payments(Seq.empty))
+      val expected: Right[Nothing, Payments] = Right(Payments(Seq.empty))
 
       setupStubs()
       private val result = await(connector.getOpenPayments("123456789"))
@@ -152,7 +163,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
     "return an BadRequestError" in new Test {
       override def setupStubs(): StubMapping = FinancialDataStub.stubInvalidVrn
 
-      val expected = Left(BadRequestError(
+      val expected: Left[BadRequestError, Nothing] = Left(BadRequestError(
         code = "INVALID_VRN",
         errorResponse = "VRN was invalid!"
       ))
@@ -169,7 +180,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
     "return a PaymentsHistoryModel" in new Test {
       override def setupStubs(): StubMapping = FinancialDataStub.stubPaidTransactions
 
-      val expected = Right(Seq(
+      val expected: Right[Nothing, Seq[PaymentsHistoryModel]] = Right(Seq(
         PaymentsHistoryModel(
           clearingSAPDocument = Some("002828853334"),
           chargeType    =  ReturnDebitCharge,
@@ -203,7 +214,8 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
     "return a DirectDebitStatus" in new Test {
       override def setupStubs(): StubMapping = FinancialDataStub.stubSuccessfulDirectDebit
 
-      val expected = Right(DirectDebitStatus(directDebitMandateFound = true, Some(Seq(DDIDetails("2018-01-01")))))
+      val expected: Right[Nothing, DirectDebitStatus] =
+        Right(DirectDebitStatus(directDebitMandateFound = true, Some(Seq(DDIDetails("2018-01-01")))))
 
       setupStubs()
       private val result = await(connector.getDirectDebitStatus("111111111"))
@@ -217,7 +229,7 @@ class FinancialDataConnectorISpec extends IntegrationBaseSpec {
     "return an BadRequestError" in new Test {
       override def setupStubs(): StubMapping = FinancialDataStub.stubInvalidVrnDirectDebit
 
-      val expected = Left(BadRequestError(
+      val expected: Left[BadRequestError, Nothing] = Left(BadRequestError(
         code = "INVALID_VRN",
         errorResponse = "VRN was invalid!"
       ))

--- a/it/stubs/FinancialDataStub.scala
+++ b/it/stubs/FinancialDataStub.scala
@@ -153,6 +153,7 @@ object FinancialDataStub extends WireMockMethods {
       |        "taxPeriodTo" : "2015-03-31",
       |        "chargeReference" : "XD002750002155",
       |        "accruedInterestAmount" : 2,
+      |        "interestRate" : 2.22,
       |        "originalAmount" : 10000,
       |        "outstandingAmount" : 10000,
       |        "items" : [

--- a/test/audit/ViewNextOutstandingVatPaymentAuditModelSpec.scala
+++ b/test/audit/ViewNextOutstandingVatPaymentAuditModelSpec.scala
@@ -25,59 +25,26 @@ import org.scalatest.matchers.should.Matchers
 
 class ViewNextOutstandingVatPaymentAuditModelSpec extends AnyWordSpecLike with Matchers {
 
-  val onePayment = Payments(
-    Seq(
-      Payment(
-        ReturnDebitCharge,
-        LocalDate.parse("2017-01-01"),
-        LocalDate.parse("2017-03-01"),
-        LocalDate.parse("2017-03-08"),
-        9999,
-        Some("#001"),
-        chargeReference = Some("XD002750002155"),
-        ddCollectionInProgress = false,
-        accruedInterestAmount = Some(BigDecimal(2)),
-        accruedPenaltyAmount = None,
-        penaltyType = None,
-        originalAmount = BigDecimal(10000)
-      )
-    )
+  val paymentModel: Payment = Payment(
+    ReturnDebitCharge,
+    Some(LocalDate.parse("2017-01-01")),
+    Some(LocalDate.parse("2017-03-01")),
+    LocalDate.parse("2017-03-08"),
+    9999,
+    Some("#001"),
+    chargeReference = Some("XD002750002155"),
+    ddCollectionInProgress = false,
+    accruedInterestAmount = Some(BigDecimal(2)),
+    interestRate = Some(2.22),
+    accruedPenaltyAmount = None,
+    penaltyType = None,
+    originalAmount = BigDecimal(10000),
+    clearedAmount = None
   )
 
-  val twoPayments = Payments(
-    Seq(
-      Payment(
-        ReturnDebitCharge,
-        LocalDate.parse("2017-01-01"),
-        LocalDate.parse("2017-03-01"),
-        LocalDate.parse("2017-03-08"),
-        9999,
-        Some("#001"),
-        chargeReference = Some("XD002750002155"),
-        ddCollectionInProgress = false,
-        accruedInterestAmount = Some(BigDecimal(2)),
-        accruedPenaltyAmount = None,
-        penaltyType = None,
-        originalAmount = BigDecimal(10000)
-      ),
-      Payment(
-        ReturnDebitCharge,
-        LocalDate.parse("2017-02-01"),
-        LocalDate.parse("2017-04-01"),
-        LocalDate.parse("2017-05-08"),
-        7777,
-        Some("#002"),
-        chargeReference = Some("XD002750002155"),
-        ddCollectionInProgress = false,
-        accruedInterestAmount = Some(BigDecimal(2)),
-        accruedPenaltyAmount = None,
-        penaltyType = None,
-        originalAmount = BigDecimal(10000)
-      )
-    )
-  )
-
-  val user = User("999999999")
+  val onePayment: Payments = Payments(Seq(paymentModel))
+  val twoPayments: Payments = Payments(Seq(paymentModel, paymentModel))
+  val user: User = User("999999999")
 
   "ViewNextOutstandingVatPaymentAuditModel" should {
 

--- a/test/common/TestModels.scala
+++ b/test/common/TestModels.scala
@@ -38,20 +38,22 @@ object TestModels {
 
   val payments: Payments = Payments(Seq(Payment(
     ReturnDebitCharge,
-    LocalDate.parse("2019-01-01"),
-    LocalDate.parse("2019-02-02"),
+    Some(LocalDate.parse("2019-01-01")),
+    Some(LocalDate.parse("2019-02-02")),
     LocalDate.parse("2019-03-03"),
     1,
     Some("#001"),
     chargeReference = Some("XD002750002155"),
     ddCollectionInProgress = false,
     accruedInterestAmount = Some(BigDecimal(2)),
+    interestRate = Some(2.22),
     accruedPenaltyAmount = None,
     penaltyType = None,
-    originalAmount = BigDecimal(10000)
+    originalAmount = BigDecimal(10000),
+    clearedAmount = None
   )))
 
-  val payment: PaymentWithPeriod = Payment(
+  val payment: PaymentWithPeriod = PaymentWithPeriod(
     ReturnDebitCharge,
     LocalDate.parse("2019-01-01"),
     LocalDate.parse("2019-02-02"),
@@ -61,6 +63,7 @@ object TestModels {
     chargeReference = Some("XD002750002155"),
     ddCollectionInProgress = false,
     accruedInterestAmount = Some(BigDecimal(2)),
+    interestRate = Some(2.22),
     originalAmount = BigDecimal(10000),
     clearedAmount = Some(0),
     accruedPenaltyAmount = Some(50.55),
@@ -72,7 +75,7 @@ object TestModels {
   val unrepayableOverpayment: PaymentWithPeriod =
     payment.copy(chargeType = VatUnrepayableOverpayment, accruedPenaltyAmount = None)
 
-  val paymentNoPeriodNoDate: PaymentNoPeriod = Payment(
+  val paymentNoPeriodNoDate: PaymentNoPeriod = PaymentNoPeriod(
     OADefaultInterestCharge,
     LocalDate.parse("2019-03-03"),
     BigDecimal("10000"),
@@ -80,6 +83,7 @@ object TestModels {
     chargeReference = Some("XD002750002155"),
     ddCollectionInProgress = false,
     accruedInterestAmount = Some(BigDecimal(2)),
+    interestRate = Some(2.22),
     accruedPenaltyAmount = None,
     penaltyType = None,
     originalAmount = BigDecimal(10000),
@@ -90,7 +94,7 @@ object TestModels {
 
   val paymentWithDifferentAgentMessage: PaymentWithPeriod = payment.copy(chargeType = BnpRegPost2010Charge)
 
-  val paymentOnAccount: PaymentNoPeriod = Payment(
+  val paymentOnAccount: PaymentNoPeriod = PaymentNoPeriod(
     PaymentOnAccount,
     LocalDate.parse("2017-01-01"),
     BigDecimal("0"),
@@ -98,9 +102,11 @@ object TestModels {
     chargeReference = Some("XD002750002155"),
     ddCollectionInProgress = false,
     accruedInterestAmount = Some(BigDecimal(2)),
+    interestRate = Some(2.22),
     accruedPenaltyAmount = None,
     penaltyType = None,
-    originalAmount = BigDecimal(10000)
+    originalAmount = BigDecimal(10000),
+    clearedAmount = None
   )
 
   val obligations: VatReturnObligations = VatReturnObligations(Seq(VatReturnObligation(
@@ -355,7 +361,7 @@ object TestModels {
     periodFrom = LocalDate.parse("2019-01-01"),
     periodTo = LocalDate.parse("2019-02-02"),
     chargeType = VatReturnLPI.value,
-    interestRate = 5.00,
+    interestRate = 2.22,
     interestAmount = BigDecimal(2),
     isPenalty = false
   )
@@ -366,7 +372,7 @@ object TestModels {
     periodFrom = LocalDate.parse("2019-01-01"),
     periodTo = LocalDate.parse("2019-02-02"),
     chargeType = "VAT Return LPI",
-    interestRate = 5.00,
+    interestRate = 2.22,
     dueDate = LocalDate.parse("2019-03-03"),
     interestAmount = 10000,
     amountReceived = 0,

--- a/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
@@ -1331,9 +1331,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(3),
           penaltyType = Some("LPP1"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           ReturnCreditCharge,
@@ -1345,9 +1347,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           OACreditCharge,
@@ -1359,9 +1363,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           OADebitCharge,
@@ -1373,9 +1379,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           CentralAssessmentCharge,
@@ -1387,9 +1395,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           DebitDefaultSurcharge,
@@ -1401,9 +1411,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           CreditDefaultSurcharge,
@@ -1415,9 +1427,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           ErrorCorrectionCreditCharge,
@@ -1429,9 +1443,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           ErrorCorrectionDebitCharge,
@@ -1443,9 +1459,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           AAInterestCharge,
@@ -1457,9 +1475,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           AAReturnDebitCharge,
@@ -1471,9 +1491,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           AAReturnCreditCharge,
@@ -1485,9 +1507,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           AAMonthlyInstalment,
@@ -1499,9 +1523,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           AAQuarterlyInstalments,
@@ -1513,9 +1539,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           OADefaultInterestCharge,
@@ -1527,9 +1555,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           AACharge,
@@ -1541,9 +1571,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           OAFurtherInterestCharge,
@@ -1555,9 +1587,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           BnpRegPre2010Charge,
@@ -1569,9 +1603,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           BnpRegPost2010Charge,
@@ -1583,9 +1619,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           FtnMatPre2010Charge,
@@ -1597,9 +1635,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           FtnMatPost2010Charge,
@@ -1611,9 +1651,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           MiscPenaltyCharge,
@@ -1625,9 +1667,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           FtnEachPartnerCharge,
@@ -1639,9 +1683,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           MpPre2009Charge,
@@ -1653,9 +1699,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           MpRepeatedPre2009Charge,
@@ -1667,9 +1715,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         PaymentWithPeriod(
           CivilEvasionPenaltyCharge,
@@ -1681,67 +1731,77 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         Payment(
           VatOAInaccuraciesFrom2009,
-          periodFrom = LocalDate.parse("2017-03-20"),
-          periodTo = LocalDate.parse("2017-06-21"),
+          periodFrom = Some(LocalDate.parse("2017-03-20")),
+          periodTo = Some(LocalDate.parse("2017-06-21")),
           due = LocalDate.parse("2017-09-27"),
           outstandingAmount = BigDecimal(50.00),
           periodKey = Some("#020"),
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         Payment(
           InaccuraciesAssessmentsPenCharge,
-          periodFrom = LocalDate.parse("2008-03-20"),
-          periodTo = LocalDate.parse("2008-06-21"),
+          periodFrom = Some(LocalDate.parse("2008-03-20")),
+          periodTo = Some(LocalDate.parse("2008-06-21")),
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
           periodKey = Some("#018"),
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         Payment(
           InaccuraciesReturnReplacedCharge,
-          periodFrom = LocalDate.parse("2008-03-20"),
-          periodTo = LocalDate.parse("2008-06-21"),
+          periodFrom = Some(LocalDate.parse("2008-03-20")),
+          periodTo = Some(LocalDate.parse("2008-06-21")),
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
           periodKey = Some("#018"),
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
         Payment(
           CarterPenaltyCharge,
-          periodFrom = LocalDate.parse("2008-03-20"),
-          periodTo = LocalDate.parse("2008-06-21"),
+          periodFrom = Some(LocalDate.parse("2008-03-20")),
+          periodTo = Some(LocalDate.parse("2008-06-21")),
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
           periodKey = Some("#018"),
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           WrongDoingPenaltyCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1749,11 +1809,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           FailureToSubmitRCSLCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1761,11 +1823,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           FailureToNotifyRCSLCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1773,11 +1837,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           PaymentOnAccountInstalments,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1785,11 +1851,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturnPOALPI,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1797,11 +1865,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatPOAReturn1stLPP,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1809,11 +1879,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatPOAReturn2ndLPP,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1821,11 +1893,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturnPOA1stLPPLPI,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1833,11 +1907,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturnPOA2ndLPPLPI,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1845,11 +1921,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           PaymentOnAccountReturnDebitCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1857,11 +1935,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           PaymentOnAccountReturnCreditCharge,
           due = LocalDate.parse("2008-09-27"),
           outstandingAmount = BigDecimal(50.00),
@@ -1869,11 +1949,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatUnrepayableOverpayment,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(200.00),
@@ -1881,11 +1963,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturn1stLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(200.00),
@@ -1893,11 +1977,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturnLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.10),
@@ -1905,11 +1991,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatPALPICharge,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.10),
@@ -1917,11 +2005,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturn1stLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.20),
@@ -1929,11 +2019,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturn2ndLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.30),
@@ -1941,11 +2033,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatCentralAssessmentLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -1953,11 +2047,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatCA1stLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -1965,11 +2061,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.0)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatCA2ndLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -1977,11 +2075,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.0)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatOfficersAssessmentLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -1989,11 +2089,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatOA1stLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2001,11 +2103,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatOA2ndLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2013,11 +2117,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatPA1stLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.50),
@@ -2025,11 +2131,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002156"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatPA2ndLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.50),
@@ -2037,11 +2145,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002157"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatPA1stLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2049,11 +2159,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatPA2ndLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2061,11 +2173,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAA1stLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2073,11 +2187,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAA2ndLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2085,11 +2201,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAA1stLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2097,11 +2215,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAA2ndLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2109,11 +2229,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAdditionalAssessmentLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2121,11 +2243,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatLateSubmissionPen,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2133,11 +2257,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatLspInterest,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2145,11 +2271,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturnAA1stLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(208.40),
@@ -2157,11 +2285,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturnAA2ndLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(208.41),
@@ -2169,11 +2299,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatManualLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(208.42),
@@ -2181,11 +2313,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatManualLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(208.43),
@@ -2193,11 +2327,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatPOAInstalmentLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2205,11 +2341,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002156"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(202.40)
+          originalAmount = BigDecimal(202.40),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAAReturnChargeLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2217,11 +2355,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002157"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(202.40)
+          originalAmount = BigDecimal(202.40),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAAQuarterlyInstalLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2229,11 +2369,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAAMonthlyInstalLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2241,11 +2383,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAAReturnCharge1stLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2253,11 +2397,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatAAReturnCharge2ndLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2265,11 +2411,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = None,
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(10000)
+          originalAmount = BigDecimal(10000),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatMigratedLiability,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(202.40),
@@ -2277,11 +2425,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(202.40)
+          originalAmount = BigDecimal(202.40),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatMigratedCredit,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(-202.40),
@@ -2289,11 +2439,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(-202.40)
+          originalAmount = BigDecimal(-202.40),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatReturn2ndLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(-202.40),
@@ -2301,11 +2453,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(-202.40)
+          originalAmount = BigDecimal(-202.40),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatErrorCorrectionLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(502.40),
@@ -2313,11 +2467,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002140"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          originalAmount = BigDecimal(502.40)
+          originalAmount = BigDecimal(502.40),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatErrorCorrection1stLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(502.41),
@@ -2325,11 +2481,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002141"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(502.41)
+          originalAmount = BigDecimal(502.41),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatErrorCorrection2ndLPP,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(502.42),
@@ -2337,11 +2495,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002142"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(502.42)
+          originalAmount = BigDecimal(502.42),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatErrorCorrection1stLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(502.43),
@@ -2349,11 +2509,13 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002143"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(502.43)
+          originalAmount = BigDecimal(502.43),
+          clearedAmount = None
         ),
-        Payment(
+        PaymentNoPeriod(
           VatErrorCorrection2ndLPPLPI,
           due = LocalDate.parse("2018-02-01"),
           outstandingAmount = BigDecimal(502.44),
@@ -2361,9 +2523,11 @@ class PaymentsHttpParserSpec extends AnyWordSpecLike with Matchers {
           chargeReference = Some("XD002750002144"),
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = Some("LPP"),
-          originalAmount = BigDecimal(502.44)
+          originalAmount = BigDecimal(502.44),
+          clearedAmount = None
         )
       )))
 

--- a/test/controllers/OpenPaymentsControllerSpec.scala
+++ b/test/controllers/OpenPaymentsControllerSpec.scala
@@ -247,35 +247,39 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
 
     "Calling the .getModel function" when {
 
+      val testPayment: PaymentWithPeriod = PaymentWithPeriod(
+        ReturnDebitCharge,
+        LocalDate.parse("2017-01-01"),
+        LocalDate.parse("2017-01-01"),
+        due = LocalDate.parse("2017-01-01"),
+        BigDecimal("10000"),
+        Some("ABCD"),
+        chargeReference = None,
+        ddCollectionInProgress = false,
+        accruedInterestAmount = Some(BigDecimal(2)),
+        interestRate = Some(2.22),
+        accruedPenaltyAmount = Some(BigDecimal(100.00)),
+        penaltyType = Some("LPP1"),
+        BigDecimal(10000),
+        None
+      )
+
         "due date of payments is in the past" when {
 
           "user has direct debit collections in progress" should {
 
             "return payments that are not overdue" in {
 
-              val testPayment: PaymentWithPeriod = Payment(
-                ReturnDebitCharge,
-                LocalDate.parse("2017-01-01"),
-                LocalDate.parse("2017-01-01"),
-                due = LocalDate.parse("2017-01-01"),
-                BigDecimal("10000"),
-                Some("ABCD"),
-                chargeReference = None,
-                ddCollectionInProgress = true,
-                accruedInterestAmount = Some(BigDecimal(2)),
-                accruedPenaltyAmount = Some(BigDecimal(100.00)),
-                penaltyType = Some("LPP1"),
-                BigDecimal(10000)
-              )
+              val paymentWithDD = testPayment.copy(ddCollectionInProgress = true)
 
               val expected: OpenPaymentsViewModel = OpenPaymentsViewModel(
                 Seq(OpenPaymentsModel(
-                  testPayment.chargeType,
-                  testPayment.outstandingAmount,
-                  testPayment.due,
-                  testPayment.periodFrom,
-                  testPayment.periodTo,
-                  testPayment.periodKey,
+                  paymentWithDD.chargeType,
+                  paymentWithDD.outstandingAmount,
+                  paymentWithDD.due,
+                  paymentWithDD.periodFrom,
+                  paymentWithDD.periodTo,
+                  paymentWithDD.periodKey,
                   isOverdue = false
                 )),
                 mandationStatus = "MTDfB"
@@ -283,7 +287,7 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
 
               val result: OpenPaymentsViewModel = {
                 mockDateServiceCall()
-                controller.getModel(Seq(testPayment), mandationStatus = "MTDfB")
+                controller.getModel(Seq(paymentWithDD), mandationStatus = "MTDfB")
               }
 
               result shouldBe expected
@@ -293,21 +297,6 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
           "user has no direct debit collections in progress" should {
 
             "return payments that are overdue" in {
-
-              val testPayment: PaymentWithPeriod = Payment(
-                ReturnDebitCharge,
-                LocalDate.parse("2017-01-01"),
-                LocalDate.parse("2017-01-01"),
-                due = LocalDate.parse("2017-01-01"),
-                BigDecimal("10000"),
-                Some("ABCD"),
-                chargeReference = None,
-                ddCollectionInProgress = false,
-                accruedInterestAmount = Some(BigDecimal(2)),
-                accruedPenaltyAmount = Some(100.00),
-                penaltyType = Some("LPP1"),
-                BigDecimal(10000)
-              )
 
               val expected: OpenPaymentsViewModel = OpenPaymentsViewModel(
                 Seq(OpenPaymentsModel(
@@ -336,29 +325,16 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
 
           "return payments that are not overdue" in {
 
-            val testPayment: PaymentWithPeriod = Payment(
-              ReturnDebitCharge,
-              LocalDate.parse("2017-01-01"),
-              LocalDate.parse("2017-01-01"),
-              due = LocalDate.parse("2020-01-01"),
-              BigDecimal("10000"),
-              Some("ABCD"),
-              chargeReference = None,
-              ddCollectionInProgress = false,
-              accruedInterestAmount = Some(BigDecimal(2)),
-              accruedPenaltyAmount = Some(BigDecimal(100.00)),
-              penaltyType = Some("LPP1"),
-              BigDecimal(10000)
-            )
+            val futurePayment = testPayment.copy(due = LocalDate.parse("2020-01-01"))
 
             val expected: OpenPaymentsViewModel = OpenPaymentsViewModel(
               Seq(OpenPaymentsModel(
-                testPayment.chargeType,
-                testPayment.outstandingAmount,
-                testPayment.due,
-                testPayment.periodFrom,
-                testPayment.periodTo,
-                testPayment.periodKey,
+                futurePayment.chargeType,
+                futurePayment.outstandingAmount,
+                futurePayment.due,
+                futurePayment.periodFrom,
+                futurePayment.periodTo,
+                futurePayment.periodKey,
                 isOverdue = false,
               )),
               mandationStatus = "MTDfB"
@@ -366,7 +342,7 @@ class OpenPaymentsControllerSpec extends ControllerBaseSpec {
 
             val result: OpenPaymentsViewModel = {
               mockDateServiceCall()
-              controller.getModel(Seq(testPayment), mandationStatus = "MTDfB")
+              controller.getModel(Seq(futurePayment), mandationStatus = "MTDfB")
             }
 
             result shouldBe expected

--- a/test/controllers/VatDetailsControllerSpec.scala
+++ b/test/controllers/VatDetailsControllerSpec.scala
@@ -25,7 +25,7 @@ import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
 import models._
 import models.errors.{NextPaymentError, ObligationsError, _}
 import models.obligations.{VatReturnObligation, VatReturnObligations}
-import models.payments.{Payment, PaymentNoPeriod, Payments, ReturnDebitCharge}
+import models.payments.{PaymentNoPeriod, Payments, ReturnDebitCharge}
 import models.penalties.PenaltiesSummary
 import models.viewModels.VatDetailsViewModel
 import org.jsoup.Jsoup
@@ -739,7 +739,7 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
             "return payment that is not overdue" in {
 
-              val testPayment: PaymentNoPeriod = Payment(
+              val testPayment: PaymentNoPeriod = PaymentNoPeriod(
                 ReturnDebitCharge,
                 due = LocalDate.parse("2017-01-01"),
                 BigDecimal("10000"),
@@ -747,9 +747,11 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
                 chargeReference = Some("XD002750002155"),
                 ddCollectionInProgress = true,
                 accruedInterestAmount = Some(BigDecimal(2)),
+                interestRate = Some(2.22),
                 accruedPenaltyAmount = Some(BigDecimal(100.00)),
                 penaltyType = Some("LPP1"),
-                BigDecimal(10000)
+                BigDecimal(10000),
+                None
               )
 
               val result: VatDetailsDataModel = {
@@ -765,7 +767,7 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
             "return payment that is overdue" in {
 
-              val testPayment: PaymentNoPeriod = Payment(
+              val testPayment: PaymentNoPeriod = PaymentNoPeriod(
                 ReturnDebitCharge,
                 due = LocalDate.parse("2017-01-01"),
                 BigDecimal("10000"),
@@ -773,9 +775,11 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
                 chargeReference = Some("XD002750002155"),
                 ddCollectionInProgress = false,
                 accruedInterestAmount = Some(BigDecimal(2)),
+                interestRate = Some(2.22),
                 accruedPenaltyAmount = Some(BigDecimal(100.00)),
                 penaltyType = Some("LPP1"),
-                BigDecimal(10000)
+                BigDecimal(10000),
+                None
               )
 
               val result: VatDetailsDataModel = {
@@ -792,7 +796,7 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
 
           "return payment that is not overdue" in {
 
-            val testPayment: PaymentNoPeriod = Payment(
+            val testPayment: PaymentNoPeriod = PaymentNoPeriod(
               ReturnDebitCharge,
               due = LocalDate.parse("2020-01-01"),
               BigDecimal("10000"),
@@ -800,9 +804,11 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
               chargeReference = Some("XD002750002155"),
               ddCollectionInProgress = false,
               accruedInterestAmount = Some(BigDecimal(2)),
+              interestRate = Some(2.22),
               accruedPenaltyAmount = Some(BigDecimal(100.00)),
               penaltyType = Some("LPP1"),
-              BigDecimal(10000)
+              BigDecimal(10000),
+              None
             )
 
             val result: VatDetailsDataModel = {

--- a/test/controllers/WhatYouOweControllerSpec.scala
+++ b/test/controllers/WhatYouOweControllerSpec.scala
@@ -490,7 +490,7 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
           LocalDate.parse("2019-01-01"),
           LocalDate.parse("2019-02-02"),
           "VAT Return LPI",
-          5.00,
+          2.22,
           LocalDate.parse("2019-03-03"),
           10000,
           0,
@@ -508,6 +508,11 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
         val charge = payment.copy(chargeType = VatReturnLPI, chargeReference = None)
         controller.buildCrystallisedIntViewModel(charge) shouldBe None
       }
+
+      "interestRate is missing" in {
+        val charge = payment.copy(chargeType = VatReturnLPI, interestRate = None)
+        controller.buildCrystallisedIntViewModel(charge) shouldBe None
+      }
     }
   }
 
@@ -520,7 +525,7 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
           LocalDate.parse("2019-01-01"),
           LocalDate.parse("2019-02-02"),
           "VAT Return LPI",
-          5.00,
+          2.22,
           2,
           isPenalty = false
         ))
@@ -531,6 +536,11 @@ class WhatYouOweControllerSpec extends ControllerBaseSpec {
 
       "accruedInterestAmount is missing" in {
         val charge = payment.copy(accruedInterestAmount = None)
+        controller.buildEstimatedIntViewModel(charge) shouldBe None
+      }
+
+      "interestRate is missing" in {
+        val charge = payment.copy(interestRate = None)
         controller.buildEstimatedIntViewModel(charge) shouldBe None
       }
     }

--- a/test/models/payments/OpenPaymentsModelSpec.scala
+++ b/test/models/payments/OpenPaymentsModelSpec.scala
@@ -25,17 +25,19 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
   val openPaymentsModelWithPeriod: OpenPaymentsModel = OpenPaymentsModel(
     payment = Payment(
       chargeType = OADebitCharge,
-      periodFrom = LocalDate.parse("2001-01-01"),
-      periodTo = LocalDate.parse("2001-03-31"),
+      periodFrom = Some(LocalDate.parse("2001-01-01")),
+      periodTo = Some(LocalDate.parse("2001-03-31")),
       due = LocalDate.parse("2003-04-05"),
       outstandingAmount = 300.00,
       periodKey = Some("#003"),
       chargeReference = None,
       ddCollectionInProgress = false,
       accruedInterestAmount = Some(BigDecimal(2)),
+      interestRate = Some(2.22),
       accruedPenaltyAmount = Some(100.00),
       penaltyType = Some("LPP1"),
-      originalAmount = BigDecimal(10000)
+      originalAmount = BigDecimal(10000),
+      clearedAmount = None
     ),
     isOverdue = false
   )
@@ -43,15 +45,19 @@ class OpenPaymentsModelSpec extends ViewBaseSpec {
   val openPaymentsModelNoPeriod: OpenPaymentsModel = OpenPaymentsModel(
     payment = Payment(
       chargeType = OADebitCharge,
+      periodFrom = None,
+      periodTo = None,
       due = LocalDate.parse("2003-04-05"),
       outstandingAmount = 300.00,
       periodKey = Some("#003"),
       chargeReference = None,
       ddCollectionInProgress = false,
       accruedInterestAmount = Some(BigDecimal(2)),
+      interestRate = Some(2.22),
       accruedPenaltyAmount = Some(BigDecimal(100.00)),
       penaltyType = Some("LPP1"),
-      originalAmount = BigDecimal(10000)
+      originalAmount = BigDecimal(10000),
+      clearedAmount = None
     ),
     isOverdue = false
   )

--- a/test/models/payments/PaymentSpec.scala
+++ b/test/models/payments/PaymentSpec.scala
@@ -29,169 +29,24 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
     val endDate = "2017-03-01"
     val dueDate = "2017-03-08"
 
-    "given a start and end date and no direct debit collection flag" should {
+    val model = PaymentWithPeriod(
+      chargeType = ReturnDebitCharge,
+      periodFrom = LocalDate.parse(startDate),
+      periodTo = LocalDate.parse(endDate),
+      due = LocalDate.parse(dueDate),
+      outstandingAmount = 0,
+      periodKey = Some("#001"),
+      Some("XD002750002155"),
+      ddCollectionInProgress = true,
+      accruedInterestAmount = Some(BigDecimal(2)),
+      interestRate = Some(2.22),
+      accruedPenaltyAmount = Some(555.55),
+      penaltyType = Some("LPP1"),
+      originalAmount = BigDecimal(10000),
+      clearedAmount = Some(100)
+    )
 
-      "write to Json correctly" in {
-        val paymentJson = Json.obj(
-          "chargeType" -> ReturnDebitCharge.value,
-          "taxPeriodFrom" -> startDate,
-          "taxPeriodTo" -> endDate,
-          "items" -> Json.arr(
-            Json.obj(
-              "dueDate" -> dueDate
-            )
-          ),
-          "outstandingAmount" -> 9999,
-          "periodKey" -> "#001",
-          "chargeReference" -> "XD002750002155",
-          "accruedInterestAmount" -> 2,
-          "originalAmount" -> 10000
-        )
-
-        val paymentWithPeriodModel = PaymentWithPeriod(
-          chargeType = ReturnDebitCharge,
-          periodFrom = LocalDate.parse(startDate),
-          periodTo = LocalDate.parse(endDate),
-          due = LocalDate.parse(dueDate),
-          outstandingAmount = 9999,
-          periodKey = Some("#001"),
-          Some("XD002750002155"),
-          ddCollectionInProgress = false,
-          accruedInterestAmount = Some(BigDecimal(2)),
-          accruedPenaltyAmount = None,
-          penaltyType = None,
-          originalAmount = BigDecimal(10000)
-        )
-        paymentJson.as[Payment] shouldBe paymentWithPeriodModel
-      }
-    }
-
-    "not given a start and end date and no direct debit collection flag" should {
-
-      "read from Json correctly" in {
-        val paymentJson = Json.obj(
-          "chargeType" -> ReturnDebitCharge.value,
-          "items" -> Json.arr(
-            Json.obj(
-              "dueDate" -> dueDate
-            )
-          ),
-          "outstandingAmount" -> -9999,
-          "periodKey" -> "#001",
-          "chargeReference" -> "XD002750002155",
-          "accruedInterestAmount" -> 2,
-          "originalAmount" -> 10000
-        )
-
-        val paymentNoPeriodModel = PaymentNoPeriod(
-          chargeType = ReturnDebitCharge,
-          due = LocalDate.parse(dueDate),
-          outstandingAmount = -9999,
-          periodKey = Some("#001"),
-          Some("XD002750002155"),
-          ddCollectionInProgress = false,
-          accruedInterestAmount = Some(BigDecimal(2)),
-          accruedPenaltyAmount = None,
-          penaltyType = None,
-          originalAmount = BigDecimal(10000)
-        )
-        paymentJson.as[Payment] shouldBe paymentNoPeriodModel
-      }
-    }
-
-    "not given only a start or an end date" should {
-
-      "read from Json correctly" in {
-        val paymentJson = Json.obj(
-          "chargeType" -> ReturnDebitCharge.value,
-          "taxPeriodFrom" -> startDate,
-          "items" -> Json.arr(
-            Json.obj(
-              "dueDate" -> dueDate
-            )
-          ),
-          "outstandingAmount" -> 9999,
-          "periodKey" -> "#001",
-          "chargeReference" -> "XD002750002155",
-          "originalAmount" -> 10000
-        )
-
-        val exception = intercept[Exception] {
-          paymentJson.as[Payment]
-        }
-        exception.getMessage shouldBe s"Partial taxPeriod was supplied: periodFrom: 'Some($startDate)', periodTo: 'None'"
-      }
-    }
-
-    "given a direct debit collection flag" should {
-
-      val paymentJson = Json.obj(
-        "chargeType" -> ReturnDebitCharge.value,
-        "taxPeriodFrom" -> startDate,
-        "taxPeriodTo" -> endDate,
-        "items" -> Json.arr(
-          Json.obj(
-            "dueDate" -> dueDate,
-            "DDcollectionInProgress" -> true
-          )
-        ),
-        "accruedInterestAmount" -> 2,
-        "outstandingAmount" -> 0,
-        "periodKey" -> "#001",
-        "chargeReference" -> "XD002750002155",
-        "originalAmount" -> 10000
-      )
-
-      val model = PaymentWithPeriod(
-        chargeType = ReturnDebitCharge,
-        periodFrom = LocalDate.parse(startDate),
-        periodTo = LocalDate.parse(endDate),
-        due = LocalDate.parse(dueDate),
-        outstandingAmount = 0,
-        periodKey = Some("#001"),
-        Some("XD002750002155"),
-        ddCollectionInProgress = true,
-        accruedInterestAmount = Some(BigDecimal(2)),
-        accruedPenaltyAmount = None,
-        penaltyType = None,
-        originalAmount = BigDecimal(10000)
-      )
-
-      "read from json correctly" in {
-        paymentJson.as[Payment] shouldBe model
-      }
-    }
-
-    "given JSON with no cleared amount fields" should {
-
-      val paymentJson = Json.obj(
-        "chargeType" -> ReturnDebitCharge.value,
-        "taxPeriodFrom" -> startDate,
-        "taxPeriodTo" -> endDate,
-        "items" -> Json.arr(
-          Json.obj(
-            "dueDate" -> dueDate,
-            "DDcollectionInProgress" -> true
-          )
-        ),
-        "outstandingAmount" -> 0,
-        "periodKey" -> "#001",
-        "chargeReference" -> "XD002750002155",
-        "originalAmount" -> 10000
-      )
-
-      val result = paymentJson.as[Payment]
-
-      "return a model" that {
-
-        "has None in the clearedAmount field" in {
-          result.clearedAmount shouldBe None
-        }
-      }
-
-    }
-
-    "given JSON with period data and original amount and cleared amount fields" should {
+    "given JSON with maximum expected fields" should {
 
       "return a model with those fields populated" in {
 
@@ -206,6 +61,9 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
             )
           ),
           "accruedInterestAmount" -> 2,
+          "interestRate" -> 2.22,
+          "accruedPenaltyAmount" -> "555.55",
+          "penaltyType" -> "LPP1",
           "outstandingAmount" -> 0,
           "periodKey" -> "#001",
           "chargeReference" -> "XD002750002155",
@@ -213,31 +71,41 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
           "clearedAmount" -> "100"
         )
 
-        val model = PaymentWithPeriod(
-          chargeType = ReturnDebitCharge,
-          periodFrom = LocalDate.parse(startDate),
-          periodTo = LocalDate.parse(endDate),
-          due = LocalDate.parse(dueDate),
-          outstandingAmount = 0,
-          periodKey = Some("#001"),
-          Some("XD002750002155"),
-          ddCollectionInProgress = true,
-          accruedInterestAmount = Some(BigDecimal(2)),
-          accruedPenaltyAmount = None,
-          penaltyType = None,
-          originalAmount = BigDecimal(10000),
-          clearedAmount = Some(100)
-        )
-
         paymentJson.as[Payment] shouldBe model
       }
 
     }
 
-    "given JSON without period data and with original amount and cleared amount fields" should {
+    "given no direct debit collection flag" should {
 
-      "return a paymentNoPeriod model with the correct original amount and cleared amount fields" in {
+      "read from Json correctly, setting the DD collection flag to false" in {
+        val paymentJson = Json.obj(
+          "chargeType" -> ReturnDebitCharge.value,
+          "taxPeriodFrom" -> startDate,
+          "taxPeriodTo" -> endDate,
+          "items" -> Json.arr(
+            Json.obj(
+              "dueDate" -> dueDate
+            )
+          ),
+          "accruedInterestAmount" -> 2,
+          "interestRate" -> 2.22,
+          "accruedPenaltyAmount" -> "555.55",
+          "penaltyType" -> "LPP1",
+          "outstandingAmount" -> 0,
+          "periodKey" -> "#001",
+          "chargeReference" -> "XD002750002155",
+          "originalAmount" -> "10000",
+          "clearedAmount" -> "100"
+        )
 
+        paymentJson.as[Payment] shouldBe model.copy(ddCollectionInProgress = false)
+      }
+    }
+
+    "not given a start and end date and no direct debit collection flag" should {
+
+      "read from Json correctly, into a PaymentNoPeriod model" in {
         val paymentJson = Json.obj(
           "chargeType" -> ReturnDebitCharge.value,
           "items" -> Json.arr(
@@ -246,29 +114,88 @@ class PaymentSpec extends AnyWordSpecLike with Matchers {
               "DDcollectionInProgress" -> true
             )
           ),
+          "accruedInterestAmount" -> 2,
+          "interestRate" -> 2.22,
+          "accruedPenaltyAmount" -> "555.55",
+          "penaltyType" -> "LPP1",
           "outstandingAmount" -> 0,
           "periodKey" -> "#001",
           "chargeReference" -> "XD002750002155",
-          "accruedInterestAmount" -> 2,
           "originalAmount" -> "10000",
           "clearedAmount" -> "100"
         )
 
-        val model = PaymentNoPeriod(
+        val paymentNoPeriodModel = PaymentNoPeriod(
           chargeType = ReturnDebitCharge,
           due = LocalDate.parse(dueDate),
           outstandingAmount = 0,
           periodKey = Some("#001"),
           Some("XD002750002155"),
           ddCollectionInProgress = true,
-          accruedInterestAmount = Some(BigDecimal(2)),
-          accruedPenaltyAmount = None,
-          penaltyType = None,
+          accruedInterestAmount = Some(2),
+          interestRate = Some(2.22),
+          accruedPenaltyAmount = Some(555.55),
+          penaltyType = Some("LPP1"),
           originalAmount = BigDecimal(10000),
           clearedAmount = Some(100)
         )
 
-        paymentJson.as[Payment] shouldBe model
+        paymentJson.as[Payment] shouldBe paymentNoPeriodModel
+      }
+    }
+
+    "given only a start date or an end date" should {
+
+      "throw an IllegalArgumentException" in {
+        val paymentJson = Json.obj(
+          "chargeType" -> ReturnDebitCharge.value,
+          "taxPeriodFrom" -> startDate,
+          "items" -> Json.arr(
+            Json.obj(
+              "dueDate" -> dueDate
+            )
+          ),
+          "outstandingAmount" -> 9999,
+          "periodKey" -> "#001",
+          "chargeReference" -> "XD002750002155",
+          "originalAmount" -> 10000
+        )
+
+        val exception = intercept[IllegalArgumentException](paymentJson.as[Payment])
+        exception.getMessage shouldBe s"Partial taxPeriod was supplied: periodFrom: 'Some($startDate)', periodTo: 'None'"
+      }
+    }
+
+    "given JSON with minimum expected fields" should {
+
+      "read from Json correctly, setting empty fields to None" in {
+        val paymentJson = Json.obj(
+          "chargeType" -> ReturnDebitCharge.value,
+          "items" -> Json.arr(
+            Json.obj(
+              "dueDate" -> dueDate
+            )
+          ),
+          "outstandingAmount" -> 0,
+          "originalAmount" -> 100
+        )
+
+        val expectedModel = PaymentNoPeriod(
+          chargeType = ReturnDebitCharge,
+          due = LocalDate.parse(dueDate),
+          outstandingAmount = 0,
+          periodKey = None,
+          chargeReference = None,
+          ddCollectionInProgress = false,
+          accruedInterestAmount = None,
+          interestRate = None,
+          accruedPenaltyAmount = None,
+          penaltyType = None,
+          originalAmount = 100,
+          clearedAmount = None
+        )
+
+        paymentJson.as[Payment] shouldBe expectedModel
       }
     }
   }

--- a/test/models/payments/PaymentsSpec.scala
+++ b/test/models/payments/PaymentsSpec.scala
@@ -35,9 +35,11 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
       Some("XD002750002155"),
       ddCollectionInProgress = false,
       Some(2),
+      Some(2.22),
       Some(BigDecimal(100.00)),
       Some("LPP1"),
-      BigDecimal(10000)
+      BigDecimal(10000),
+      Some(50.55)
     )
 
     val exampleInputString =
@@ -50,9 +52,11 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
         |"periodKey":"#001",
         |"chargeReference": "XD002750002155",
         |"accruedInterestAmount": 2,
+        |"interestRate": 2.22,
         |"accruedPenaltyAmount" : 100.00,
         |"penaltyType" : "LPP1",
-        |"originalAmount" : 10000
+        |"originalAmount" : 10000,
+        |"clearedAmount" : 50.55
         |}"""
         .stripMargin.replace("\n", "")
 
@@ -77,9 +81,11 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
           Some("XD002750002155"),
           ddCollectionInProgress = false,
           Some(2),
+          Some(2.22),
           Some(BigDecimal(100.00)),
           Some("LPP1"),
-          BigDecimal(10000)
+          BigDecimal(10000),
+          Some(50.55)
         ),
         PaymentWithPeriod(
           ReturnCreditCharge,
@@ -91,9 +97,11 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
           Some("XD002750002155"),
           ddCollectionInProgress = false,
           Some(2),
+          Some(2.22),
           Some(BigDecimal(100.00)),
           Some("LPP1"),
-          BigDecimal(10000)
+          BigDecimal(10000),
+          Some(60.66)
         )
       )
     )
@@ -109,9 +117,11 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
         |"periodKey":"#001",
         |"chargeReference": "XD002750002155",
         |"accruedInterestAmount": 2,
+        |"interestRate": 2.22,
         |"accruedPenaltyAmount" : 100.00,
         |"penaltyType" : "LPP1",
-        |"originalAmount" : 10000
+        |"originalAmount" : 10000,
+        |"clearedAmount" : 50.55
         |},{
         |"chargeType":"VAT Return Credit Charge",
         |"taxPeriodFrom":"2017-02-01",
@@ -121,9 +131,11 @@ class PaymentsSpec extends AnyWordSpecLike with Matchers {
         |"periodKey":"#002",
         |"chargeReference": "XD002750002155",
         |"accruedInterestAmount": 2,
+        |"interestRate": 2.22,
         |"accruedPenaltyAmount" : 100.00,
         |"penaltyType" : "LPP1",
-        |"originalAmount" : 10000
+        |"originalAmount" : 10000,
+        |"clearedAmount" : 60.66
         |}]}"""
         .stripMargin.replace("\n", "")
 

--- a/test/services/PaymentsServiceSpec.scala
+++ b/test/services/PaymentsServiceSpec.scala
@@ -45,6 +45,7 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
     "the user has payments outstanding" should {
 
       "return a list of payments sorted by due date in descending order" in {
+
         val payment1 = PaymentWithPeriod(
           ReturnDebitCharge,
           LocalDate.parse("2008-01-01"),
@@ -55,52 +56,16 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = Some(2.22),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP1"),
-          BigDecimal("10000")
+          10000,
+          Some(200.00)
         )
-        val payment2 = PaymentWithPeriod(
-          ReturnDebitCharge,
-          LocalDate.parse("2008-01-01"),
-          LocalDate.parse("2009-01-01"),
-          LocalDate.parse("2008-12-01"),
-          BigDecimal("21.22"),
-          Some(""),
-          Some("XD002750002155"),
-          ddCollectionInProgress = false,
-          accruedInterestAmount = Some(BigDecimal(2)),
-          accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP1"),
-          BigDecimal("10000")
-        )
-        val payment3 = PaymentWithPeriod(
-          ReturnDebitCharge,
-          LocalDate.parse("2008-01-01"),
-          LocalDate.parse("2009-01-01"),
-          LocalDate.parse("2009-01-01"),
-          BigDecimal("21.22"),
-          Some(""),
-          Some("XD002750002155"),
-          ddCollectionInProgress = false,
-          accruedInterestAmount = Some(BigDecimal(2)),
-          accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP1"),
-          BigDecimal("10000")
-        )
-        val payment4 = PaymentWithPeriod(
-          ReturnDebitCharge,
-          LocalDate.parse("2008-01-01"),
-          LocalDate.parse("2009-01-01"),
-          LocalDate.parse("2008-11-30"),
-          BigDecimal("21.22"),
-          Some(""),
-          Some("XD002750002155"),
-          ddCollectionInProgress = false,
-          accruedInterestAmount = Some(BigDecimal(2)),
-          accruedPenaltyAmount = Some(BigDecimal(100.00)),
-          penaltyType = Some("LPP1"),
-          BigDecimal("10000")
-        )
+
+        val payment2 = payment1.copy(due = LocalDate.parse("2008-12-01"))
+        val payment3 = payment1.copy(due = LocalDate.parse("2009-01-01"))
+        val payment4 = payment1.copy(due = LocalDate.parse("2008-11-30"))
 
         val payments = Payments(Seq(payment1, payment2, payment3, payment4))
         lazy val responseFromFinancialDataConnector = Right(payments)
@@ -117,7 +82,7 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
       }
     }
 
-    "the user has no payments outstanding" should {
+    "the user has no charges with positive outstanding amounts" should {
 
       "return an empty list of payments" in {
         val payments = Payments(Seq(PaymentWithPeriod(
@@ -130,9 +95,11 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           Some("XD002750002155"),
           ddCollectionInProgress = false,
           accruedInterestAmount = Some(BigDecimal(2)),
+          interestRate = Some(2.22),
           accruedPenaltyAmount = Some(BigDecimal(100.00)),
           penaltyType = Some("LPP1"),
-          BigDecimal("10000")
+          BigDecimal("10000"),
+          None
         )))
         lazy val responseFromFinancialDataConnector = Right(payments)
 
@@ -160,9 +127,11 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           None,
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          BigDecimal("10000")
+          BigDecimal("10000"),
+          None
         )
 
         val payments = Payments(Seq(payment1))
@@ -192,9 +161,11 @@ class PaymentsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers
           None,
           ddCollectionInProgress = false,
           accruedInterestAmount = None,
+          interestRate = None,
           accruedPenaltyAmount = None,
           penaltyType = None,
-          BigDecimal("10000")
+          BigDecimal("10000"),
+          None
         )
 
         val payments = Payments(Seq(payment1))

--- a/test/services/VatDetailsServiceSpec.scala
+++ b/test/services/VatDetailsServiceSpec.scala
@@ -30,67 +30,43 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class VatDetailsServiceSpec extends ControllerBaseSpec {
   
-    val obligations: VatReturnObligations = VatReturnObligations(Seq(VatReturnObligation(
-      periodFrom = LocalDate.parse("2017-01-01"),
-      periodTo = LocalDate.parse("2017-03-30"),
-      due = LocalDate.parse("2017-04-30"),
-      status = "O",
-      received = None,
-      periodKey = "#001"
-    )))
+  val obligations: VatReturnObligations = VatReturnObligations(Seq(VatReturnObligation(
+    periodFrom = LocalDate.parse("2017-01-01"),
+    periodTo = LocalDate.parse("2017-03-30"),
+    due = LocalDate.parse("2017-04-30"),
+    status = "O",
+    received = None,
+    periodKey = "#001"
+  )))
 
-    val payments: Seq[Payment] = Seq(
-      PaymentWithPeriod(
-        ReturnDebitCharge,
-        periodFrom = LocalDate.parse("2017-11-22"),
-        periodTo = LocalDate.parse("2017-12-22"),
-        due = LocalDate.parse("2017-12-26"),
-        outstandingAmount = BigDecimal(1000.00),
-        periodKey = Some("#003"),
-        chargeReference = Some("XD002750002155"),
-        ddCollectionInProgress = false,
-        accruedInterestAmount = Some(BigDecimal(2)),
-        accruedPenaltyAmount = Some(BigDecimal(100.00)),
-        penaltyType = Some("LPP1"),
-        originalAmount = BigDecimal(10000)
-      )
-    )
+  val payment: PaymentWithPeriod = PaymentWithPeriod(
+    ReturnDebitCharge,
+    periodFrom = LocalDate.parse("2017-11-22"),
+    periodTo = LocalDate.parse("2017-12-22"),
+    due = LocalDate.parse("2017-12-26"),
+    outstandingAmount = BigDecimal(1000.00),
+    periodKey = Some("#003"),
+    chargeReference = Some("XD002750002155"),
+    ddCollectionInProgress = false,
+    accruedInterestAmount = Some(BigDecimal(2)),
+    interestRate = Some(2.22),
+    accruedPenaltyAmount = Some(BigDecimal(100.00)),
+    penaltyType = Some("LPP1"),
+    originalAmount = BigDecimal(10000),
+    clearedAmount = Some(50.55)
+  )
+
+  val payments: Seq[Payment] = Seq(payment)
 
   val POAPayments: Seq[Payment] = Seq(
-      PaymentWithPeriod(
-        PaymentOnAccount,
-        periodFrom = LocalDate.parse("2017-11-22"),
-        periodTo = LocalDate.parse("2017-12-22"),
-        due = LocalDate.parse("2017-12-26"),
-        outstandingAmount = BigDecimal(1000.00),
-        periodKey = Some("#003"),
-        chargeReference = Some("XD002750002155"),
-        ddCollectionInProgress = false,
-        accruedInterestAmount = Some(BigDecimal(2)),
-        accruedPenaltyAmount = Some(BigDecimal(100.00)),
-        penaltyType = Some("LPP1"),
-        originalAmount = BigDecimal(10000)
-      ),
-      PaymentWithPeriod(
-        CentralAssessmentCharge,
-        periodFrom = LocalDate.parse("2017-11-22"),
-        periodTo = LocalDate.parse("2017-12-22"),
-        due = LocalDate.parse("2017-12-26"),
-        outstandingAmount = BigDecimal(0),
-        periodKey = Some("#003"),
-        chargeReference = Some("XD002750002155"),
-        ddCollectionInProgress = false,
-        accruedInterestAmount = Some(BigDecimal(2)),
-        accruedPenaltyAmount = Some(BigDecimal(100.00)),
-        penaltyType = Some("LPP1"),
-        originalAmount = BigDecimal(10000)
-      )
-    )
+    payment.copy(chargeType = PaymentOnAccount),
+    payment.copy(chargeType = CentralAssessmentCharge, outstandingAmount = 0)
+  )
 
-    implicit val hc: HeaderCarrier = HeaderCarrier()
-    val mockObligationsConnector: VatObligationsConnector = mock[VatObligationsConnector]
-    val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
-    val mockSubscriptionConnector: VatSubscriptionConnector = mock[VatSubscriptionConnector]
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  val mockObligationsConnector: VatObligationsConnector = mock[VatObligationsConnector]
+  val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
+  val mockSubscriptionConnector: VatSubscriptionConnector = mock[VatSubscriptionConnector]
 
   def callObligationsConnector(obligationResult: HttpGetResult[VatReturnObligations] = Right(obligations)): Any = {
     (mockObligationsConnector.getVatReturnObligations(_: String, _: Obligation.Status.Value, _: Option[LocalDate], _: Option[LocalDate])


### PR DESCRIPTION
Also removed lots of bloat from `Payment` model, and refactored the tests for that model. The many `apply` functions were only being used across various test specs and this was unnecessary. This unfortunately meant making the same change to many test models which clogs up the PR a bit.

Have not been able to manually or acceptance test this yet without stub data