### PR TITLE
Fixed bug with WYO API error mixing

### DIFF
--- a/app/controllers/WhatYouOweController.scala
+++ b/app/controllers/WhatYouOweController.scala
@@ -76,10 +76,10 @@ class WhatYouOweController @Inject()(authorisedController: AuthorisedController,
                       logger.warn("[WhatYouOweController][show] incorrect fields received for payment(s); failed to render view")
                       Future.successful(InternalServerError(paymentsError()))
                   }
-                case (Right(_), _) =>
+                case (Right(None), Right(_)) =>
                   val clientName = request.session.get(SessionKeys.mtdVatvcAgentClientName)
                   Future.successful(Ok(noPayments(user, serviceInfoContent, clientName, mandationStatus)))
-                case (Left(_), _) | (_, Left(_)) =>
+                case _ =>
                   logger.warn(s"[WhatYouOweController][show] Error retrieving data from financial or penalty API")
                   Future.successful(InternalServerError(paymentsError()))
               }

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -37,8 +37,10 @@ import uk.gov.hmrc.auth.core.{AffinityGroup, AuthConnector, Enrolments, Insuffic
 import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys => GovUKSessionKeys}
 import org.scalatest.wordspec.AnyWordSpecLike
 import views.html.errors.{AgentUnauthorised, Unauthorised, UserInsolventError}
+
 import java.time.LocalDate
 import models.payments.Payments
+import models.penalties.PenaltyDetails
 import models.viewModels.ChargeDetailsViewModel
 import org.scalatest.enablers.Existence
 import org.scalatest.matchers.should.Matchers
@@ -146,10 +148,10 @@ class ControllerBaseSpec extends AnyWordSpecLike with MockFactory with GuiceOneA
       .stubs(*)
       .returns(Future.successful(model))
 
-  def mockPenaltyDetailsServiceCall(): Any =
+  def mockPenaltyDetailsServiceCall(penaltyDetails: HttpResult[PenaltyDetails] = penaltyDetailsResponse): Any =
     (mockPenaltyDetailsService.getPenaltyDetails(_: String)(_: HeaderCarrier, _: ExecutionContext))
       .stubs(*, *, *)
-      .returns(Future.successful(penaltyDetailsResponse))
+      .returns(Future.successful(penaltyDetails))
 
   def mockAuth(isAgent: Boolean, authResult: Future[~[Enrolments, Option[AffinityGroup]]]): Any = {
     (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])


### PR DESCRIPTION
We were incorrectly showing the "no payments" screen when the 1811 call was successful but the 1812 call failed