### PR TITLE
BTAT-11524 Refactor to overview tile auditing to include error scenario

### DIFF
--- a/app/audit/models/ViewNextOpenVatObligationAuditModel.scala
+++ b/app/audit/models/ViewNextOpenVatObligationAuditModel.scala
@@ -16,23 +16,24 @@
 
 package audit.models
 
-import models.User
+import models.{ServiceResponse, User}
 import models.obligations.VatReturnObligations
 
 case class ViewNextOpenVatObligationAuditModel(user: User,
-                                               obligations: Option[VatReturnObligations]) extends AuditModel {
+                                               obligations: ServiceResponse[Option[VatReturnObligations]]) extends AuditModel {
 
   private val openObligation: Map[String, String] = obligations match {
-    case Some(obs) if obs.obligations.size > 1 => Map(
+    case Right(Some(obs)) if obs.obligations.size > 1 => Map(
       "numberOfObligations" -> obs.obligations.size.toString
     )
-    case Some(obs) => Map(
+    case Right(Some(obs)) => Map(
       "obligationOpen" -> "yes",
       "obligationDueBy" -> obs.obligations.head.due.toString,
       "obligationPeriodFrom" -> obs.obligations.head.periodFrom.toString,
       "obligationPeriodTo" -> obs.obligations.head.periodTo.toString
     )
-    case _ => Map("obligationOpen" -> "no")
+    case Right(None) => Map("obligationOpen" -> "no")
+    case Left(_) => Map("obligationsTileError" -> "true")
   }
 
   override val auditType: String = "OverviewPageView"

--- a/app/audit/models/ViewNextOutstandingVatPaymentAuditModel.scala
+++ b/app/audit/models/ViewNextOutstandingVatPaymentAuditModel.scala
@@ -16,19 +16,19 @@
 
 package audit.models
 
-import models.User
+import models.{ServiceResponse, User}
 import models.payments.Payments
 
 case class ViewNextOutstandingVatPaymentAuditModel(user: User,
-                                                   payments: Option[Payments]) extends AuditModel {
+                                                   payments: ServiceResponse[Option[Payments]]) extends AuditModel {
 
   private val paymentDetails: Map[String, String] = payments match {
-
-    case Some(data) if data.financialTransactions.size > 1 => Map(
+    case Right(Some(data)) if data.financialTransactions.size > 1 => Map(
       "numberOfPayments" -> data.financialTransactions.size.toString
     )
-    case Some(data) => data.financialTransactions.head.auditDetails
-    case _ => Map("paymentOutstanding" -> "no")
+    case Right(Some(data)) => data.financialTransactions.head.auditDetails
+    case Right(None) => Map("paymentOutstanding" -> "no")
+    case Left(_) => Map("paymentsTileError" -> "true")
   }
 
   override val auditType: String = "OverviewPageView"

--- a/app/controllers/VatDetailsController.scala
+++ b/app/controllers/VatDetailsController.scala
@@ -57,7 +57,7 @@ class VatDetailsController @Inject()(vatDetailsService: VatDetailsService,
   def details: Action[AnyContent] = authorisedController.authorisedAction { implicit request =>
     implicit user =>
         val accountDetailsCall = accountDetailsService.getAccountDetails(user.vrn)
-        val returnObligationsCall = vatDetailsService.getReturnObligations(user.vrn, dateService.now())
+        val returnObligationsCall = vatDetailsService.getReturnObligations(user.vrn)
         lazy val paymentObligationsCall = vatDetailsService.getPaymentObligations(user.vrn)
         for {
           customerInfo <- accountDetailsCall
@@ -255,20 +255,9 @@ class VatDetailsController @Inject()(vatDetailsService: VatDetailsService,
                                        returnObligations: ServiceResponse[Option[VatReturnObligations]],
                                        paymentObligations: ServiceResponse[Option[Payments]])
                                       (implicit hc: HeaderCarrier): Unit = {
-
-    val returnObs: Option[VatReturnObligations] = returnObligations match {
-      case Right(returns) => returns
-      case _ => None
-    }
-
-    val paymentObs: Option[Payments] = paymentObligations match {
-      case Right(payments) => payments
-      case _ => None
-    }
-
     auditingService.audit(
-      ViewNextOutstandingVatPaymentAuditModel(user, paymentObs), routes.VatDetailsController.details.url)
+      ViewNextOutstandingVatPaymentAuditModel(user, paymentObligations), routes.VatDetailsController.details.url)
     auditingService.audit(
-      ViewNextOpenVatObligationAuditModel(user, returnObs), routes.VatDetailsController.details.url)
+      ViewNextOpenVatObligationAuditModel(user, returnObligations), routes.VatDetailsController.details.url)
   }
 }

--- a/app/services/VatDetailsService.scala
+++ b/app/services/VatDetailsService.scala
@@ -16,7 +16,6 @@
 
 package services
 
-import java.time.LocalDate
 import config.AppConfig
 import connectors.{FinancialDataConnector, VatObligationsConnector}
 import javax.inject.{Inject, Singleton}
@@ -33,7 +32,7 @@ class VatDetailsService @Inject()(vatObligationsConnector: VatObligationsConnect
                                   financialDataConnector: FinancialDataConnector,
                                   implicit val appConfig: AppConfig) {
 
-  def getReturnObligations(vrn: String, date: LocalDate)
+  def getReturnObligations(vrn: String)
                           (implicit hc: HeaderCarrier,
                            ec: ExecutionContext): Future[ServiceResponse[Option[VatReturnObligations]]] =
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,10 @@
 
 import sbt.Tests.{Group, SubProcess}
 import uk.gov.hmrc.DefaultBuildSettings._
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 
 val appName: String = "vat-summary-frontend"
 lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 lazy val plugins: Seq[Plugins] = Seq.empty
-lazy val playSettings: Seq[Setting[_]] = Seq.empty
 
 scalacOptions ++= Seq("-Wconf:cat=unused-imports&site=.*views.html.*:s")
 
@@ -82,7 +80,6 @@ lazy val microservice: Project = Project(appName, file("."))
   .settings(PlayKeys.playDefaultPort := 9152)
   .settings(majorVersion := 0)
   .settings(coverageSettings: _*)
-  .settings(playSettings: _*)
   .settings(scalaSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(

--- a/test/audit/ViewNextOpenVatObligationAuditModelSpec.scala
+++ b/test/audit/ViewNextOpenVatObligationAuditModelSpec.scala
@@ -17,16 +17,16 @@
 package audit
 
 import java.time.LocalDate
-
-import _root_.models.User
+import _root_.models.errors.ObligationsError
 import _root_.models.obligations.{VatReturnObligation, VatReturnObligations}
+import _root_.models.User
 import audit.models.ViewNextOpenVatObligationAuditModel
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class ViewNextOpenVatObligationAuditModelSpec extends AnyWordSpecLike with Matchers {
 
-  val obligationOne = VatReturnObligation(
+  val obligationOne: VatReturnObligation = VatReturnObligation(
     LocalDate.parse("2018-01-01"),
     LocalDate.parse("2018-02-02"),
     LocalDate.parse("2018-03-03"),
@@ -35,14 +35,14 @@ class ViewNextOpenVatObligationAuditModelSpec extends AnyWordSpecLike with Match
     "18AA"
   )
 
-  val user = User("999999999")
+  val user: User = User("999999999")
 
   "ViewNextOpenVatObligationAuditModel" should {
 
     "be constructed correctly when there is one open obligation" in {
       val testData = ViewNextOpenVatObligationAuditModel(
         user,
-        obligations = Some(VatReturnObligations(Seq(obligationOne)))
+        obligations = Right(Some(VatReturnObligations(Seq(obligationOne))))
       )
 
       val expected: Map[String, String] = Map(
@@ -71,7 +71,7 @@ class ViewNextOpenVatObligationAuditModelSpec extends AnyWordSpecLike with Match
 
       val testData = ViewNextOpenVatObligationAuditModel(
         user,
-        multipleObligations
+        Right(multipleObligations)
       )
 
       val expected: Map[String, String] = Map(
@@ -85,12 +85,26 @@ class ViewNextOpenVatObligationAuditModelSpec extends AnyWordSpecLike with Match
     "be constructed correctly when there are no open obligations" in {
       val testData = ViewNextOpenVatObligationAuditModel(
         user,
-        None
+        Right(None)
       )
 
       val expected: Map[String, String] = Map(
         "vrn" -> "999999999",
         "obligationOpen" -> "no"
+      )
+
+      testData.detail shouldBe expected
+    }
+
+    "be constructed correctly when there was an error retrieving obligations" in {
+      val testData = ViewNextOpenVatObligationAuditModel(
+        user,
+        Left(ObligationsError)
+      )
+
+      val expected: Map[String, String] = Map(
+        "vrn" -> "999999999",
+        "obligationsTileError" -> "true"
       )
 
       testData.detail shouldBe expected

--- a/test/audit/ViewNextOutstandingVatPaymentAuditModelSpec.scala
+++ b/test/audit/ViewNextOutstandingVatPaymentAuditModelSpec.scala
@@ -17,8 +17,9 @@
 package audit
 
 import java.time.LocalDate
-import _root_.models.User
+import _root_.models.errors.NextPaymentError
 import _root_.models.payments.{Payment, Payments, ReturnDebitCharge}
+import _root_.models.User
 import audit.models.ViewNextOutstandingVatPaymentAuditModel
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -50,7 +51,7 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends AnyWordSpecLike with M
     "be constructed correctly when there is one outstanding payment" in {
       val testData = ViewNextOutstandingVatPaymentAuditModel(
         user,
-        payments = Some(onePayment))
+        payments = Right(Some(onePayment)))
 
       val expected: Map[String, String] = Map(
         "vrn" -> "999999999",
@@ -67,7 +68,7 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends AnyWordSpecLike with M
 
       val testData = ViewNextOutstandingVatPaymentAuditModel(
         user,
-        Some(twoPayments)
+        Right(Some(twoPayments))
       )
 
       val expected: Map[String, String] = Map(
@@ -81,12 +82,26 @@ class ViewNextOutstandingVatPaymentAuditModelSpec extends AnyWordSpecLike with M
     "be constructed correctly when there are no outstanding payments" in {
       val testData = ViewNextOutstandingVatPaymentAuditModel(
         user,
-        None
+        Right(None)
       )
 
       val expected: Map[String, String] = Map(
         "vrn" -> "999999999",
         "paymentOutstanding" -> "no"
+      )
+
+      testData.detail shouldBe expected
+    }
+
+    "be constructed correctly when there was an error receiving financial data" in {
+      val testData = ViewNextOutstandingVatPaymentAuditModel(
+        user,
+        Left(NextPaymentError)
+      )
+
+      val expected: Map[String, String] = Map(
+        "vrn" -> "999999999",
+        "paymentsTileError" -> "true"
       )
 
       testData.detail shouldBe expected

--- a/test/controllers/VatDetailsControllerSpec.scala
+++ b/test/controllers/VatDetailsControllerSpec.scala
@@ -47,8 +47,8 @@ class VatDetailsControllerSpec extends ControllerBaseSpec {
   val duplicateObligations: VatReturnObligations = TestModels.duplicateObligations
 
   def mockReturnObligations(result: ServiceResponse[Option[VatReturnObligations]]): Any =
-    (mockVatDetailsService.getReturnObligations(_: String, _: LocalDate)(_: HeaderCarrier, _: ExecutionContext))
-      .stubs(*, *, *, *)
+    (mockVatDetailsService.getReturnObligations(_: String)(_: HeaderCarrier, _: ExecutionContext))
+      .stubs(*, *, *)
       .returns(Future.successful(result))
 
   def mockPaymentLiabilities(result: ServiceResponse[Option[Payments]]): Any =

--- a/test/services/VatDetailsServiceSpec.scala
+++ b/test/services/VatDetailsServiceSpec.scala
@@ -94,8 +94,7 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
 
       "return the most recent outstanding obligation" in {
         callObligationsConnector(obligationResult = Right(obligations))
-        val result: ServiceResponse[Option[VatReturnObligations]] =
-          await(vatDetailsService.getReturnObligations("1111", LocalDate.parse("2018-01-01")))
+        val result: ServiceResponse[Option[VatReturnObligations]] = await(vatDetailsService.getReturnObligations("1111"))
         result shouldBe Right(Some(obligations))
       }
     }
@@ -104,8 +103,7 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
 
       "return nothing" in {
         callObligationsConnector(obligationResult = Right(VatReturnObligations(Seq.empty)))
-        val result: ServiceResponse[Option[VatReturnObligations]] =
-          await(vatDetailsService.getReturnObligations("1111", LocalDate.parse("2018-01-01")))
+        val result: ServiceResponse[Option[VatReturnObligations]] = await(vatDetailsService.getReturnObligations("1111"))
         result shouldBe Right(None)
       }
     }
@@ -114,8 +112,7 @@ class VatDetailsServiceSpec extends ControllerBaseSpec {
 
       "return the error" in {
         callObligationsConnector(obligationResult = Left(BadRequestError("TEST_FAIL", "this is a test")))
-        val result: ServiceResponse[Option[VatReturnObligations]] =
-          await(vatDetailsService.getReturnObligations("1111", LocalDate.parse("2018-01-01")))
+        val result: ServiceResponse[Option[VatReturnObligations]] = await(vatDetailsService.getReturnObligations("1111"))
         result shouldBe Left(ObligationsError)
       }
     }


### PR DESCRIPTION
The `date: LocalDate` param in the service function was simply unused so I removed it.

Upgrading hmrc-frontend and bootstrap causes many test failures, so I thought it was not appropriate to tackle those in this task.

Tested manually with Wireshark:
![image](https://user-images.githubusercontent.com/29063729/231196208-35ad7d29-da8f-4fa7-813b-6dfe454c6e6d.png)
![image](https://user-images.githubusercontent.com/29063729/231196227-177bc14f-c3b0-4f6e-9d3e-38f975faeedb.png)
