### PR TITLE
BTAT-11281 Added route/controller/service layer for TTP API call

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 trait AppConfig {
   val appName: String
+  val host: String
   val reportAProblemPartialUrl: String
   val reportAProblemNonJSUrl: String
   val authUrl: String
@@ -197,14 +198,13 @@ class FrontendAppConfig @Inject()(val runModeConfiguration: Configuration, sc: S
 
   override val routeToSwitchLanguage: String => Call = (lang: String) => controllers.routes.LanguageController.switchToLanguage(lang)
 
-  private val host: String = sc.getString(Keys.host)
+  override lazy val host: String = sc.getString(Keys.host)
 
   override def feedbackUrl(redirect: String): String = s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier" +
     s"&backUrl=${SafeRedirectUrl(host + redirect).encodedUrl}"
 
   // Agent Client Lookup
-  private lazy val platformHost = sc.getString(Keys.host)
-  private lazy val agentClientLookupRedirectUrl: String => String = uri => SafeRedirectUrl(platformHost + uri).encodedUrl
+  private lazy val agentClientLookupRedirectUrl: String => String = uri => SafeRedirectUrl(host + uri).encodedUrl
   private lazy val agentClientLookupHost = sc.getString(Keys.vatAgentClientLookupFrontendHost)
   override lazy val agentClientLookupStartUrl: String => String = uri =>
     agentClientLookupHost +

--- a/app/connectors/TimeToPayConnector.scala
+++ b/app/connectors/TimeToPayConnector.scala
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-package models.errors
+package connectors
 
-sealed trait ServiceError
+import connectors.httpParsers.ResponseHttpParsers.HttpPostResult
+import models.TTPRequestModel
 
-case object PaymentSetupError extends ServiceError
-case object VatLiabilitiesError extends ServiceError
-case object PaymentsError extends ServiceError
-case object ObligationsError extends ServiceError
-case object NextPaymentError extends ServiceError
-case object CustomerInformationError extends ServiceError
-case object DirectDebitStatusError extends ServiceError
-case object TimeToPayRedirectError extends ServiceError
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.Future
+
+@Singleton
+class TimeToPayConnector @Inject()() {
+
+  // TODO to be replaced in other task
+  def callApi(requestModel: TTPRequestModel): Future[HttpPostResult[String]] = ???
+}

--- a/app/controllers/TimeToPayController.scala
+++ b/app/controllers/TimeToPayController.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.{AppConfig, ServiceErrorHandler}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.TimeToPayService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import utils.LoggerUtil
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TimeToPayController @Inject()(authorisedController: AuthorisedController,
+                                    mcc: MessagesControllerComponents,
+                                    timeToPayService: TimeToPayService,
+                                    errorHandler: ServiceErrorHandler)
+                                   (implicit ec: ExecutionContext,
+                                    appConfig: AppConfig)
+  extends FrontendController(mcc) with I18nSupport with LoggerUtil {
+
+  def redirect: Action[AnyContent] = authorisedController.authorisedAction { implicit request => _ =>
+    if(appConfig.features.overdueTimeToPayDescriptionEnabled()) {
+      timeToPayService.retrieveRedirectUrl.map {
+        case Right(url) => Redirect(url)
+        case Left(_) =>
+          logger.warn("[TimeToPayController][redirect] - Unable to retrieve successful response from TTP service, rendering ISE")
+          errorHandler.showInternalServerError
+      }
+    } else {
+      Future.successful(NotFound(errorHandler.notFoundTemplate))
+    }
+  }
+}

--- a/app/models/TTPRequestModel.scala
+++ b/app/models/TTPRequestModel.scala
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-package models.errors
+package models
 
-sealed trait ServiceError
+import play.api.libs.json.{Json, OWrites}
 
-case object PaymentSetupError extends ServiceError
-case object VatLiabilitiesError extends ServiceError
-case object PaymentsError extends ServiceError
-case object ObligationsError extends ServiceError
-case object NextPaymentError extends ServiceError
-case object CustomerInformationError extends ServiceError
-case object DirectDebitStatusError extends ServiceError
-case object TimeToPayRedirectError extends ServiceError
+case class TTPRequestModel(returnUrl: String, backUrl: String)
+
+object TTPRequestModel {
+  implicit val writes: OWrites[TTPRequestModel] = Json.writes[TTPRequestModel]
+}

--- a/app/services/TimeToPayService.scala
+++ b/app/services/TimeToPayService.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import config.AppConfig
+import connectors.TimeToPayConnector
+import models.errors.TimeToPayRedirectError
+import models.{ServiceResponse, TTPRequestModel}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TimeToPayService @Inject()(ttpConnector: TimeToPayConnector) {
+
+  def retrieveRedirectUrl(implicit ec: ExecutionContext, appConfig: AppConfig): Future[ServiceResponse[String]] = {
+    val wyoRoute = appConfig.host + controllers.routes.WhatYouOweController.show.url
+    val requestModel = TTPRequestModel(wyoRoute, wyoRoute)
+
+    ttpConnector.callApi(requestModel).map {
+      case Right(url) => Right(url) // TODO pull this URL out of the response model added in other task
+      case Left(_) => Left(TimeToPayRedirectError)
+    }
+  }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -9,6 +9,8 @@ GET        /vat-certificate                                                     
 GET        /make-payment/:amountInPence/:taxPeriodMonth/:taxPeriodYear/:vatPeriodEnding/:chargeType/:dueDate/:chargeReference        controllers.MakePaymentController.makePayment(amountInPence: Long, taxPeriodMonth: Int, taxPeriodYear: Int, vatPeriodEnding: String, chargeType: String, dueDate: String, chargeReference: String)
 GET        /make-payment/:amountInPence/:chargeType/:dueDate/:chargeReference                                                        controllers.MakePaymentController.makePaymentNoPeriod(amountInPence: Long, chargeType: String, dueDate: String, chargeReference: String)
 
+GET        /time-to-pay                                                                            controllers.TimeToPayController.redirect
+
 #Portal hand-off Routes
 GET        /portal-what-you-owe                                                                    controllers.PortalController.hybridWYO
 GET        /portal-payment-history                                                                 controllers.PortalController.hybridPH

--- a/test/controllers/TimeToPayControllerSpec.scala
+++ b/test/controllers/TimeToPayControllerSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.AppConfig
+import models.ServiceResponse
+import models.errors.TimeToPayRedirectError
+import org.jsoup.Jsoup
+import play.api.http.Status
+import play.api.test.Helpers._
+import services.TimeToPayService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TimeToPayControllerSpec extends ControllerBaseSpec {
+
+  val mockTTPService: TimeToPayService = mock[TimeToPayService]
+
+  def mockTTPServiceCall(serviceResponse: ServiceResponse[String]): Any =
+    (mockTTPService.retrieveRedirectUrl(_: ExecutionContext, _: AppConfig))
+      .expects(*,*).returns(Future.successful(serviceResponse))
+
+  val controller = new TimeToPayController(authorisedController, mcc, mockTTPService, mockServiceErrorHandler)
+
+  "The redirect action" when {
+
+    "the TTP feature switch is on" when {
+
+      "the service returns a URL" should {
+
+        lazy val result = {
+          mockAppConfig.features.overdueTimeToPayDescriptionEnabled(true)
+          mockPrincipalAuth()
+          mockTTPServiceCall(Right("/example-url"))
+          controller.redirect(fakeRequest)
+        }
+
+        "return 303" in {
+          status(result) shouldBe Status.SEE_OTHER
+        }
+
+        "redirect the request to the provided URL" in {
+          redirectLocation(result) shouldBe Some("/example-url")
+        }
+      }
+
+      "the service returns an error" should {
+
+        lazy val result = {
+          mockAppConfig.features.overdueTimeToPayDescriptionEnabled(true)
+          mockPrincipalAuth()
+          mockTTPServiceCall(Left(TimeToPayRedirectError))
+          controller.redirect(fakeRequest)
+        }
+
+        "return 500" in {
+          status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+        }
+
+        "render the technical difficulties page" in {
+          Jsoup.parse(contentAsString(result)).title shouldBe "There is a problem with the service - VAT - GOV.UK"
+        }
+      }
+    }
+
+    "the TTP feature switch is off" should {
+
+      lazy val result = {
+        mockAppConfig.features.overdueTimeToPayDescriptionEnabled(false)
+        mockPrincipalAuth()
+        controller.redirect(fakeRequest)
+      }
+
+      "return 404" in {
+        status(result) shouldBe Status.NOT_FOUND
+      }
+
+      "render the not found page" in {
+        Jsoup.parse(contentAsString(result)).title shouldBe "Page not found - VAT - GOV.UK"
+      }
+    }
+  }
+}

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -25,6 +25,7 @@ import play.api.mvc.Call
 import play.api.{Configuration, Mode}
 
 class MockAppConfig(val runModeConfiguration: Configuration, val mode: Mode = Mode.Test) extends AppConfig {
+  override val host: String = "http://localhost:1234"
   override def feedbackUrl(redirect: String): String = ""
   override val reportAProblemPartialUrl: String = ""
   override val reportAProblemNonJSUrl: String = ""

--- a/test/models/TTPRequestModelSpec.scala
+++ b/test/models/TTPRequestModelSpec.scala
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package models.errors
+package models
 
-sealed trait ServiceError
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.Json
 
-case object PaymentSetupError extends ServiceError
-case object VatLiabilitiesError extends ServiceError
-case object PaymentsError extends ServiceError
-case object ObligationsError extends ServiceError
-case object NextPaymentError extends ServiceError
-case object CustomerInformationError extends ServiceError
-case object DirectDebitStatusError extends ServiceError
-case object TimeToPayRedirectError extends ServiceError
+class TTPRequestModelSpec extends AnyWordSpec with Matchers {
+
+  "TTPRequestModel" should {
+
+    "write to JSON" in {
+      val model = TTPRequestModel("/return-url", "/back-url")
+      val expectedJson = Json.obj("returnUrl" -> "/return-url", "backUrl" -> "/back-url")
+
+      Json.toJson(model) shouldBe expectedJson
+    }
+  }
+}

--- a/test/services/TimeToPayServiceSpec.scala
+++ b/test/services/TimeToPayServiceSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.TimeToPayConnector
+import connectors.httpParsers.ResponseHttpParsers.HttpPostResult
+import controllers.ControllerBaseSpec
+import models.errors.{TimeToPayRedirectError, UnknownError}
+import models.TTPRequestModel
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class TimeToPayServiceSpec extends ControllerBaseSpec {
+
+  val mockTTPConnector: TimeToPayConnector = mock[TimeToPayConnector]
+
+  // TODO update return type of this mock; the connector will return a response model not a String
+  def mockTTPConnectorCall(response: HttpPostResult[String]): Any =
+    (mockTTPConnector.callApi(_: TTPRequestModel)).expects(*).returns(Future.successful(response))
+
+  val service = new TimeToPayService(mockTTPConnector)
+
+  "The retrieveRedirectUrl function" should {
+
+    "return a URL when the call is successful" in {
+      val result = {
+        mockTTPConnectorCall(Right("/example-url"))
+        service.retrieveRedirectUrl
+      }
+
+      await(result) shouldBe Right("/example-url")
+    }
+
+    "return an error model when the call is unsuccessful" in {
+      val result = {
+        mockTTPConnectorCall(Left(UnknownError))
+        service.retrieveRedirectUrl
+      }
+
+      await(result) shouldBe Left(TimeToPayRedirectError)
+    }
+  }
+}

--- a/test/views/payments/WhatYouOweViewSpec.scala
+++ b/test/views/payments/WhatYouOweViewSpec.scala
@@ -32,7 +32,10 @@ class WhatYouOweViewSpec extends ViewBaseSpec {
 
     "there is at least one overdue payment and the overdueTimeToPayDescriptionEnabled feature switch is on" should {
 
-      lazy val view = whatYouOweView(whatYouOweViewModel2Charge, Html(""))
+      lazy val view = {
+        mockConfig.features.overdueTimeToPayDescriptionEnabled(true)
+        whatYouOweView(whatYouOweViewModel2Charge, Html(""))
+      }
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "have the correct title" in {


### PR DESCRIPTION
The connector was added so I could fully unit test the service. The function is unimplemented for now but the code is protected by the feature switch.