### PR TITLE
BTAT-11290 Added support for breathingSpace boolean

### DIFF
--- a/app/connectors/httpParsers/PenaltyDetailsHttpParser.scala
+++ b/app/connectors/httpParsers/PenaltyDetailsHttpParser.scala
@@ -29,7 +29,7 @@ object PenaltyDetailsHttpParser extends ResponseHttpParsers with LoggerUtil{
     override def read(method: String, url: String, response: HttpResponse): HttpGetResult[PenaltyDetails] = {
       response.status match {
         case OK => Right(response.json.as[PenaltyDetails])
-        case NOT_FOUND => Right(PenaltyDetails(Seq.empty))
+        case NOT_FOUND => Right(PenaltyDetails(Seq.empty, breathingSpace = false))
         case _ =>
           logger.warn(s"[PenaltyDetailsReads][read] unexpected ${response.status} returned from financial transactions" +
           s"Status code:'${response.status}', Body: '${response.body}")
@@ -37,5 +37,4 @@ object PenaltyDetailsHttpParser extends ResponseHttpParsers with LoggerUtil{
       }
     }
   }
-
 }

--- a/app/models/penalties/PenaltyDetails.scala
+++ b/app/models/penalties/PenaltyDetails.scala
@@ -18,10 +18,11 @@ package models.penalties
 
 import play.api.libs.json.{Reads, Json}
 
-case class PenaltyDetails(LPPDetails : Seq[LPPDetails])
+case class PenaltyDetails(LPPDetails : Seq[LPPDetails],
+                          breathingSpace: Boolean)
 
 object PenaltyDetails {
 
-  implicit val format: Reads[PenaltyDetails] = Json.reads[PenaltyDetails]
+  implicit val reads: Reads[PenaltyDetails] = Json.reads[PenaltyDetails]
 
 }

--- a/app/services/PenaltyDetailsService.scala
+++ b/app/services/PenaltyDetailsService.scala
@@ -32,8 +32,6 @@ class PenaltyDetailsService @Inject()(connector: PenaltyDetailsConnector) {
     if (appConfig.features.penaltiesAndInterestWYOEnabled()) {
       connector.getPenaltyDetails(idValue)
     } else {
-      Future(Right(PenaltyDetails(Seq.empty)))
+      Future(Right(PenaltyDetails(Seq.empty, breathingSpace = false)))
     }
-
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,6 @@ lazy val microservice: Project = Project(appName, file("."))
   .settings(coverageSettings: _*)
   .settings(playSettings: _*)
   .settings(scalaSettings: _*)
-  .settings(publishingSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(
     Test / Keys.fork := true,

--- a/it/connectors/PenaltyDetailsISpec.scala
+++ b/it/connectors/PenaltyDetailsISpec.scala
@@ -19,13 +19,14 @@ package connectors
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import helpers.IntegrationBaseSpec
 import models.errors.UnexpectedStatusError
+import models.penalties.PenaltyDetails
 import uk.gov.hmrc.http.HeaderCarrier
 import stubs.PenaltyDetailsStub
 import stubs.PenaltyDetailsStub._
 import play.api.http.Status._
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
-class PenaltyDetailsISpec extends IntegrationBaseSpec{
+class PenaltyDetailsISpec extends IntegrationBaseSpec {
 
   val idValue = "999999999"
 
@@ -40,7 +41,7 @@ class PenaltyDetailsISpec extends IntegrationBaseSpec{
     "return a users penaltyDetails information" in new Test {
       override def setupStubs(): StubMapping = PenaltyDetailsStub.stubPenaltyDetails()
 
-      val expected = Right(penaltyDetailsModelMax)
+      val expected: Right[Nothing, PenaltyDetails] = Right(penaltyDetailsModelMax)
 
       setupStubs()
       private val result = await(connector.getPenaltyDetails(idValue))
@@ -52,13 +53,12 @@ class PenaltyDetailsISpec extends IntegrationBaseSpec{
       override def setupStubs(): StubMapping = PenaltyDetailsStub.stubPenaltyDetails(INTERNAL_SERVER_ERROR, errorJson)
 
       val message: String = """{"code":"500","message":"INTERNAL_SERVER_ERROR"}"""
-      val expected = Left(UnexpectedStatusError(INTERNAL_SERVER_ERROR.toString,message))
+      val expected: Left[UnexpectedStatusError, Nothing] = Left(UnexpectedStatusError(INTERNAL_SERVER_ERROR.toString,message))
 
       setupStubs()
       private val result = await(connector.getPenaltyDetails(idValue))
 
       result shouldEqual expected
     }
-
   }
 }

--- a/it/stubs/PenaltyDetailsStub.scala
+++ b/it/stubs/PenaltyDetailsStub.scala
@@ -67,7 +67,9 @@ object PenaltyDetailsStub extends WireMockMethods {
   val penaltyDetailsModelMax: PenaltyDetails = PenaltyDetails(
     LPPDetails = Seq(
       estimatedLPP1DetailsModel, estimatedLPP2DetailsModel, crystallisedLPP1DetailsModel,
-      crystallisedLPP1Part1OnlyModel, crystallisedLPP2DetailsModel)
+      crystallisedLPP1Part1OnlyModel, crystallisedLPP2DetailsModel
+    ),
+    breathingSpace = false
   )
 
   val estimatedLPP1PenDetails: JsObject = Json.obj(
@@ -133,7 +135,13 @@ object PenaltyDetailsStub extends WireMockMethods {
     "LPPDetails" -> Json.arr(
       estimatedLPP1PenDetails, estimatedLPP2PenDetails, crystallisedLPP1Details,
       crystallisedLPP1Part1OnlyDetails, crystallisedLPP2Details
-    )
+    ),
+    "breathingSpace" -> false
+  )
+
+  val penaltyDetailsJsonMin: JsObject = Json.obj(
+    "LPPDetails" -> Json.arr(),
+    "breathingSpace" -> false
   )
 
   val errorJson: JsObject = Json.obj(

--- a/test/common/TestModels.scala
+++ b/test/common/TestModels.scala
@@ -783,7 +783,8 @@ object TestModels {
   )
 
   val penaltyDetailsModelMax: PenaltyDetails = PenaltyDetails(
-    LPPDetails = Seq(LPPDetailsModelMax)
+    LPPDetails = Seq(LPPDetailsModelMax),
+    breathingSpace = false
   )
 
   val LPPDetailsModelMin: LPPDetails = LPPDetails(
@@ -801,7 +802,8 @@ object TestModels {
   )
 
   val penaltyDetailsModelMin: PenaltyDetails = PenaltyDetails(
-    LPPDetails = Seq(LPPDetailsModelMin)
+    LPPDetails = Seq(),
+    breathingSpace = false
   )
 
   val LPPDetailsJsonMax: JsObject = Json.obj(
@@ -826,11 +828,13 @@ object TestModels {
   )
 
   val penaltyDetailsJsonMax : JsObject = Json.obj(
-    "LPPDetails" -> Json.arr(LPPDetailsJsonMax)
+    "LPPDetails" -> Json.arr(LPPDetailsJsonMax),
+    "breathingSpace" -> false
   )
 
   val penaltyDetailsJsonMin : JsObject = Json.obj(
-    "LPPDetails" -> Json.arr(LPPDetailsJsonMin)
+    "LPPDetails" -> Json.arr(),
+    "breathingSpace" -> false
   )
 
   implicit val dateFormat: Format[LocalDateTime] = MongoJavatimeFormats.localDateTimeFormat

--- a/test/connectors/httpParsers/PenaltyDetailsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PenaltyDetailsHttpParserSpec.scala
@@ -42,13 +42,25 @@ class PenaltyDetailsHttpParserSpec extends AnyWordSpecLike with Matchers{
       }
     }
 
-    "the http response status is 404 NOT_FOUND no LPP data is returned" should {
+    "the http response status is 200 OK, with no penalties" should {
 
-      val httpResponse = HttpResponse(Status.NOT_FOUND, "")
-      val expected = Right(PenaltyDetails(List()))
+      val jsonResponse = penaltyDetailsJsonMin
+      val httpResponse = HttpResponse(Status.OK, jsonResponse.toString())
+      val expected = Right(penaltyDetailsModelMin)
       val result = PenaltyDetailsReads.read("", "", httpResponse)
 
-      "return an empty Penalty Details object with an empty sequence" in {
+      "return a PenaltyDetails instance" in {
+        result shouldEqual expected
+      }
+    }
+
+    "the http response status is 404 NOT_FOUND" should {
+
+      val httpResponse = HttpResponse(Status.NOT_FOUND, "")
+      val expected = Right(PenaltyDetails(Seq(), breathingSpace = false))
+      val result = PenaltyDetailsReads.read("", "", httpResponse)
+
+      "return an empty Penalty Details object with an empty sequence and breathing space defaulted to false" in {
         result shouldEqual expected
       }
     }
@@ -57,7 +69,7 @@ class PenaltyDetailsHttpParserSpec extends AnyWordSpecLike with Matchers{
 
       val body: JsObject = Json.obj(
         "code" -> "Conflict",
-        "message" -> "CONFLCIT"
+        "message" -> "CONFLICT"
       )
 
       val httpResponse = HttpResponse(Status.CONFLICT, body.toString())

--- a/test/models/penalties/LPPDetailsSpec.scala
+++ b/test/models/penalties/LPPDetailsSpec.scala
@@ -20,9 +20,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import common.TestModels._
 
-
-class LPPDetailsSpec extends AnyWordSpec with Matchers{
-
+class LPPDetailsSpec extends AnyWordSpec with Matchers {
 
   "LPP details" should {
 
@@ -31,12 +29,10 @@ class LPPDetailsSpec extends AnyWordSpec with Matchers{
       "optional fields are present" in {
         LPPDetailsJsonMax.as[LPPDetails] shouldBe LPPDetailsModelMax
       }
-      "optional are not present" in {
+
+      "optional fields are not present" in {
         LPPDetailsJsonMin.as[LPPDetails] shouldBe LPPDetailsModelMin
       }
     }
   }
-
-
-
 }

--- a/test/models/penalties/PenaltyDetailsSpec.scala
+++ b/test/models/penalties/PenaltyDetailsSpec.scala
@@ -30,8 +30,9 @@ class PenaltyDetailsSpec extends AnyWordSpec with Matchers{
         penaltyDetailsJsonMax.as[PenaltyDetails] shouldBe penaltyDetailsModelMax
       }
 
+      "there are no penalties in the array" in {
+        penaltyDetailsJsonMin.as[PenaltyDetails] shouldBe penaltyDetailsModelMin
+      }
     }
-
-    }
-
+  }
 }

--- a/test/services/PenaltyDetailsServiceSpec.scala
+++ b/test/services/PenaltyDetailsServiceSpec.scala
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PenaltyDetailsServiceSpec extends AnyWordSpecLike with MockFactory with Matchers with GuiceOneAppPerSuite {
 
-  val mockPenaltyDetailsConnector = mock[PenaltyDetailsConnector]
+  val mockPenaltyDetailsConnector: PenaltyDetailsConnector = mock[PenaltyDetailsConnector]
   implicit val hc: HeaderCarrier = HeaderCarrier()
   implicit val mockAppConfig: AppConfig = new MockAppConfig(app.configuration)
 
@@ -60,9 +60,7 @@ class PenaltyDetailsServiceSpec extends AnyWordSpecLike with MockFactory with Ma
 
     "return an empty Penalty details model" in {
       mockAppConfig.features.penaltiesAndInterestWYOEnabled(false)
-      await(service.getPenaltyDetails("123")) shouldBe Right(PenaltyDetails(Seq.empty))
+      await(service.getPenaltyDetails("123")) shouldBe Right(PenaltyDetails(Seq.empty, breathingSpace = false))
     }
-
   }
-
 }


### PR DESCRIPTION
I added in multiple tests to make sure an empty penalties array with breathing space boolean is supported, as we no longer want to treat no penalty details as 404. A change will be made in the backend to accomodate for this. Please don't merge until the backend work is ready.